### PR TITLE
Use SDL_GetTicks64() in place of SDL_GetTicks()

### DIFF
--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -293,7 +293,7 @@ Gfx::Gfx()
 void Gfx::init()
 {
 	SDL_ShowCursor(SDL_DISABLE);
-	lastFrame = SDL_GetTicks();
+	lastFrame = SDL_GetTicks64();
 
 	playRenderer.init(320, 200);
 	singleScreenRenderer.init(640, 400);
@@ -923,11 +923,11 @@ void Gfx::flip()
 
 	static unsigned int const delay = 14u;
 
-	uint32_t wantedTime = lastFrame + delay;
+	auto wantedTime = lastFrame + delay;
 
 	while(true)
 	{
-		uint32_t now = SDL_GetTicks();
+		auto now = SDL_GetTicks64();
 		if(now >= wantedTime)
 			break;
 

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -282,7 +282,7 @@ struct Gfx
 	bool running;
 	bool spectatorFullscreen, doubleRes;
 
-	Uint32 lastFrame;
+	uint64_t lastFrame;
 	unsigned menuCycles;
 	int windowW, windowH;
 	int prevMag; // Previous magnification used for drawing

--- a/src/game/menu/menu.cpp
+++ b/src/game/menu/menu.cpp
@@ -18,7 +18,7 @@ void Menu::onKeys(SDL_Keysym* begin, SDL_Keysym* end, bool contains)
 		if ((begin->sym >= 32 && begin->sym <= 127) // x >= SDLK_SPACE && x <= SDLK_DELETE
 		  || isTab)
 		{
-			Uint32 time = SDL_GetTicks();
+			auto time = SDL_GetTicks64();
 			if (!isTab && time - searchTime > 1500)
 				searchPrefix.clear();
 

--- a/src/game/menu/menu.hpp
+++ b/src/game/menu/menu.hpp
@@ -187,7 +187,7 @@ struct Menu
 	void scroll(int amount);
 
 	std::string searchPrefix;
-	Uint32 searchTime;
+	Uint64 searchTime;
 
 	std::vector<MenuItem> items;
 	int itemHeight;


### PR DESCRIPTION
As recommended by the SDL documentation:
https://wiki.libsdl.org/SDL2/SDL_GetTicks
"This function is not recommended as of SDL 2.0.18; use SDL_GetTicks64()
instead, where the value doesn't wrap every ~49 days."
https://wiki.libsdl.org/SDL2/SDL_GetTicks