### PR TITLE
refactor: replace header guards with pragma once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ set(GAME_SOURCES ${SOURCES}
   src/game/menu/enumBehavior.cpp
   src/game/menu/hiddenMenu.cpp
   src/game/menu/integerBehavior.cpp
-  src/game/menu/itemBehavior.cpp
   src/game/menu/mainMenu.cpp
   src/game/menu/menu.cpp
   src/game/menu/menuItem.cpp

--- a/src/game/ai/astar.hpp
+++ b/src/game/ai/astar.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <gvl/containers/pairing_heap.hpp>
 
 #include "../level.hpp"

--- a/src/game/ai/dijkstra.hpp
+++ b/src/game/ai/dijkstra.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_AI_DIJKSTRA_HPP
-#define LIERO_AI_DIJKSTRA_HPP
+#pragma once
 
 #include <gvl/containers/pairing_heap.hpp>
 #include <gvl/math/vec.hpp>
@@ -279,5 +278,3 @@ struct dijkstra_level : dijkstra_state<level_cell*, dijkstra_level>
 			c.reset();
 	}
 };
-
-#endif // LIERO_AI_DIJKSTRA_HPP

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_PREDICTIVE_AI_HPP
-#define LIERO_PREDICTIVE_AI_HPP
+#pragma once
 
 #include <SDL.h>
 
@@ -436,5 +435,3 @@ struct FollowAI : WormAI, AiContext
 	Weights weights;
 
 };
-
-#endif // LIERO_PREDICTIVE_AI_HPP

--- a/src/game/ai/work_queue.hpp
+++ b/src/game/ai/work_queue.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_WORK_QUEUE_HPP
-#define LIERO_WORK_QUEUE_HPP
+#pragma once
 
 #include <SDL.h>
 #include <SDL_atomic.h>
@@ -161,5 +160,3 @@ struct WorkQueue
 
 	SDL_Thread* threads[8];
 };
-
-#endif // LIERO_WORK_QUEUE_HPP

--- a/src/game/bobject.hpp
+++ b/src/game/bobject.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_BOBJECT_HPP
-#define LIERO_BOBJECT_HPP
+#pragma once
 
 #include "math.hpp"
 #include "fastObjectList.hpp"
@@ -13,5 +12,3 @@ struct BObject
 	fixedvec pos, vel;
 	int color;
 };
-
-#endif // LIERO_BOBJECT_HPP

--- a/src/game/bonus.hpp
+++ b/src/game/bonus.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_BONUS_HPP
-#define LIERO_BONUS_HPP
+#pragma once
 
 #include "math.hpp"
 #include "exactObjectList.hpp"
@@ -22,5 +21,3 @@ struct Bonus : ExactObjectListBase
 
 	void process(Game& game);
 };
-
-#endif // LIERO_BONUS_HPP

--- a/src/game/common.hpp
+++ b/src/game/common.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_9E238CFB9F074A3A432E22AE5B8EE5FB
-#define UUID_9E238CFB9F074A3A432E22AE5B8EE5FB
+#pragma once
 
 #include "gfx/font.hpp"
 #include "weapon.hpp"
@@ -178,5 +177,3 @@ struct Common
 	bool writeTrace;
 #endif
 };
-
-#endif // UUID_9E238CFB9F074A3A432E22AE5B8EE5FB

--- a/src/game/common_model.hpp
+++ b/src/game/common_model.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <gvl/serialization/toml.hpp>
 #include "common.hpp"
 #include <gvl/io2/stream.hpp>

--- a/src/game/console.hpp
+++ b/src/game/console.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_CONSOLE_HPP
-#define LIERO_CONSOLE_HPP
+#pragma once
 
 #include <string>
 
@@ -11,5 +10,3 @@ void writeLine(std::string const& str);
 void writeWarning(std::string const& str);
 
 }
-
-#endif // LIERO_CONSOLE_HPP

--- a/src/game/constants.hpp
+++ b/src/game/constants.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_CONSTANTS_HPP
-#define LIERO_CONSTANTS_HPP
+#pragma once
 
 #include <string>
 
@@ -163,6 +162,3 @@ enum
 
 
 // TODO: Move these to Common
-
-
-#endif // LIERO_CONSTANTS_HPP

--- a/src/game/controller/commonController.cpp
+++ b/src/game/controller/commonController.cpp
@@ -1,4 +1,3 @@
-
 #include "commonController.hpp"
 
 #include "../gfx.hpp"

--- a/src/game/controller/commonController.hpp
+++ b/src/game/controller/commonController.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_CONTROLLER_COMMON_CONTROLLER_HPP
-#define LIERO_CONTROLLER_COMMON_CONTROLLER_HPP
+#pragma once
 
 #include "controller.hpp"
 
@@ -12,5 +11,3 @@ struct CommonController : Controller
 	bool inverseFrameSkip;
 	int cycles;
 };
-
-#endif // LIERO_CONTROLLER_COMMON_CONTROLLER_HPP

--- a/src/game/controller/controller.hpp
+++ b/src/game/controller/controller.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_9CD8C22BC14D4832AE2A859530FE6339
-#define UUID_9CD8C22BC14D4832AE2A859530FE6339
+#pragma once
 
 struct Level;
 struct Game;
@@ -37,7 +36,3 @@ struct Controller
 
 	virtual void swapLevel(Level& newLevel) = 0;
 };
-
-
-
-#endif // UUID_9CD8C22BC14D4832AE2A859530FE6339

--- a/src/game/controller/localController.cpp
+++ b/src/game/controller/localController.cpp
@@ -1,4 +1,3 @@
-
 #include "localController.hpp"
 
 #include <chrono>

--- a/src/game/controller/localController.hpp
+++ b/src/game/controller/localController.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_CONTROLLER_LOCAL_CONTROLLER_HPP
-#define LIERO_CONTROLLER_LOCAL_CONTROLLER_HPP
+#pragma once
 
 #include "commonController.hpp"
 
@@ -41,5 +40,3 @@ struct LocalController : CommonController
 	bool goingToMenu;
 	std::unique_ptr<ReplayWriter> replay;
 };
-
-#endif // LIERO_CONTROLLER_LOCAL_CONTROLLER_HPP

--- a/src/game/controller/replayController.hpp
+++ b/src/game/controller/replayController.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_CONTROLLER_REPLAY_CONTROLLER_HPP
-#define LIERO_CONTROLLER_REPLAY_CONTROLLER_HPP
+#pragma once
 
 #include "commonController.hpp"
 
@@ -49,5 +48,3 @@ struct ReplayController : CommonController
 	std::shared_ptr<Common> common;
 
 };
-
-#endif // LIERO_CONTROLLER_REPLAY_CONTROLLER_HPP

--- a/src/game/controller/stats_presenter.hpp
+++ b/src/game/controller/stats_presenter.hpp
@@ -1,9 +1,5 @@
-#ifndef LIERO_CONTROLLER_STATS_PRESENTER_HPP
-#define LIERO_CONTROLLER_STATS_PRESENTER_HPP
+#pragma once
 
 #include "../stats_recorder.hpp"
 
 void presentStats(NormalStatsRecorder& recorder, Game& game);
-
-#endif // LIERO_CONTROLLER_STATS_PRESENTER_HPP
-

--- a/src/game/exactObjectList.hpp
+++ b/src/game/exactObjectList.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_EXACTOBJECTLIST_HPP
-#define LIERO_EXACTOBJECTLIST_HPP
+#pragma once
 
 #include <cstddef>
 #include <cassert>
@@ -197,5 +196,3 @@ struct ExactObjectList
 
 	std::size_t count;
 };
-
-#endif // LIERO_EXACTOBJECTLIST_HPP

--- a/src/game/fastObjectList.hpp
+++ b/src/game/fastObjectList.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_A25E9863C68345C3B8E281AB7DFE5401
-#define UUID_A25E9863C68345C3B8E281AB7DFE5401
+#pragma once
 
 #include <cstddef>
 #include <cassert>
@@ -115,5 +114,3 @@ struct FastObjectList
 	std::vector<T> arr;
 	std::size_t count;
 };
-
-#endif // UUID_A25E9863C68345C3B8E281AB7DFE5401

--- a/src/game/filesystem.hpp
+++ b/src/game/filesystem.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_FILESYSTEM_HPP
-#define LIERO_FILESYSTEM_HPP
+#pragma once
 
 #include <string>
 #include <cstdio>
@@ -156,5 +155,3 @@ struct FsNode
 		return s;
 	}
 };
-
-#endif // LIERO_FILESYSTEM_HPP

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_GAME_HPP
-#define LIERO_GAME_HPP
+#pragma once
 
 #include <vector>
 #include "level.hpp"
@@ -130,6 +129,3 @@ struct Game
 };
 
 bool checkRespawnPosition(Game& game, int x2, int y2, int oldX, int oldY, int x, int y);
-
-#endif // LIERO_GAME_HPP
-

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_GFX_HPP
-#define LIERO_GFX_HPP
+#pragma once
 
 #include <SDL.h>
 #include <gvl/math/rect.hpp>
@@ -299,5 +298,3 @@ struct Gfx
 };
 
 extern Gfx gfx;
-
-#endif // LIERO_GFX_HPP

--- a/src/game/gfx/bitmap.hpp
+++ b/src/game/gfx/bitmap.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_GFX_BITMAP_HPP
-#define LIERO_GFX_BITMAP_HPP
+#pragma once
 
 #include "color.hpp"
 #include <cstring>
@@ -63,5 +62,3 @@ struct Bitmap : gvl::noncopyable
 		pixels = 0;
 	}
 };
-
-#endif // LIERO_GFX_BITMAP_HPP

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_9059AB0F9EA54E1EDF52E7BF41433D0B
-#define UUID_9059AB0F9EA54E1EDF52E7BF41433D0B
+#pragma once
 
 #include "color.hpp"
 #include "sprite.hpp"
@@ -108,5 +107,3 @@ struct Heatmap
 };
 
 void drawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm);
-
-#endif // UUID_9059AB0F9EA54E1EDF52E7BF41433D0B

--- a/src/game/gfx/color.hpp
+++ b/src/game/gfx/color.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_5BD6F9D1EBD64180EE632D8970906BDA
-#define UUID_5BD6F9D1EBD64180EE632D8970906BDA
+#pragma once
 
 #include <cstdint>
 
@@ -11,5 +10,3 @@ typedef struct Color {
 	uint8_t b;
 	uint8_t unused;
 } Color;
-
-#endif // UUID_5BD6F9D1EBD64180EE632D8970906BDA

--- a/src/game/gfx/font.hpp
+++ b/src/game/gfx/font.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_B06B65B783A849C7B4E509A9676180F8
-#define UUID_B06B65B783A849C7B4E509A9676180F8
+#pragma once
 
 #include <vector>
 #include <string>
@@ -88,5 +87,3 @@ struct Font
 
 	std::vector<Char> chars;
 };
-
-#endif // UUID_B06B65B783A849C7B4E509A9676180F8

--- a/src/game/gfx/macros.hpp
+++ b/src/game/gfx/macros.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_16A8D91C6BEA4174A45E11A5F85FB93C
-#define UUID_16A8D91C6BEA4174A45E11A5F85FB93C
+#pragma once
 
 inline uint8_t choose(uint8_t this_, uint8_t if_this, uint8_t is_different_from_this, uint8_t otherwise_this)
 {
@@ -168,5 +167,3 @@ inline uint8_t choose(uint8_t this_, uint8_t if_this, uint8_t is_different_from_
 	if(right > 0) width -= right; \
 	if(width <= 0 || height <= 0) return; \
 }
-
-#endif // UUID_16A8D91C6BEA4174A45E11A5F85FB93C

--- a/src/game/gfx/palette.hpp
+++ b/src/game/gfx/palette.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_74C8EE76D5564F2D8C7BBC9B26C16192
-#define UUID_74C8EE76D5564F2D8C7BBC9B26C16192
+#pragma once
 
 #include <cstdint>
 #include <gvl/support/debug.hpp>
@@ -56,5 +55,3 @@ struct Palette
 
 	void clear();
 };
-
-#endif // UUID_74C8EE76D5564F2D8C7BBC9B26C16192

--- a/src/game/gfx/renderer.hpp
+++ b/src/game/gfx/renderer.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_GFX_RENDERER_HPP
-#define LIERO_GFX_RENDERER_HPP
+#pragma once
 
 #include "../common.hpp"
 #include "../rand.hpp"
@@ -26,5 +25,3 @@ struct Renderer
 	int renderResX = 320;
 	int renderResY = 200;
 };
-
-#endif // LIERO_GFX_RENDERER_HPP

--- a/src/game/gfx/sprite.hpp
+++ b/src/game/gfx/sprite.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_FB823C685B8D47570B89508CD25CC4A6
-#define UUID_FB823C685B8D47570B89508CD25CC4A6
+#pragma once
 
 #include <vector>
 #include <cstdio>
@@ -40,5 +39,3 @@ struct SpriteSet
 
 	void allocate(int width, int height, int count);
 };
-
-#endif // UUID_FB823C685B8D47570B89508CD25CC4A6

--- a/src/game/keys.hpp
+++ b/src/game/keys.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_96141CB1E20547016970B28195515A14
-#define UUID_96141CB1E20547016970B28195515A14
+#pragma once
 
 #include <SDL.h>
 
@@ -27,5 +26,3 @@ inline bool isExtendedKey( uint32_t k ) {
 }
 
 const int JoyAxisThreshold = 10000;
-
-#endif // UUID_96141CB1E20547016970B28195515A14

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_LEVEL_HPP
-#define LIERO_LEVEL_HPP
+#pragma once
 
 #include <vector>
 #include <string>
@@ -132,5 +131,3 @@ struct Level
 	Palette origpal;
 	Material zeroMaterial;
 };
-
-#endif // LIERO_LEVEL_HPP

--- a/src/game/lfs.hpp
+++ b/src/game/lfs.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_LFS_HPP
-#define LIERO_LFS_HPP
+#pragma once
 
 // Tausworte 1965
 template<class UIntType, int w, int k, int q, int s, UIntType val>
@@ -73,6 +72,3 @@ struct LFS
 	UIntType wordmask; // avoid "left shift count >= width of type" warnings
 	UIntType value;
 };
-
-
-#endif // BOOST_RANDOM_LINEAR_FEEDBACK_SHIFT_HPP

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -1,6 +1,3 @@
-#ifndef UUID_DC1D9513CDD34960AB8A648004DA149D
-#define UUID_DC1D9513CDD34960AB8A648004DA149D
-
 #include <SDL.h>
 
 #include "gfx.hpp"
@@ -153,5 +150,3 @@ catch(std::exception&)
 	SDL_Quit();
 	throw;
 }
-
-#endif // UUID_DC1D9513CDD34960AB8A648004DA149D

--- a/src/game/material.hpp
+++ b/src/game/material.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_MATERIAL_HPP
-#define LIERO_MATERIAL_HPP
+#pragma once
 
 #include <cstdint>
 
@@ -29,5 +28,3 @@ struct Material
 
 	uint8_t flags;
 };
-
-#endif // LIERO_MATERIAL_HPP

--- a/src/game/math.hpp
+++ b/src/game/math.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_MATH_HPP
-#define LIERO_MATH_HPP
+#pragma once
 
 #include <gvl/math/vec.hpp>
 
@@ -37,5 +36,3 @@ inline int distanceTo(int x1, int y1, int x2, int y2)
 }
 
 void precomputeTables();
-
-#endif // LIERO_MATH_HPP

--- a/src/game/menu/arrayEnumBehavior.hpp
+++ b/src/game/menu/arrayEnumBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_CCCDF474CB704A62DC6F0AB0CBBD2EFD
-#define UUID_CCCDF474CB704A62DC6F0AB0CBBD2EFD
+#pragma once
 
 #include "enumBehavior.hpp"
 
@@ -25,5 +24,3 @@ struct ArrayEnumBehavior : EnumBehavior
 
 	std::string const* arr;
 };
-
-#endif // UUID_CCCDF474CB704A62DC6F0AB0CBBD2EFD

--- a/src/game/menu/booleanSwitchBehavior.cpp
+++ b/src/game/menu/booleanSwitchBehavior.cpp
@@ -1,4 +1,3 @@
-
 #include "booleanSwitchBehavior.hpp"
 
 #include "menu.hpp"

--- a/src/game/menu/booleanSwitchBehavior.hpp
+++ b/src/game/menu/booleanSwitchBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_0F083A4D564C4D79CA6387B1D0F1901E
-#define UUID_0F083A4D564C4D79CA6387B1D0F1901E
+#pragma once
 
 #include "itemBehavior.hpp"
 #include <functional>
@@ -30,5 +29,3 @@ struct BooleanSwitchBehavior : ItemBehavior
 	Common& common;
 	bool& v;
 };
-
-#endif // UUID_0F083A4D564C4D79CA6387B1D0F1901E

--- a/src/game/menu/enumBehavior.cpp
+++ b/src/game/menu/enumBehavior.cpp
@@ -1,4 +1,3 @@
-
 #include "enumBehavior.hpp"
 
 #include "menu.hpp"

--- a/src/game/menu/enumBehavior.hpp
+++ b/src/game/menu/enumBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_171F520E38DF4A036E1AA3901EEA4801
-#define UUID_171F520E38DF4A036E1AA3901EEA4801
+#pragma once
 
 #include "itemBehavior.hpp"
 
@@ -28,5 +27,3 @@ struct EnumBehavior : ItemBehavior
 	uint32_t min, max;
 	bool brokenLeftRight;
 };
-
-#endif // UUID_171F520E38DF4A036E1AA3901EEA4801

--- a/src/game/menu/fileSelector.hpp
+++ b/src/game/menu/fileSelector.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_MENU_FILESELECTOR_HPP
-#define LIERO_MENU_FILESELECTOR_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -327,5 +326,3 @@ struct FileSelector
 
 	//Menu menu;
 };
-
-#endif // LIERO_MENU_FILESELECTOR_HPP

--- a/src/game/menu/hiddenMenu.cpp
+++ b/src/game/menu/hiddenMenu.cpp
@@ -1,4 +1,3 @@
-
 #include "hiddenMenu.hpp"
 
 #include "arrayEnumBehavior.hpp"

--- a/src/game/menu/hiddenMenu.hpp
+++ b/src/game/menu/hiddenMenu.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_C2D646F783444E7630AA27BB8F6C0B15
-#define UUID_C2D646F783444E7630AA27BB8F6C0B15
+#pragma once
 
 #include "menu.hpp"
 
@@ -42,5 +41,3 @@ struct HiddenMenu : Menu
 
 	int paletteColor;
 };
-
-#endif // UUID_C2D646F783444E7630AA27BB8F6C0B15

--- a/src/game/menu/integerBehavior.cpp
+++ b/src/game/menu/integerBehavior.cpp
@@ -1,4 +1,3 @@
-
 #include "integerBehavior.hpp"
 
 #include "menu.hpp"

--- a/src/game/menu/integerBehavior.hpp
+++ b/src/game/menu/integerBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_C5F17B0F3E6B43526CD95D90435B7596
-#define UUID_C5F17B0F3E6B43526CD95D90435B7596
+#pragma once
 
 #include "itemBehavior.hpp"
 
@@ -28,5 +27,3 @@ struct IntegerBehavior : ItemBehavior
 	bool percentage;
 	bool allowEntry;
 };
-
-#endif // UUID_C5F17B0F3E6B43526CD95D90435B7596

--- a/src/game/menu/itemBehavior.cpp
+++ b/src/game/menu/itemBehavior.cpp
@@ -1,3 +1,0 @@
-
-#include "itemBehavior.hpp"
-

--- a/src/game/menu/itemBehavior.hpp
+++ b/src/game/menu/itemBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_8BF7504F0306489E5EA42995B2020DD2
-#define UUID_8BF7504F0306489E5EA42995B2020DD2
+#pragma once
 
 #include <vector>
 
@@ -30,5 +29,3 @@ struct ItemBehavior
 	{
 	}
 };
-
-#endif // UUID_8BF7504F0306489E5EA42995B2020DD2

--- a/src/game/menu/mainMenu.hpp
+++ b/src/game/menu/mainMenu.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_MENU_MAINMENU_HPP
-#define LIERO_MENU_MAINMENU_HPP
+#pragma once
 
 #include "menu.hpp"
 
@@ -29,5 +28,3 @@ struct MainMenu : Menu
 
 	virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item);
 };
-
-#endif // LIERO_MENU_MAINMENU_HPP

--- a/src/game/menu/menu.hpp
+++ b/src/game/menu/menu.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_3DC24B15AD67494EEAB541B4AE253D0F
-#define UUID_3DC24B15AD67494EEAB541B4AE253D0F
+#pragma once
 
 #include <SDL.h>
 #include <cstddef>
@@ -206,5 +205,3 @@ struct Menu
 private:
 	int selection_; // Global index
 };
-
-#endif // UUID_3DC24B15AD67494EEAB541B4AE253D0F

--- a/src/game/menu/menuItem.hpp
+++ b/src/game/menu/menuItem.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_68BF27AE54944A5A75C91BBAD19D89F9
-#define UUID_68BF27AE54944A5A75C91BBAD19D89F9
+#pragma once
 
 #include <string>
 #include "../gfx/color.hpp"
@@ -42,5 +41,3 @@ struct MenuItem
 	bool visible, selectable;
 	int id;
 };
-
-#endif // UUID_68BF27AE54944A5A75C91BBAD19D89F9

--- a/src/game/menu/timeBehavior.cpp
+++ b/src/game/menu/timeBehavior.cpp
@@ -1,4 +1,3 @@
-
 #include "timeBehavior.hpp"
 
 #include "menu.hpp"

--- a/src/game/menu/timeBehavior.hpp
+++ b/src/game/menu/timeBehavior.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_3B614A27F8FE4D5D7E0254BE877C9E5F
-#define UUID_3B614A27F8FE4D5D7E0254BE877C9E5F
+#pragma once
 
 #include "integerBehavior.hpp"
 
@@ -19,6 +18,3 @@ struct TimeBehavior : IntegerBehavior
 
 	bool frames;
 };
-
-
-#endif // UUID_3B614A27F8FE4D5D7E0254BE877C9E5F

--- a/src/game/mixer/mixer.hpp
+++ b/src/game/mixer/mixer.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_3B31F81A4DBD4530E2E6F5ACC61DDDAB
-#define UUID_3B31F81A4DBD4530E2E6F5ACC61DDDAB
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -27,5 +26,3 @@ std::vector<int16_t>& sfx_sound_data(sfx_sound* snd);
 
 void sfx_mixer_mix(sfx_mixer* self, void* output, unsigned long frame_count);
 //void sfx_mixer_fill(sfx_stream* str, uint32_t start, uint32_t frames);
-
-#endif // UUID_3B31F81A4DBD4530E2E6F5ACC61DDDAB

--- a/src/game/mixer/player.hpp
+++ b/src/game/mixer/player.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_MIXER_PLAYER_HPP
-#define LIERO_MIXER_PLAYER_HPP
+#pragma once
 
 #include <gvl/resman/shared.hpp>
 
@@ -53,5 +52,3 @@ struct NullSoundPlayer : SoundPlayer
 	{
 	}
 };
-
-#endif // LIERO_MIXER_PLAYER_HPP

--- a/src/game/nobject.hpp
+++ b/src/game/nobject.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_NOBJECT_HPP
-#define LIERO_NOBJECT_HPP
+#pragma once
 
 #include "math.hpp"
 #include "exactObjectList.hpp"
@@ -64,5 +63,3 @@ struct NObject : ExactObjectListBase
 	WormWeapon* firedBy;
 	bool hasHit;
 };
-
-#endif // LIERO_NOBJECT_HPP

--- a/src/game/objectList.hpp
+++ b/src/game/objectList.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_OBJECTLIST_HPP
-#define LIERO_OBJECTLIST_HPP
+#pragma once
 
 #include <cstddef>
 #include <cassert>
@@ -163,5 +162,3 @@ struct ObjectList
 	//ObjectListBase sentinel;
 	std::size_t count;
 };
-
-#endif // LIERO_OBJECTLIST_HPP

--- a/src/game/rand.hpp
+++ b/src/game/rand.hpp
@@ -1,10 +1,7 @@
-#ifndef UUID_C1DCDBE1BD8541A14AEC91A1BDF3B9F4
-#define UUID_C1DCDBE1BD8541A14AEC91A1BDF3B9F4
+#pragma once
 
 #include <gvl/math/cmwc.hpp>
 
 struct Rand : gvl::mwc
 {
 };
-
-#endif // UUID_C1DCDBE1BD8541A14AEC91A1BDF3B9F4

--- a/src/game/reader.hpp
+++ b/src/game/reader.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_READER_HPP
-#define LIERO_READER_HPP
+#pragma once
 
 #include <cstdint>
 #include <cstdio>
@@ -85,5 +84,3 @@ struct ReaderFile : gvl::noncopyable
 		pos += l;
 	}
 };
-
-#endif // LIERO_READER_HPP

--- a/src/game/rect.hpp
+++ b/src/game/rect.hpp
@@ -1,10 +1,7 @@
-#ifndef LIERO_RECT_HPP
-#define LIERO_RECT_HPP
+#pragma once
 
 #error NO!
 
 #include <gvl/math/rect.hpp>
 
 typedef gvl::basic_rect<int> Rect;
-
-#endif // LIERO_RECT_HPP

--- a/src/game/replay.hpp
+++ b/src/game/replay.hpp
@@ -1,5 +1,4 @@
-#ifndef UUID_4CF92C398C724F883A02E8A68FE1584F
-#define UUID_4CF92C398C724F883A02E8A68FE1584F
+#pragma once
 
 #include <gvl/io2/stream.hpp>
 #include <gvl/serialization/context.hpp>
@@ -96,5 +95,3 @@ struct ReplayReader : Replay
 
 	gvl::octet_reader reader;
 };
-
-#endif // UUID_4CF92C398C724F883A02E8A68FE1584F

--- a/src/game/settings.hpp
+++ b/src/game/settings.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_SETTINGS_HPP
-#define LIERO_SETTINGS_HPP
+#pragma once
 
 #include "worm.hpp"
 #include <string>
@@ -415,5 +414,3 @@ void archive_text(Settings& settings, Archive& ar)
 
 	#undef S
 }
-
-#endif // LIERO_SETTINGS_HPP

--- a/src/game/sfx.hpp
+++ b/src/game/sfx.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_SFX_HPP
-#define LIERO_SFX_HPP
+#pragma once
 
 #if !DISABLE_SOUND
 #include "mixer/mixer.hpp"
@@ -69,7 +68,3 @@ struct DefaultSoundPlayer : SoundPlayer
 		sfx.stop(id);
 	}
 };
-
-
-
-#endif // LIERO_SFX_HPP

--- a/src/game/sobject.hpp
+++ b/src/game/sobject.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_SOBJECT_HPP
-#define LIERO_SOBJECT_HPP
+#pragma once
 
 #include "math.hpp"
 #include "exactObjectList.hpp"
@@ -40,5 +39,3 @@ struct SObject : ExactObjectListBase
 	int curFrame;
 	int animDelay;
 };
-
-#endif // LIERO_SOBJECT_HPP

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_SPECTATORVIEWPORT_HPP
-#define LIERO_SPECTATORVIEWPORT_HPP
+#pragma once
 
 #include "game.hpp"
 #include "worm.hpp"
@@ -20,5 +19,3 @@ struct SpectatorViewport : Viewport
 	void draw(Game& game, Renderer& renderer, GameState state, bool isReplay);
 	void process(Game& game);
 };
-
-#endif // LIERO_SPECTATORVIEWPORT_HPP

--- a/src/game/stats.hpp
+++ b/src/game/stats.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_STATS_HPP
-#define LIERO_STATS_HPP
+#pragma once
 
 #include <vector>
 #include <type_traits>
@@ -109,5 +108,3 @@ vector<T> zip(vector<T>& src, vector<T> const& other, Op op)
 
 	return std::move(n);
 }
-
-#endif // LIERO_STATS_HPP

--- a/src/game/stats_recorder.hpp
+++ b/src/game/stats_recorder.hpp
@@ -1,5 +1,4 @@
-#ifndef STATS_RECORDER_HPP
-#define STATS_RECORDER_HPP
+#pragma once
 
 #include <chrono>
 #include "worm.hpp"
@@ -151,5 +150,3 @@ struct NormalStatsRecorder : StatsRecorder
 
 	//void write(Common& common, gvl::stream_ptr sink);
 };
-
-#endif // STATS_RECORDER_HPP

--- a/src/game/text.hpp
+++ b/src/game/text.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_TEXT_HPP
-#define LIERO_TEXT_HPP
+#pragma once
 
 #include <string>
 #include <cstring>
@@ -44,5 +43,3 @@ bool ciCompare(std::string const& a, std::string const& b);
 bool ciLess(std::string const& a, std::string const& b);
 // converts an extremely limited subset of UTF-8 to extended ASCII
 char utf8ToDOS(char* str);
-
-#endif // LIERO_TEXT_HPP

--- a/src/game/version.hpp
+++ b/src/game/version.hpp
@@ -1,7 +1,4 @@
-#ifndef LIERO_VERSION_HPP
-#define LIERO_VERSION_HPP
+#pragma once
 
 static int const myGameVersion = 10;
 static int const myReplayVersion = 4;
-
-#endif // LIERO_VERSION_HPP

--- a/src/game/viewport.hpp
+++ b/src/game/viewport.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_VIEWPORT_HPP
-#define LIERO_VIEWPORT_HPP
+#pragma once
 
 #include "game.hpp"
 #include "worm.hpp"
@@ -62,5 +61,3 @@ struct Viewport
 	virtual void draw(Game& game, Renderer& renderer, GameState state, bool isReplay);
 	virtual void process(Game& game);
 };
-
-#endif // LIERO_VIEWPORT_HPP

--- a/src/game/weapon.hpp
+++ b/src/game/weapon.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_WEAPON_HPP
-#define LIERO_WEAPON_HPP
+#pragma once
 
 #include "math.hpp"
 #include "exactObjectList.hpp"
@@ -96,6 +95,3 @@ struct WObject : ExactObjectListBase
 	WormWeapon* firedBy;
 	bool hasHit;
 };
-
-
-#endif // LIERO_WEAPON_HPP

--- a/src/game/weapsel.hpp
+++ b/src/game/weapsel.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_WEAPSEL_HPP
-#define LIERO_WEAPSEL_HPP
+#pragma once
 
 #include "game.hpp"
 #include "menu/menu.hpp"
@@ -31,5 +30,3 @@ struct WeaponSelection
 };
 
 //void selectWeapons(Game& game);
-
-#endif // LIERO_WEAPSEL_HPP

--- a/src/game/worm.hpp
+++ b/src/game/worm.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_WORM_HPP
-#define LIERO_WORM_HPP
+#pragma once
 
 #include "math.hpp"
 #include "rand.hpp"
@@ -402,6 +401,3 @@ struct Worm : gvl::shared
 bool checkForWormHit(Game& game, int x, int y, int dist, Worm* ownWorm);
 bool checkForSpecWormHit(Game& game, int x, int y, int dist, Worm& w);
 int sqrVectorLength(int x, int y);
-
-
-#endif // LIERO_WORM_HPP

--- a/src/tc_tool/common_exereader.hpp
+++ b/src/tc_tool/common_exereader.hpp
@@ -1,5 +1,4 @@
-#ifndef LIERO_COMMON_EXEREADER_HPP
-#define LIERO_COMMON_EXEREADER_HPP
+#pragma once
 
 #include "game/common.hpp"
 
@@ -7,5 +6,3 @@ struct ReaderFile;
 
 void loadFromExe(Common& common, ReaderFile& exe, ReaderFile& gfx, ReaderFile& snd);
 void loadSfx(std::vector<sfx_sound*>& sounds, ReaderFile& snd);
-
-#endif // LIERO_COMMON_EXEREADER_HPP

--- a/src/tc_tool/common_writer.hpp
+++ b/src/tc_tool/common_writer.hpp
@@ -1,10 +1,7 @@
-#ifndef LIERO_COMMON_WRITER_HPP
-#define LIERO_COMMON_WRITER_HPP
+#pragma once
 
 #include <string>
 
 struct Common;
 
 void commonSave(Common& common, std::string const& path);
-
-#endif // LIERO_COMMON_WRITER_HPP

--- a/src/video_tool/replay_to_video.hpp
+++ b/src/video_tool/replay_to_video.hpp
@@ -1,5 +1,4 @@
-#ifndef REPLAY_TO_VIDEO_HPP
-#define REPLAY_TO_VIDEO_HPP
+#pragma once
 
 #include <memory>
 #include <string>
@@ -10,5 +9,3 @@ void replayToVideo(
     bool spectator,
 	std::string const& fullPath,
 	std::string const& replayVideoName);
-
-#endif // REPLAY_TO_VIDEO_HPP

--- a/src/video_tool/tools_main.cpp
+++ b/src/video_tool/tools_main.cpp
@@ -1,6 +1,3 @@
-#ifndef UUID_8615289728154E2FB9B179C2745D5FA9
-#define UUID_8615289728154E2FB9B179C2745D5FA9
-
 #include "game/reader.hpp"
 #include "game/filesystem.hpp"
 #include "game/text.hpp"
@@ -113,5 +110,3 @@ catch(std::exception& ex)
 	//Console::waitForAnyKey();
 	return 1;
 }
-
-#endif // UUID_8615289728154E2FB9B179C2745D5FA9

--- a/src/video_tool/video_recorder.h
+++ b/src/video_tool/video_recorder.h
@@ -1,5 +1,4 @@
-#ifndef VIDEOTEST_H
-#define VIDEOTEST_H
+#pragma once
 
 #include "libavformat/avformat.h"
 #include "libswscale/swscale.h"
@@ -21,5 +20,3 @@ int  vidrec_init(video_recorder* self, char const* filename, int width, int heig
 int  vidrec_write_audio_frame(video_recorder* self, int16_t* samples, int audio_input_frame_size);
 int  vidrec_write_video_frame(video_recorder* self, AVFrame* pic);
 int  vidrec_finalize(video_recorder* self);
-
-#endif // VIDEOTEST_H


### PR DESCRIPTION
`#pragma once` is easier to deal with than having ~5 or so lines to muck around with at the beginning & end of header files.