### PR TITLE
Various build fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,10 @@ jobs:
             libjack-dev \
             libsndio-dev \
             libtool \
+            libltdl-dev \
             autoconf \
             automake \
+            autoconf-archive \
             pkg-config
 
       - name: Get cmake/ninja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-22.04
+            os: ubuntu-latest
             workflow_preset: linux-x64-ci
           - name: windows
             os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,15 +96,15 @@ jobs:
       - name: Create build artifact (Linux)
         if: runner.os == 'linux'
         run: |
-          cmake --install build/linux-x64-ci
+          cmake --install build/linux-x64-ci --config Release
           cd install/linux-x64-ci
           tar cvf ../openliero-linux-x64.tar.gz .
 
       - name: Create build artifact (macOS)
         if: runner.os == 'macos'
         run: |
-          cmake --install build/macos-arm64-ci
-          cmake --install build/macos-x64-ci
+          cmake --install build/macos-arm64-ci --config Release
+          cmake --install build/macos-x64-ci --config Release
           lipo -create \
             -output install/openliero \
             install/macos-arm64-ci/openliero \
@@ -120,7 +120,7 @@ jobs:
       - name: Create build artifact (Windows)
         if: runner.os == 'windows'
         run: |
-          cmake --install build/windows-x64-ci
+          cmake --install build/windows-x64-ci --config Release
           Compress-Archive `
            -Path install/windows-x64-ci/* `
            -DestinationPath install/openliero-windows-x64.zip

--- a/tools/vcpkg/overlay-triplets/arm64-linux.cmake
+++ b/tools/vcpkg/overlay-triplets/arm64-linux.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# GCC 16 made -Wincompatible-pointer-types a hard error; suppress it for
+# third-party dependencies until upstream (SDL2) fixes their ALSA bindings.
+set(VCPKG_C_FLAGS "-Wno-incompatible-pointer-types")
+set(VCPKG_CXX_FLAGS "")

--- a/tools/vcpkg/overlay-triplets/x64-linux.cmake
+++ b/tools/vcpkg/overlay-triplets/x64-linux.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# GCC 16 made -Wincompatible-pointer-types a hard error; suppress it for
+# third-party dependencies until upstream (SDL2) fixes their ALSA bindings.
+set(VCPKG_C_FLAGS "-Wno-incompatible-pointer-types")
+set(VCPKG_CXX_FLAGS "")


### PR DESCRIPTION
This pull request updates the build configuration and dependency setup for improved compatibility and reliability across platforms. The main changes include updating the GitHub Actions workflow to use the latest Ubuntu runner, adding required build dependencies, ensuring release builds are created for all platforms, and introducing custom vcpkg triplet files to handle GCC 16 compatibility issues.

**Build workflow improvements:**

* Updated the GitHub Actions workflow to use `ubuntu-latest` instead of a specific Ubuntu version for the Linux build job, ensuring the build uses the most up-to-date environment.
* Added `libltdl-dev` and `autoconf-archive` to the list of dependencies installed in the Linux build job to support a broader range of build requirements.
* Modified the `cmake --install` commands for Linux, macOS, and Windows to explicitly specify the `Release` configuration, ensuring that release builds are consistently produced across all platforms. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L97-R107) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L121-R123)

**Dependency/toolchain configuration:**

* Added custom vcpkg triplet files for `arm64-linux` and `x64-linux` that set up architecture, linkage, and system name, and suppress the `-Wincompatible-pointer-types` error introduced by GCC 16 for third-party dependencies (notably SDL2), improving build compatibility with newer GCC versions. [[1]](diffhunk://#diff-a601502abcb0f656dd5c1d458e0bbc399e1a33e5d03f0dab1a26fa90be9538a6R1-R10) [[2]](diffhunk://#diff-07598aac9cf7af23f39b933f23b7519cc6274474edca01121525217495f77203R1-R10)