### PR TITLE
Migrate from SDL2 to SDL3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,28 +52,31 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libx11-dev \
-            libxft-dev \
-            libxext-dev \
-            libxcursor-dev \
-            libxrandr-dev \
-            libxi-dev \
-            libxss-dev \
-            libwayland-dev \
-            libxkbcommon-dev \
-            libegl1-mesa-dev \
-            libibus-1.0-dev \
+            pkg-config \
             libasound2-dev \
             libpulse-dev \
             libaudio-dev \
             libjack-dev \
             libsndio-dev \
-            libtool \
-            libltdl-dev \
-            autoconf \
-            automake \
-            autoconf-archive \
-            pkg-config
+            libx11-dev \
+            libxext-dev \
+            libxrandr-dev \
+            libxcursor-dev \
+            libxfixes-dev \
+            libxi-dev \
+            libxss-dev \
+            libxtst-dev \
+            libxkbcommon-dev \
+            libdrm-dev \
+            libgbm-dev \
+            libgl1-mesa-dev \
+            libgles2-mesa-dev \
+            libegl1-mesa-dev \
+            libdbus-1-dev \
+            libibus-1.0-dev \
+            libudev-dev \
+            libwayland-dev \
+            libdecor-0-dev
 
       - name: Get cmake/ninja
         uses: lukka/get-cmake@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
             libgles2-mesa-dev \
             libegl1-mesa-dev \
             libdbus-1-dev \
-            libibus-1.0-dev \
             libudev-dev \
             libwayland-dev \
             libdecor-0-dev
@@ -90,7 +89,7 @@ jobs:
         with:
           vcpkgDirectory: '${{ github.workspace }}/tools/vcpkg/vcpkg'
           vcpkgConfigurationJsonGlob: 'vcpkg-configuration.json'
-          appendedCacheKey: 'sdl3-v1'
+          appendedCacheKey: 'sdl3-v2'
 
       - name: Run cmake
         uses: lukka/run-cmake@v10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
             libx11-dev \
             libxft-dev \
             libxext-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxi-dev \
+            libxss-dev \
             libwayland-dev \
             libxkbcommon-dev \
             libegl1-mesa-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            autoconf \
+            autoconf-archive \
+            automake \
+            libtool \
             pkg-config \
             libasound2-dev \
             libpulse-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           vcpkgDirectory: '${{ github.workspace }}/tools/vcpkg/vcpkg'
           vcpkgConfigurationJsonGlob: 'vcpkg-configuration.json'
+          appendedCacheKey: 'sdl3-v1'
 
       - name: Run cmake
         uses: lukka/run-cmake@v10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ project(openliero
 )
 
 # find dependencies
-find_package(SDL2 CONFIG REQUIRED)
-find_package(SDL2_image CONFIG REQUIRED)
+find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3)
+find_package(SDL3_image REQUIRED CONFIG)
 find_package(miniz CONFIG REQUIRED)
 
 # local dependencies
@@ -129,8 +129,8 @@ target_link_libraries(game
   PUBLIC
   miniz::miniz
   gvl
-  $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
-  $<IF:$<TARGET_EXISTS:SDL2_image::SDL2_image>,SDL2_image::SDL2_image,SDL2_image::SDL2_image-static>
+  SDL3::SDL3
+  SDL3_image::SDL3_image
 )
 
 if(APPLE)
@@ -184,7 +184,7 @@ if(OPENLIERO_BUILD_TCTOOL)
     PUBLIC
     miniz::miniz
     gvl
-    $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    SDL3::SDL3
   )
 
   add_executable(tctool ${TC_TOOL_SOURCES})
@@ -204,7 +204,7 @@ if(OPENLIERO_BUILD_VIDEOTOOL)
     PUBLIC
     miniz
     gvl
-    $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    SDL3::SDL3
     avcodec
     avformat
     avutil

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include "../worm.hpp"
 #include "../math.hpp"

--- a/src/game/ai/work_queue.hpp
+++ b/src/game/ai/work_queue.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <SDL.h>
-#include <SDL_atomic.h>
+#include <SDL3/SDL.h>
 #include <sstream>
 #include <vector>
 #include <memory>
 
 struct LockMutex
 {
-	LockMutex(SDL_mutex* m)
+	LockMutex(SDL_Mutex* m)
 	: m(m)
 	{
 		SDL_LockMutex(m);
@@ -19,7 +18,7 @@ struct LockMutex
 		SDL_UnlockMutex(m);
 	}
 
-	SDL_mutex* m;
+	SDL_Mutex* m;
 };
 
 struct Work
@@ -28,13 +27,13 @@ struct Work
 	: done_(false)
 	{
 		mutex = SDL_CreateMutex();
-		stateCond = SDL_CreateCond();
+		stateCond = SDL_CreateCondition();
 	}
 
 	virtual ~Work()
 	{
 		SDL_DestroyMutex(mutex);
-		SDL_DestroyCond(stateCond);
+		SDL_DestroyCondition(stateCond);
 	}
 
 	bool waitDone()
@@ -42,14 +41,14 @@ struct Work
 		LockMutex m(mutex);
 
 		while (!done_)
-			SDL_CondWait(stateCond, mutex);
+			SDL_WaitCondition(stateCond, mutex);
 
 		return done_;
 	}
 
 	bool done_;
-	SDL_mutex* mutex;
-	SDL_cond* stateCond;
+	SDL_Mutex* mutex;
+	SDL_Condition* stateCond;
 
 	void run()
 	{
@@ -62,7 +61,7 @@ struct Work
 			done_ = true;
 			SDL_MemoryBarrierRelease();
 
-			SDL_CondSignal(stateCond);
+			SDL_SignalCondition(stateCond);
 		}
 	}
 
@@ -80,7 +79,7 @@ struct WorkQueue
 	: queueAlive(true)
 	{
 		queueMutex = SDL_CreateMutex();
-		queueCond = SDL_CreateCond();
+		queueCond = SDL_CreateCondition();
 
 		std::memset(threads, 0, sizeof(threads));
 		for (int i = 0; i < threadCount; ++i)
@@ -97,7 +96,7 @@ struct WorkQueue
 			LockMutex m(queueMutex);
 
 			queueAlive = false;
-			SDL_CondBroadcast(queueCond);
+			SDL_BroadcastCondition(queueCond);
 		}
 
 		for (int i = 0; i < 8; ++i)
@@ -108,14 +107,14 @@ struct WorkQueue
 		}
 
 		SDL_DestroyMutex(queueMutex);
-		SDL_DestroyCond(queueCond);
+		SDL_DestroyCondition(queueCond);
 	}
 
 	void add(std::unique_ptr<Work> work)
 	{
 		LockMutex m(queueMutex);
 		queue.push_back(std::move(work));
-		SDL_CondSignal(queueCond);
+		SDL_SignalCondition(queueCond);
 	}
 
 	std::unique_ptr<Work> waitForWork()
@@ -123,7 +122,7 @@ struct WorkQueue
 		LockMutex m(queueMutex);
 
 		while (queue.empty() && queueAlive)
-			SDL_CondWait(queueCond, queueMutex);
+			SDL_WaitCondition(queueCond, queueMutex);
 
 		if (!queueAlive)
 			throw StopWorker();
@@ -133,7 +132,7 @@ struct WorkQueue
 		return ret;
 	}
 
-	static int worker(void* self)
+	static int SDLCALL worker(void* self)
 	{
 		try
 		{
@@ -153,8 +152,8 @@ struct WorkQueue
 		return 0;
 	}
 
-	SDL_mutex* queueMutex;
-	SDL_cond* queueCond;
+	SDL_Mutex* queueMutex;
+	SDL_Condition* queueCond;
 	std::vector<std::unique_ptr<Work>> queue;
 	bool queueAlive;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cstdlib>
 #include <ctime>
 

--- a/src/game/gameEntry.cpp
+++ b/src/game/gameEntry.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include "gfx.hpp"
 #include "sfx.hpp"
@@ -21,7 +21,7 @@ int gameEntry(int argc, char* argv[])
 try
 {
 	// TODO: Better PRNG seeding
-	gfx.rand.seed(Uint32(std::time(0)));
+	gfx.rand.seed(uint32_t(std::time(0)));
 
 	bool tcSet = false;
 
@@ -50,7 +50,7 @@ try
 		}
 	}
 
-	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
+	SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD);
 
 	initKeys();
 

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1,5 +1,5 @@
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL3/SDL.h>
+#include <SDL3_image/SDL_image.h>
 #include <cstring>
 #include <cassert>
 #include <cstdlib>
@@ -293,25 +293,25 @@ Gfx::Gfx()
 
 void Gfx::init()
 {
-	SDL_ShowCursor(SDL_DISABLE);
-	lastFrame = SDL_GetTicks64();
+	SDL_HideCursor();
+	lastFrame = SDL_GetTicks();
 
 	playRenderer.init(320, 200);
 	singleScreenRenderer.init(640, 400);
-	// Joystick init
-	SDL_GameControllerEventState(SDL_ENABLE);
-	int numJoysticks = SDL_NumJoysticks();
-	joysticks.resize(numJoysticks);
-	for ( int i = 0; i < numJoysticks; ++i ) {
-		joysticks[i].sdlGameController= SDL_GameControllerOpen(i);
+	// Gamepad init
+	SDL_SetGamepadEventsEnabled(true);
+	int numGamepads = 0;
+	SDL_JoystickID *gamepadIds = SDL_GetGamepads(&numGamepads);
+	joysticks.resize(numGamepads);
+	for ( int i = 0; i < numGamepads; ++i ) {
+		joysticks[i].sdlGamepad = SDL_OpenGamepad(gamepadIds[i]);
 		joysticks[i].clearState();
 	}
+	SDL_free(gamepadIds);
 }
 
 void Gfx::setVideoMode()
 {
-	int flags;
-
 	if (sdlSpectatorRenderer)
 	{
 		SDL_DestroyRenderer(sdlSpectatorRenderer);
@@ -319,30 +319,17 @@ void Gfx::setVideoMode()
 	}
 	if (settings->spectatorWindow)
 	{
-		flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
-		if (spectatorFullscreen)
-		{
-			flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-		}
 		if (!sdlSpectatorWindow)
 		{
-      std::string spectatorWindowTitle = std::string("Liero Spectator Window - ") + build_version();
-			sdlSpectatorWindow = SDL_CreateWindow(spectatorWindowTitle.c_str(),
-				SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowW, windowH, flags);
+			std::string spectatorWindowTitle = std::string("Liero Spectator Window - ") + build_version();
+			sdlSpectatorWindow = SDL_CreateWindow(spectatorWindowTitle.c_str(), windowW, windowH,
+				SDL_WINDOW_RESIZABLE | (spectatorFullscreen ? SDL_WINDOW_FULLSCREEN : 0));
 		}
 		else
 		{
-			if (spectatorFullscreen)
-			{
-				SDL_SetWindowFullscreen(sdlSpectatorWindow,
-					SDL_WINDOW_FULLSCREEN_DESKTOP);
-			}
-			else
-			{
-				SDL_SetWindowFullscreen(sdlSpectatorWindow, 0);
-			}
+			SDL_SetWindowFullscreen(sdlSpectatorWindow, spectatorFullscreen);
 		}
-		sdlSpectatorRenderer = SDL_CreateRenderer(sdlSpectatorWindow, -1, 0/*SDL_RENDERER_PRESENTVSYNC*/);
+		sdlSpectatorRenderer = SDL_CreateRenderer(sdlSpectatorWindow, NULL);
 		onWindowResize(SDL_GetWindowID(sdlSpectatorWindow));
 	}
 	else
@@ -354,7 +341,7 @@ void Gfx::setVideoMode()
 		}
 		if (sdlSpectatorDrawSurface)
 		{
-			SDL_FreeSurface(sdlSpectatorDrawSurface);
+			SDL_DestroySurface(sdlSpectatorDrawSurface);
 			sdlSpectatorDrawSurface = NULL;
 		}
 		if (sdlSpectatorWindow)
@@ -364,46 +351,25 @@ void Gfx::setVideoMode()
 		}
 	}
 
-	flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
-
-	if (settings->fullscreen)
-	{
-		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-	}
-
 	if (!sdlWindow)
 	{
-		int x = SDL_WINDOWPOS_UNDEFINED;
-		int y = SDL_WINDOWPOS_UNDEFINED;
-		if (sdlSpectatorWindow)
-		{
-			SDL_GetWindowPosition(sdlSpectatorWindow, &x, &y);
-		}
-    std::string windowTitle = std::string("Liero ") + build_version();
-		sdlWindow = SDL_CreateWindow(windowTitle.c_str(), x + 100, y + 50, windowW, windowH, flags);
+		std::string windowTitle = std::string("Liero ") + build_version();
+		sdlWindow = SDL_CreateWindow(windowTitle.c_str(), windowW, windowH,
+			SDL_WINDOW_RESIZABLE | (settings->fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
 
-		// The Mac app will automatically use the .icns icon file located in the
-		// .app bundle, so don't override that here.
 #ifndef __APPLE__
 		std::string s = (getConfigNode() / "Resources" / "icon.png").fullPath();
 		SDL_Surface *icon = IMG_Load(s.c_str());
 		if (icon)
 		{
 			SDL_SetWindowIcon(sdlWindow, icon);
-			SDL_FreeSurface(icon);
+			SDL_DestroySurface(icon);
 		}
 #endif
 	}
 	else
 	{
-		if (settings->fullscreen)
-		{
-			SDL_SetWindowFullscreen(sdlWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
-		}
-		else
-		{
-			SDL_SetWindowFullscreen(sdlWindow, 0);
-		}
+		SDL_SetWindowFullscreen(sdlWindow, settings->fullscreen);
 	}
 	if (sdlRenderer)
 	{
@@ -412,7 +378,7 @@ void Gfx::setVideoMode()
 	}
 	// vertical sync is always disabled. Frame limiting is done manually below,
 	// to keep the correct speed
-	sdlRenderer = SDL_CreateRenderer(sdlWindow, -1, 0 /*SDL_RENDERER_PRESENTVSYNC*/);
+	sdlRenderer = SDL_CreateRenderer(sdlWindow, NULL);
 	onWindowResize(SDL_GetWindowID(sdlWindow));
 
 	// Set the spectator window's icon after the main window has been initialized.
@@ -427,13 +393,13 @@ void Gfx::setVideoMode()
 		if (spectator_icon)
 		{
 			SDL_SetWindowIcon(sdlSpectatorWindow, spectator_icon);
-			SDL_FreeSurface(spectator_icon);
+			SDL_DestroySurface(spectator_icon);
 		}
 	}
 #endif
 }
 
-void Gfx::onWindowResize(Uint32 windowID)
+void Gfx::onWindowResize(uint32_t windowID)
 {
 	if (windowID == SDL_GetWindowID(sdlWindow))
 	{
@@ -449,16 +415,16 @@ void Gfx::onWindowResize(Uint32 windowID)
 
 		if (sdlDrawSurface)
 		{
-			SDL_FreeSurface(sdlDrawSurface);
+			SDL_DestroySurface(sdlDrawSurface);
 			sdlDrawSurface = NULL;
 		}
-		sdlDrawSurface = SDL_CreateRGBSurface(0, doubleRes ? 640 : 320,
-		                         doubleRes ? 400 : 200, 32, 0, 0, 0, 0);
+		sdlDrawSurface = SDL_CreateSurface(doubleRes ? 640 : 320,
+		                         doubleRes ? 400 : 200, SDL_PIXELFORMAT_ARGB8888);
 		// linear for that old-school chunky look, but consider adding a user
 		// option for this
-		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-		SDL_RenderSetLogicalSize(sdlRenderer, doubleRes ? 640 : 320,
-		                         doubleRes ? 400 : 200);
+		SDL_SetTextureScaleMode(sdlTexture, SDL_SCALEMODE_LINEAR);
+		SDL_SetRenderLogicalPresentation(sdlRenderer, doubleRes ? 640 : 320,
+		                         doubleRes ? 400 : 200, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 	}
 	else
 	{
@@ -469,7 +435,7 @@ void Gfx::onWindowResize(Uint32 windowID)
 		}
 		if (sdlSpectatorDrawSurface)
 		{
-			SDL_FreeSurface(sdlSpectatorDrawSurface);
+			SDL_DestroySurface(sdlSpectatorDrawSurface);
 			sdlSpectatorDrawSurface = NULL;
 		}
 
@@ -479,9 +445,8 @@ void Gfx::onWindowResize(Uint32 windowID)
 			                                        SDL_PIXELFORMAT_ARGB8888,
 				                           			SDL_TEXTUREACCESS_STREAMING,
 				                           			640, 400);
-			sdlSpectatorDrawSurface = SDL_CreateRGBSurface(0, 640, 400, 32, 0,
-			                                               0, 0, 0);
-			SDL_RenderSetLogicalSize(sdlSpectatorRenderer, 640, 400);
+			sdlSpectatorDrawSurface = SDL_CreateSurface(640, 400, SDL_PIXELFORMAT_ARGB8888);
+			SDL_SetRenderLogicalPresentation(sdlSpectatorRenderer, 640, 400, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 		}
 	}
 }
@@ -630,15 +595,15 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 {
 	switch(ev.type)
 	{
-		case SDL_KEYDOWN:
+		case SDL_EVENT_KEY_DOWN:
 		{
 
-			SDL_Scancode s = ev.key.keysym.scancode;
+			SDL_Scancode s = ev.key.scancode;
 
 			if (keyBufPtr < keyBuf + 32)
-				*keyBufPtr++ = ev.key.keysym;
+				*keyBufPtr++ = ev.key.scancode;
 
-			Uint32 dosScan = SDLToDOSKey(ev.key.keysym.scancode);
+			uint32_t dosScan = SDLToDOSKey(ev.key.scancode);
 			if(dosScan)
 			{
 				dosKeys[dosScan] = true;
@@ -661,11 +626,11 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 		}
 		break;
 
-		case SDL_KEYUP:
+		case SDL_EVENT_KEY_UP:
 		{
-			SDL_Scancode s = ev.key.keysym.scancode;
+			SDL_Scancode s = ev.key.scancode;
 
-			Uint32 dosScan = SDLToDOSKey(s);
+			uint32_t dosScan = SDLToDOSKey(s);
 			if(dosScan)
 			{
 				dosKeys[dosScan] = false;
@@ -675,29 +640,19 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 		}
 		break;
 
-		case SDL_WINDOWEVENT:
+		case SDL_EVENT_WINDOW_RESIZED:
 		{
-			switch (ev.window.event)
-			{
-				case SDL_WINDOWEVENT_RESIZED:
-				{
-					onWindowResize(ev.window.windowID);
-				}
-				break;
-
-				default:
-				break;
-			}
+			onWindowResize(ev.window.windowID);
 		}
 		break;
 
-		case SDL_QUIT:
+		case SDL_EVENT_QUIT:
 		{
 			running = false;
 		}
 		break;
 
-		case SDL_JOYAXISMOTION:
+		case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 		{
 			Joystick& js = joysticks[ev.jaxis.which];
 			int jbtnBase = 4 + 2 * ev.jaxis.axis;
@@ -721,7 +676,7 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 		}
 		break;
 
-		case SDL_JOYHATMOTION:
+		case SDL_EVENT_JOYSTICK_HAT_MOTION:
 		{
 			Joystick& js = joysticks[ev.jhat.which];
 
@@ -744,12 +699,12 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 		}
 		break;
 
-		case SDL_JOYBUTTONDOWN:
-		case SDL_JOYBUTTONUP: /* Fall-through */
+		case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+		case SDL_EVENT_JOYSTICK_BUTTON_UP: /* Fall-through */
 		{
 			Joystick& js = joysticks[ev.jbutton.which];
 			int jbtn = 16 + ev.jbutton.button;
-			js.btnState[jbtn] = (ev.jbutton.state == SDL_PRESSED);
+			js.btnState[jbtn] = ev.jbutton.down;
 			if(controller)
 				controller->onKey(joyButtonToExKey(ev.jbutton.which, jbtn), js.btnState[jbtn]);
 		}
@@ -770,19 +725,19 @@ void Gfx::process(Controller* controller)
 	}
 }
 
-SDL_Keysym Gfx::waitForKey()
+SDL_Scancode Gfx::waitForKey()
 {
 	SDL_Event ev;
 	while(SDL_WaitEvent(&ev))
 	{
 		processEvent(ev);
-		if(ev.type == SDL_KEYDOWN)
+		if(ev.type == SDL_EVENT_KEY_DOWN)
 		{
-			return ev.key.keysym;
+			return ev.key.scancode;
 		}
 	}
 
-	return SDL_Keysym(); // Dummy
+	return SDL_SCANCODE_UNKNOWN; // Dummy
 }
 
 uint32_t Gfx::waitForKeyEx()
@@ -793,17 +748,17 @@ uint32_t Gfx::waitForKeyEx()
 		processEvent(ev);
 		switch (ev.type)
 		{
-		case SDL_KEYDOWN:
-			return SDLToDOSKey(ev.key.keysym);
+		case SDL_EVENT_KEY_DOWN:
+			return SDLToDOSKey(ev.key.scancode);
 
-		case SDL_JOYAXISMOTION:
+		case SDL_EVENT_JOYSTICK_AXIS_MOTION:
 			if(ev.jaxis.value > JoyAxisThreshold)
 				return joyButtonToExKey( ev.jaxis.which, 4 + 2 * ev.jaxis.axis );
 			else if ( ev.jaxis.value < -JoyAxisThreshold )
 				return joyButtonToExKey( ev.jaxis.which, 5 + 2 * ev.jaxis.axis );
 
 			break;
-		case SDL_JOYHATMOTION:
+		case SDL_EVENT_JOYSTICK_HAT_MOTION:
 			if(ev.jhat.value & SDL_HAT_UP)
 				return joyButtonToExKey(ev.jhat.which, 0);
 			else if(ev.jhat.value & SDL_HAT_DOWN)
@@ -814,7 +769,7 @@ uint32_t Gfx::waitForKeyEx()
 				return joyButtonToExKey(ev.jhat.which, 3);
 
 			break;
-		case SDL_JOYBUTTONDOWN:
+		case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
 			return joyButtonToExKey(ev.jbutton.which, 16 + ev.jbutton.button);
 		default:
 			break;
@@ -846,11 +801,11 @@ void Gfx::clearKeys()
 	std::memset(dosKeys, 0, sizeof(dosKeys));
 }
 
-void Gfx::preparePalette(SDL_PixelFormat* format, Color realPal[256], uint32_t (&pal32)[256])
+void Gfx::preparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette, Color realPal[256], uint32_t (&pal32)[256])
 {
 	for(int i = 0; i < 256; ++i)
 	{
-		pal32[i] = SDL_MapRGB(format, realPal[i].r, realPal[i].g, realPal[i].b);
+		pal32[i] = SDL_MapRGB(format, palette, realPal[i].r, realPal[i].g, realPal[i].b);
 	}
 }
 
@@ -888,7 +843,7 @@ void Gfx::draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdlRend
 	{
 		// Clear background if magnification is decreased to
 		// avoid leftovers.
-		SDL_FillRect(&surface, 0, 0);
+		SDL_FillSurfaceRect(&surface, 0, 0);
 		updateRect = lastUpdateRect | newRect;
 	}
 	else
@@ -898,16 +853,17 @@ void Gfx::draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdlRend
 	std::size_t destPitch = surface.pitch;
 	std::size_t srcPitch = renderer.bmp.pitch;
 
-	PalIdx* dest = reinterpret_cast<PalIdx*>(surface.pixels) + offsetY * destPitch + offsetX * surface.format->BytesPerPixel;
+	SDL_PixelFormatDetails const* formatDetails = SDL_GetPixelFormatDetails(surface.format);
+	PalIdx* dest = reinterpret_cast<PalIdx*>(surface.pixels) + offsetY * destPitch + offsetX * formatDetails->bytes_per_pixel;
 	PalIdx* src = renderer.bmp.pixels;
 
 	uint32_t pal32[256];
-	preparePalette(surface.format, realPal, pal32);
+	preparePalette(formatDetails, NULL, realPal, pal32);
 	scaleDraw(src, renderer.renderResX, renderer.renderResY, srcPitch, dest, destPitch, mag, pal32);
 
 	SDL_UpdateTexture(&texture, NULL, surface.pixels, surface.w * 4);
 	SDL_RenderClear(&sdlRenderer);
-	SDL_RenderCopy(&sdlRenderer, &texture, NULL, NULL);
+	SDL_RenderTexture(&sdlRenderer, &texture, NULL, NULL);
 	SDL_RenderPresent(&sdlRenderer);
 
 	lastUpdateRect = updateRect;
@@ -930,11 +886,11 @@ void Gfx::flip()
 
 	while(true)
 	{
-		auto now = SDL_GetTicks64();
+		auto now = SDL_GetTicks();
 		if(now >= wantedTime)
 			break;
 
-		SDL_Delay(wantedTime - now);
+		SDL_Delay((uint32_t)(wantedTime - now));
 	}
 
 	lastFrame = wantedTime;
@@ -1675,14 +1631,14 @@ bool Gfx::inputString(std::string& dest, std::size_t maxLen, int x, int y, int (
 		font.drawText(playRenderer.bmp, str, x - adjust, y + 1, 50);
 		flip();
 
-		SDL_StartTextInput();
+		SDL_StartTextInput(sdlWindow);
 		SDL_WaitEvent(&ev);
 		processEvent(ev);
 
 		switch (ev.type)
 		{
-			case SDL_KEYDOWN:
-				switch (ev.key.keysym.scancode)
+			case SDL_EVENT_KEY_DOWN:
+				switch (ev.key.scancode)
 				{
 					case SDL_SCANCODE_BACKSPACE:
 						if(!buffer.empty())
@@ -1707,7 +1663,7 @@ bool Gfx::inputString(std::string& dest, std::size_t maxLen, int x, int y, int (
 				}
 				break;
 
-			case SDL_TEXTINPUT:
+			case SDL_EVENT_TEXT_INPUT:
 			{
 				int k = utf8ToDOS(ev.text.text);
 				if (k && buffer.size() < maxLen &&
@@ -1717,7 +1673,7 @@ bool Gfx::inputString(std::string& dest, std::size_t maxLen, int x, int y, int (
 				}
 				break;
 			}
-			case SDL_TEXTEDITING:
+			case SDL_EVENT_TEXT_EDITING:
 				// since there's no support for any characters that can use a
 				// complex IME input (like East Asian languages), we naively
 				// discard this event

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <gvl/math/rect.hpp>
 
 #include <cstdio>
@@ -104,7 +104,7 @@ struct SettingsMenu : Menu
 };
 
 struct Joystick {
-	SDL_GameController *sdlGameController;
+	SDL_Gamepad *sdlGamepad;
 	bool btnState[MaxJoyButtons];
 
 	void clearState() {
@@ -119,7 +119,7 @@ struct Gfx
 
 	void init();
 	void setVideoMode();
-	void onWindowResize(Uint32 windowId);
+	void onWindowResize(uint32_t windowId);
 	void loadMenus();
 
 	void process(Controller* controller = 0);
@@ -130,58 +130,58 @@ struct Gfx
 
 	void clearKeys();
 
-	bool testKeyOnce(Uint32 key)
+	bool testKeyOnce(uint32_t key)
 	{
 		bool state = dosKeys[key];
 		dosKeys[key] = false;
 		return state;
 	}
 
-	bool testKey(Uint32 key)
+	bool testKey(uint32_t key)
 	{
 		return dosKeys[key];
 	}
 
-	void releaseKey(Uint32 key)
+	void releaseKey(uint32_t key)
 	{
 		dosKeys[key] = false;
 	}
 
-	void pressKey(Uint32 key)
+	void pressKey(uint32_t key)
 	{
 		dosKeys[key] = true;
 	}
 
-	void setKey(Uint32 key, bool state)
+	void setKey(uint32_t key, bool state)
 	{
 		dosKeys[key] = state;
 	}
 
-	void toggleKey(Uint32 key)
+	void toggleKey(uint32_t key)
 	{
 		dosKeys[key] = !dosKeys[key];
 	}
 
 	bool testSDLKeyOnce(SDL_Scancode key)
 	{
-		Uint32 k = SDLToDOSKey(key);
+		uint32_t k = SDLToDOSKey(key);
 		return k ? testKeyOnce(k) : false;
 	}
 
 	bool testSDLKey(SDL_Scancode key)
 	{
-		Uint32 k = SDLToDOSKey(key);
+		uint32_t k = SDLToDOSKey(key);
 		return k ? testKey(k) : false;
 	}
 
 	void releaseSDLKey(SDL_Scancode key)
 	{
-		Uint32 k = SDLToDOSKey(key);
+		uint32_t k = SDLToDOSKey(key);
 		if(k)
 			dosKeys[k] = false;
 	}
 
-	SDL_Keysym waitForKey();
+	SDL_Scancode waitForKey();
 	uint32_t waitForKeyEx();
 	std::string getKeyName(uint32_t key);
 	void setSpectatorFullscreen(bool newFullscreen);
@@ -211,10 +211,10 @@ struct Gfx
 	void weaponOptions();
 	void infoBox(std::string const& text, int x = 320/2, int y = 200/2, bool clearScreen = true);
 
-	static void preparePalette(SDL_PixelFormat* format, Color realPal[256], uint32_t (&pal32)[256]);
+	static void preparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette, Color realPal[256], uint32_t (&pal32)[256]);
 
 	static void overlay(
-		SDL_PixelFormat* format,
+		SDL_PixelFormatDetails const* format,
 		uint8_t* src, int w, int h, std::size_t srcPitch,
 		uint8_t* dest, std::size_t destPitch, int mag);
 
@@ -291,7 +291,7 @@ struct Gfx
 
 	std::vector<Joystick> joysticks;
 
-	SDL_Keysym keyBuf[32], *keyBufPtr;
+	SDL_Scancode keyBuf[32], *keyBufPtr;
 
 	std::vector<std::pair<int, int>> debugPoints;
 	std::string debugInfo;

--- a/src/game/keys.cpp
+++ b/src/game/keys.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cstddef>
 #include <cassert>
 #include <map>
@@ -57,7 +57,7 @@ SDL_Scancode lieroToSDLKeys[] =
 	Z, Z, Z, Z, Z // 5 zeroes
 };
 
-Uint32 const maxScanCodes = sizeof(lieroToSDLKeys) / sizeof(*lieroToSDLKeys);
+uint32_t const maxScanCodes = sizeof(lieroToSDLKeys) / sizeof(*lieroToSDLKeys);
 
 void initKeys()
 {
@@ -70,17 +70,17 @@ void initKeys()
 	}
 }
 
-Uint32 SDLToDOSKey(SDL_Scancode scancode)
+uint32_t SDLToDOSKey(SDL_Scancode scancode)
 {
-	std::map<int, int>::iterator i = SDLToDOSScanCodes.find(Uint32(scancode));
+	std::map<int, int>::iterator i = SDLToDOSScanCodes.find(uint32_t(scancode));
 	if(i != SDLToDOSScanCodes.end())
 		return i->second;
 	return 89;
 }
 
-Uint32 SDLToDOSKey(SDL_Keysym const& keysym)
+uint32_t SDLToDOSKey(SDL_Scancode scancode, SDL_Keymod /*mod*/)
 {
-	Uint32 key = SDLToDOSKey(keysym.scancode);
+	uint32_t key = SDLToDOSKey(scancode);
 
 	if(key >= 177) // Liero doesn't have keys >= 177
 		return 89; // Arbitrarily translate it to 89

--- a/src/game/keys.hpp
+++ b/src/game/keys.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 //extern int SDLToLieroKeys[SDL_SCANCODE_LAST];
 //extern int lieroToSDLKeys[177];
 
 void initKeys();
 
-Uint32 SDLToDOSKey(SDL_Keysym const& keysym);
-Uint32 SDLToDOSKey(SDL_Scancode scancode);
+uint32_t SDLToDOSKey(SDL_Scancode scancode, SDL_Keymod mod);
+uint32_t SDLToDOSKey(SDL_Scancode scancode);
 
 int const DkEscape = 1;
 

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -1,5 +1,6 @@
 #include <exception>
 #include <string>
+#include <SDL3/SDL_main.h>
 
 int gameEntry(int argc, char *argv[]);
 

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -1,27 +1,25 @@
 #include <exception>
 #include <string>
 #include <SDL3/SDL_main.h>
+#if _WIN32
+#include <windows.h>
+#endif
 
 int gameEntry(int argc, char *argv[]);
 
-#if _WIN32
-#include <windows.h>
-
-INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow)
+int main(int argc, char *argv[])
 {
 	try
 	{
-		return gameEntry(__argc, __argv);
+		return gameEntry(argc, argv);
 	}
 	catch(std::exception& ex)
 	{
+#if _WIN32
 		MessageBoxA(NULL, (std::string("Sorry, something went wrong :(\r\n\r\n") + ex.what()).c_str(), "Liero", MB_OK | MB_ICONWARNING);
+#else
+		(void)ex;
+#endif
 		return 1;
 	}
 }
-#else
-int main(int argc, char *argv[])
-{
-	return gameEntry(argc, argv);
-}
-#endif

--- a/src/game/menu/menu.cpp
+++ b/src/game/menu/menu.cpp
@@ -10,15 +10,17 @@
 
 #include "../common.hpp"
 
-void Menu::onKeys(SDL_Keysym* begin, SDL_Keysym* end, bool contains)
+void Menu::onKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains)
 {
 	for (; begin != end; ++begin)
 	{
-		bool isTab = begin->scancode == SDL_SCANCODE_TAB;
-		if ((begin->sym >= 32 && begin->sym <= 127) // x >= SDLK_SPACE && x <= SDLK_DELETE
+		SDL_Scancode scancode = *begin;
+		SDL_Keycode sym = SDL_GetKeyFromScancode(scancode, SDL_KMOD_NONE, false);
+		bool isTab = scancode == SDL_SCANCODE_TAB;
+		if ((sym >= 32 && sym <= 127) // x >= SDLK_SPACE && x <= SDLK_DELETE
 		  || isTab)
 		{
-			auto time = SDL_GetTicks64();
+			auto time = SDL_GetTicks();
 			if (!isTab && time - searchTime > 1500)
 				searchPrefix.clear();
 
@@ -28,7 +30,7 @@ void Menu::onKeys(SDL_Keysym* begin, SDL_Keysym* end, bool contains)
 				auto newPrefix = searchPrefix;
 
 				if (!isTab)
-					newPrefix += char(begin->sym);
+					newPrefix += char(sym);
 				searchTime = time;
 
 				bool found = false;

--- a/src/game/menu/menu.hpp
+++ b/src/game/menu/menu.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cstddef>
 #include <string>
 #include <cstdio>
@@ -90,7 +90,7 @@ struct Menu
 		return b->onEnter(*this, *s);
 	}
 
-	void onKeys(SDL_Keysym* begin, SDL_Keysym* end, bool contains = false);
+	void onKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains = false);
 
 	void updateItems(Common& common)
 	{

--- a/src/game/mixer/mixer.cpp
+++ b/src/game/mixer/mixer.cpp
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <cstring>
 #include <vector>
-#include <SDL_atomic.h>
+#include <SDL3/SDL.h>
 
 typedef struct channel
 {

--- a/src/game/sfx.cpp
+++ b/src/game/sfx.cpp
@@ -5,16 +5,22 @@
 #include <vector>
 #include <cassert>
 #if !DISABLE_SOUND
-#	include <SDL.h>
+#	include <SDL3/SDL.h>
 #endif
 
 Sfx sfx;
 
-extern "C" void SDLCALL Sfx_callback(void *userdata, Uint8 *stream, int len)
+static void SDLCALL Sfx_stream_callback(void *userdata, SDL_AudioStream *stream, int additional_amount, int total_amount)
 {
-	uint32_t frame_count = len / 2;
-
-	sfx_mixer_mix((sfx_mixer*)userdata, stream, frame_count);
+	if (additional_amount > 0) {
+		uint8_t *data = (uint8_t *)SDL_stack_alloc(uint8_t, additional_amount);
+		if (data) {
+			uint32_t frame_count = additional_amount / 2;
+			sfx_mixer_mix((sfx_mixer*)userdata, data, frame_count);
+			SDL_PutAudioStreamData(stream, data, additional_amount);
+			SDL_stack_free(data);
+		}
+	}
 }
 
 void Sfx::init()
@@ -27,25 +33,17 @@ void Sfx::init()
 
 	mixer = sfx_mixer_create();
 
-	SDL_AudioSpec spec;
-	memset(&spec, 0, sizeof(spec));
-	spec.channels = 1;
-	spec.freq = 44100;
-	spec.format = AUDIO_S16SYS;
-	spec.size = 4*512;
-	spec.callback = Sfx_callback;
-	spec.userdata = mixer;
+	const SDL_AudioSpec spec = { SDL_AUDIO_S16, 1, 44100 };
+	stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, Sfx_stream_callback, mixer);
 
-	int ret = SDL_OpenAudio(&spec, NULL);
-
-	if(ret == 0)
+	if(stream)
 	{
 		initialized = true;
-		SDL_PauseAudio(0);
+		SDL_ResumeAudioStreamDevice(stream);
 	}
 	else
 	{
-		Console::writeWarning(std::string("SDL_OpenAudio returned error: ") + SDL_GetError());
+		Console::writeWarning(std::string("SDL_OpenAudioDeviceStream returned error: ") + SDL_GetError());
 	}
 #endif
 }
@@ -57,7 +55,11 @@ void Sfx::deinit()
 		return;
 	initialized = false;
 
-	SDL_CloseAudio();
+	if (stream)
+	{
+		SDL_DestroyAudioStream(stream);
+		stream = nullptr;
+	}
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
 #endif
 }

--- a/src/game/sfx.hpp
+++ b/src/game/sfx.hpp
@@ -2,6 +2,7 @@
 
 #if !DISABLE_SOUND
 #include "mixer/mixer.hpp"
+#include <SDL3/SDL.h>
 #endif
 #include <vector>
 #include "mixer/player.hpp"
@@ -22,6 +23,7 @@ struct Sfx
 
 	Sfx()
 	: initialized(false)
+	, stream(nullptr)
 	{
 	}
 	~Sfx();
@@ -38,6 +40,7 @@ struct Sfx
 #endif
 
 	sfx_mixer* mixer;
+	SDL_AudioStream* stream;
 	bool initialized;
 };
 

--- a/src/game/text.cpp
+++ b/src/game/text.cpp
@@ -97,7 +97,7 @@ bool ciLess(std::string const& a, std::string const& b)
 	return b.size() > a.size(); // if b is longer, then a < b, otherwise a == b
 }
 
-char utf8ToDOS(char* str)
+char utf8ToDOS(const char* str)
 {
 	if (str[1] == 0) {
 		return str[0];

--- a/src/game/text.hpp
+++ b/src/game/text.hpp
@@ -42,4 +42,4 @@ bool ciStartsWith(std::string const& a, std::string const& b);
 bool ciCompare(std::string const& a, std::string const& b);
 bool ciLess(std::string const& a, std::string const& b);
 // converts an extremely limited subset of UTF-8 to extended ASCII
-char utf8ToDOS(char* str);
+char utf8ToDOS(const char* str);

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -1,4 +1,4 @@
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 #include "weapsel.hpp"
 #include "gfx.hpp"

--- a/tools/vcpkg/overlay-triplets/arm64-linux.cmake
+++ b/tools/vcpkg/overlay-triplets/arm64-linux.cmake
@@ -3,8 +3,3 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-
-# GCC 16 made -Wincompatible-pointer-types a hard error; suppress it for
-# third-party dependencies until upstream (SDL2) fixes their ALSA bindings.
-set(VCPKG_C_FLAGS "-Wno-incompatible-pointer-types")
-set(VCPKG_CXX_FLAGS "")

--- a/tools/vcpkg/overlay-triplets/x64-linux.cmake
+++ b/tools/vcpkg/overlay-triplets/x64-linux.cmake
@@ -3,8 +3,3 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-
-# GCC 16 made -Wincompatible-pointer-types a hard error; suppress it for
-# third-party dependencies until upstream (SDL2) fixes their ALSA bindings.
-set(VCPKG_C_FLAGS "-Wno-incompatible-pointer-types")
-set(VCPKG_CXX_FLAGS "")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
       "name": "sdl3",
       "features": [
         "alsa",
-        "ibus",
         "wayland",
         "x11"
       ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
       "name": "sdl3",
       "features": [
         "alsa",
+        "ibus",
         "wayland",
         "x11"
       ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     "miniz",
     {
-      "name": "sdl2",
+      "name": "sdl3",
       "features": [
         "alsa",
         "wayland",
@@ -11,9 +11,9 @@
       "platform": "linux"
     },
     {
-      "name": "sdl2",
+      "name": "sdl3",
       "platform": "!linux"
     },
-    "sdl2-image"
+    "sdl3-image"
   ]
 }


### PR DESCRIPTION
Major changes:
- Update vcpkg dependencies (sdl2 -> sdl3, sdl2-image -> sdl3-image)
- Update CMakeLists.txt targets (SDL2::SDL2 -> SDL3::SDL3)
- Update all includes (<SDL.h> -> <SDL3/SDL.h>, etc.)
- Add SDL3/SDL_main.h include to main.cpp
- Rewrite audio subsystem to use SDL3 AudioStream API
- Update window creation (simplified SDL_CreateWindow API)
- Update fullscreen handling (SDL_SetWindowFullscreen now takes bool)
- Update renderer creation (SDL_CreateRenderer signature change)
- Rename SDL_RenderCopy -> SDL_RenderTexture
- Rename SDL_RenderSetLogicalSize -> SDL_SetRenderLogicalPresentation
- Rename SDL_CreateRGBSurface -> SDL_CreateSurface
- Rename SDL_FreeSurface -> SDL_DestroySurface
- Rename SDL_FillRect -> SDL_FillSurfaceRect
- Update SDL_MapRGB to use SDL_PixelFormatDetails
- Update event constants (SDL_KEYDOWN -> SDL_EVENT_KEY_DOWN, etc.)
- Remove SDL_WINDOWEVENT (window events are now top-level)
- Remove SDL_Keysym struct usage (keysym field removed from events)
- Update GameController -> Gamepad API
- Update threading APIs (SDL_CreateCond -> SDL_CreateCondition, etc.)
- Update mutex/condition type names (SDL_mutex -> SDL_Mutex, etc.)
- Replace SDL_ShowCursor(SDL_DISABLE) with SDL_HideCursor()
- Replace SDL_GetTicks64 with SDL_GetTicks (already 64-bit in SDL3)
- Replace SDL_INIT_GAMECONTROLLER with SDL_INIT_GAMEPAD
- Replace Uint32/Uint8 with uint32_t/uint8_t
- Fix utf8ToDOS to accept const char* (SDL3 text events use const)
- Update SDL_StartTextInput to pass window parameter

This resolves #47.