### PR TITLE
Audio improvements

### DIFF
--- a/src/game/common.cpp
+++ b/src/game/common.cpp
@@ -499,6 +499,7 @@ std::string Common::guessName() const {
 
 void SfxSample::createSound() {
   std::vector<int16_t>& samples = sfx_sound_data(sound);
+  samples.clear();
 
   int prev = static_cast<int8_t>(originalData[0]) * 30;
   samples.push_back(prev);

--- a/src/game/sfx.cpp
+++ b/src/game/sfx.cpp
@@ -29,6 +29,10 @@ void Sfx::init()
 	if(initialized)
 		return;
 
+	// Request a small audio buffer for low latency (~5.8ms at 44100Hz).
+	// Must be set before opening the audio device.
+	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, "256");
+
 	SDL_InitSubSystem(SDL_INIT_AUDIO);
 
 	mixer = sfx_mixer_create();


### PR DESCRIPTION
This pull request introduces improvements to the audio system, focusing on reducing audio latency and ensuring proper sound data initialization. The key changes are:

Audio latency reduction:

* Set the SDL audio buffer size to 256 frames by adding a call to `SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, "256")` before initializing the audio subsystem, which helps achieve lower latency (~5.8ms at 44100Hz).

Sound data initialization:

* Clear the `samples` vector at the start of `SfxSample::createSound()` to ensure that old sound data does not persist when generating new sound samples.

Fixes #45.