### PR TITLE
Allow using player controls for navigating menus

### DIFF
--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -40,7 +40,8 @@ bool FileSelectorState::update()
 	}
 
 	if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN)
-	 || gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER))
+	 || gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER)
+	 || gfx->testControlOnce(WormSettingsExtensions::Fire))
 	{
 		sfx.play(*gfx->common, 27);
 

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -554,8 +554,10 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 				if(newState != js.btnState[jbtn])
 				{
 					js.btnState[jbtn] = newState;
+					uint32_t exKey = joyButtonToExKey(ev.jaxis.which, jbtn);
+					exKeys[exKey] = newState;
 					if (controller)
-						controller->onKey(joyButtonToExKey(ev.jaxis.which, jbtn), newState);
+						controller->onKey(exKey, newState);
 				}
 			}
 		}
@@ -577,8 +579,10 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 				if(newState != js.btnState[jbtn])
 				{
 					js.btnState[jbtn] = newState;
+					uint32_t exKey = joyButtonToExKey(ev.jhat.which, jbtn);
+					exKeys[exKey] = newState;
 					if(controller)
-						controller->onKey(joyButtonToExKey(ev.jhat.which, jbtn), newState);
+						controller->onKey(exKey, newState);
 				}
 			}
 		}
@@ -590,8 +594,10 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller)
 			Joystick& js = joysticks[ev.jbutton.which];
 			int jbtn = 16 + ev.jbutton.button;
 			js.btnState[jbtn] = ev.jbutton.down;
+			uint32_t exKey = joyButtonToExKey(ev.jbutton.which, jbtn);
+			exKeys[exKey] = ev.jbutton.down;
 			if(controller)
-				controller->onKey(joyButtonToExKey(ev.jbutton.which, jbtn), js.btnState[jbtn]);
+				controller->onKey(exKey, js.btnState[jbtn]);
 		}
 		break;
 
@@ -631,6 +637,44 @@ std::string Gfx::getKeyName(uint32_t key)
 void Gfx::clearKeys()
 {
 	std::memset(dosKeys, 0, sizeof(dosKeys));
+	exKeys.clear();
+}
+
+bool Gfx::testControlOnce(int control)
+{
+	for(int p = 0; p < 2; ++p)
+	{
+		uint32_t key = settings->extensions
+			? settings->wormSettings[p]->controlsEx[control]
+			: settings->wormSettings[p]->controls[control];
+		if(testAnyKeyOnce(key))
+			return true;
+	}
+	return false;
+}
+
+bool Gfx::testControl(int control)
+{
+	for(int p = 0; p < 2; ++p)
+	{
+		uint32_t key = settings->extensions
+			? settings->wormSettings[p]->controlsEx[control]
+			: settings->wormSettings[p]->controls[control];
+		if(testAnyKey(key))
+			return true;
+	}
+	return false;
+}
+
+void Gfx::releaseControl(int control)
+{
+	for(int p = 0; p < 2; ++p)
+	{
+		uint32_t key = settings->extensions
+			? settings->wormSettings[p]->controlsEx[control]
+			: settings->wormSettings[p]->controls[control];
+		releaseAnyKey(key);
+	}
 }
 
 void Gfx::preparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette, Color realPal[256], uint32_t (&pal32)[256])

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 #include <cassert>
+#include <unordered_map>
 
 #include "state.hpp"
 #include "gfx/font.hpp"
@@ -182,6 +183,49 @@ struct Gfx
 			dosKeys[k] = false;
 	}
 
+	// Test any key (both regular DOS keys and extended joystick keys)
+	bool testAnyKeyOnce(uint32_t key)
+	{
+		if(key == 0) return false;
+		if(key < MaxDOSKey)
+			return testKeyOnce(key);
+		auto it = exKeys.find(key);
+		if(it != exKeys.end() && it->second)
+		{
+			it->second = false;
+			return true;
+		}
+		return false;
+	}
+
+	bool testAnyKey(uint32_t key)
+	{
+		if(key == 0) return false;
+		if(key < MaxDOSKey)
+			return testKey(key);
+		auto it = exKeys.find(key);
+		return it != exKeys.end() && it->second;
+	}
+
+	void releaseAnyKey(uint32_t key)
+	{
+		if(key == 0) return;
+		if(key < MaxDOSKey)
+			dosKeys[key] = false;
+		else
+			exKeys[key] = false;
+	}
+
+	// Test if any player's configured control for a given action was pressed.
+	// Uses controlsEx which covers both keyboard and joystick bindings.
+	bool testControlOnce(int control);
+
+	// Non-destructive version for held keys (left/right repeat)
+	bool testControl(int control);
+
+	// Release a control key for all players
+	void releaseControl(int control);
+
 	std::string getKeyName(uint32_t key);
 	void setSpectatorFullscreen(bool newFullscreen);
 	void setFullscreen(bool newFullscreen);
@@ -256,6 +300,7 @@ struct Gfx
 	std::shared_ptr<Settings> settings;
 
 	bool dosKeys[177];
+	std::unordered_map<uint32_t, bool> exKeys;
 	// the window to render into
 	SDL_Window* sdlWindow = NULL;
 	// the window to render the spectator view into

--- a/src/game/inputState.cpp
+++ b/src/game/inputState.cpp
@@ -216,7 +216,8 @@ void InfoBoxState::handleEvent(SDL_Event& ev)
 {
 	gfx->processEvent(ev);
 
-	if (ev.type == SDL_EVENT_KEY_DOWN)
+	if (ev.type == SDL_EVENT_KEY_DOWN
+	 || ev.type == SDL_EVENT_JOYSTICK_BUTTON_DOWN)
 		done_ = true;
 }
 

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -50,6 +50,8 @@ static void resetLeftRight()
 {
 	gfx.releaseSDLKey(SDL_SCANCODE_LEFT);
 	gfx.releaseSDLKey(SDL_SCANCODE_RIGHT);
+	gfx.releaseControl(WormSettingsExtensions::Left);
+	gfx.releaseControl(WormSettingsExtensions::Right);
 }
 
 MainMenuState::MainMenuState()
@@ -135,7 +137,8 @@ bool MainMenuState::update()
 	// Phase::Active — process input
 	Common& common = *gfx->common;
 
-	if(gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE))
+	if(gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE)
+	|| gfx->testControlOnce(WormSettingsExtensions::Jump))
 	{
 		if(gfx->curMenu == &gfx->mainMenu)
 			gfx->mainMenu.moveToId(MainMenu::MaQuit);
@@ -143,20 +146,23 @@ bool MainMenuState::update()
 			gfx->curMenu = &gfx->mainMenu;
 	}
 
-	if(gfx->testSDLKeyOnce(SDL_SCANCODE_UP))
+	if(gfx->testSDLKeyOnce(SDL_SCANCODE_UP)
+	|| gfx->testControlOnce(WormSettingsExtensions::Up))
 	{
 		sfx.play(common, 26);
 		gfx->curMenu->movement(-1);
 	}
 
-	if(gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN))
+	if(gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN)
+	|| gfx->testControlOnce(WormSettingsExtensions::Down))
 	{
 		sfx.play(common, 25);
 		gfx->curMenu->movement(1);
 	}
 
 	if(gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN)
-	|| gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER))
+	|| gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER)
+	|| gfx->testControlOnce(WormSettingsExtensions::Fire))
 	{
 		if(gfx->curMenu == &gfx->mainMenu)
 		{
@@ -527,12 +533,14 @@ bool MainMenuState::update()
 		}
 	}
 
-	if(gfx->testSDLKey(SDL_SCANCODE_LEFT))
+	if(gfx->testSDLKey(SDL_SCANCODE_LEFT)
+	|| gfx->testControl(WormSettingsExtensions::Left))
 	{
 		if(!gfx->curMenu->onLeftRight(common, -1))
 			resetLeftRight();
 	}
-	if(gfx->testSDLKey(SDL_SCANCODE_RIGHT))
+	if(gfx->testSDLKey(SDL_SCANCODE_RIGHT)
+	|| gfx->testControl(WormSettingsExtensions::Right))
 	{
 		if(!gfx->curMenu->onLeftRight(common, 1))
 			resetLeftRight();

--- a/src/game/menu/fileSelector.hpp
+++ b/src/game/menu/fileSelector.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <utility>
 #include "../text.hpp"
+#include "../worm.hpp"
 #include "menu.hpp"
 #include "../common.hpp"
 
@@ -270,14 +271,16 @@ struct FileSelector
 
 	bool process()
 	{
-		if(gfx.testSDLKeyOnce(SDL_SCANCODE_UP))
+		if(gfx.testSDLKeyOnce(SDL_SCANCODE_UP)
+		|| gfx.testControlOnce(WormSettingsExtensions::Up))
 		{
 			sfx.play(common, 26);
 
 			menu().movement(-1);
 		}
 
-		if(gfx.testSDLKeyOnce(SDL_SCANCODE_DOWN))
+		if(gfx.testSDLKeyOnce(SDL_SCANCODE_DOWN)
+		|| gfx.testControlOnce(WormSettingsExtensions::Down))
 		{
 			sfx.play(common, 25);
 
@@ -298,17 +301,20 @@ struct FileSelector
 			menu().movementPage(1);
 		}
 
-		if (gfx.testSDLKeyOnce(SDL_SCANCODE_ESCAPE))
+		if (gfx.testSDLKeyOnce(SDL_SCANCODE_ESCAPE)
+		|| gfx.testControlOnce(WormSettingsExtensions::Jump))
 		{
 			return false;
 		}
 
-		if (gfx.testSDLKeyOnce(SDL_SCANCODE_LEFT))
+		if (gfx.testSDLKeyOnce(SDL_SCANCODE_LEFT)
+		|| gfx.testControlOnce(WormSettingsExtensions::Left))
 		{
 			exit();
 		}
 
-		if (gfx.testSDLKeyOnce(SDL_SCANCODE_RIGHT))
+		if (gfx.testSDLKeyOnce(SDL_SCANCODE_RIGHT)
+		|| gfx.testControlOnce(WormSettingsExtensions::Right))
 		{
 			enter();
 		}

--- a/src/game/statsState.cpp
+++ b/src/game/statsState.cpp
@@ -302,24 +302,30 @@ void StatsState::handleEvent(SDL_Event& ev)
 
 bool StatsState::update()
 {
-	if (gfx->testSDLKey(SDL_SCANCODE_DOWN))
+	if (gfx->testSDLKey(SDL_SCANCODE_DOWN)
+	|| gfx->testControl(WormSettingsExtensions::Down))
 	{
 		destOffset_ -= 10;
 	}
-	else if (gfx->testSDLKey(SDL_SCANCODE_UP))
+	else if (gfx->testSDLKey(SDL_SCANCODE_UP)
+	|| gfx->testControl(WormSettingsExtensions::Up))
 	{
 		destOffset_ = std::min(destOffset_ + 10.0, 0.0);
 	}
-	else if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT))
+	else if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT)
+	|| gfx->testControlOnce(WormSettingsExtensions::Right))
 	{
 		destPane_ = std::min(destPane_ + 1.0, 1.0);
 	}
-	else if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT))
+	else if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT)
+	|| gfx->testControlOnce(WormSettingsExtensions::Left))
 	{
 		destPane_ = std::max(destPane_ - 1.0, -1.0);
 	}
 	else if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN) ||
-	         gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE))
+	         gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
+	         gfx->testControlOnce(WormSettingsExtensions::Fire) ||
+	         gfx->testControlOnce(WormSettingsExtensions::Jump))
 	{
 		fill(gfx->playRenderer.bmp, 0);
 		gfx->clearKeys();

--- a/src/game/weaponMenuState.cpp
+++ b/src/game/weaponMenuState.cpp
@@ -59,23 +59,27 @@ bool WeaponMenuState::update()
 
 	Common& common = *gfx->common;
 
-	if (gfx->testSDLKeyOnce(SDL_SCANCODE_UP))
+	if (gfx->testSDLKeyOnce(SDL_SCANCODE_UP)
+	|| gfx->testControlOnce(WormSettingsExtensions::Up))
 	{
 		sfx.play(common, 26);
 		weaponMenu_->movement(-1);
 	}
 
-	if (gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN))
+	if (gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN)
+	|| gfx->testControlOnce(WormSettingsExtensions::Down))
 	{
 		sfx.play(common, 25);
 		weaponMenu_->movement(1);
 	}
 
-	if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT))
+	if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT)
+	|| gfx->testControlOnce(WormSettingsExtensions::Left))
 	{
 		weaponMenu_->onLeftRight(common, -1);
 	}
-	if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT))
+	if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT)
+	|| gfx->testControlOnce(WormSettingsExtensions::Right))
 	{
 		weaponMenu_->onLeftRight(common, 1);
 	}
@@ -97,7 +101,8 @@ bool WeaponMenuState::update()
 
 	weaponMenu_->onKeys(gfx->keyBuf, gfx->keyBufPtr);
 
-	if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE))
+	if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE)
+	|| gfx->testControlOnce(WormSettingsExtensions::Jump))
 	{
 		int count = 0;
 


### PR DESCRIPTION
Add support for using configured player 1/player 2 controls (including joystick) to navigate all menu screens. This enables playing on platforms without keyboards.

Control mapping in menus:
- Player Up/Down: navigate menu items
- Player Left/Right: adjust values
- Player Fire: confirm/enter
- Player Jump: back/escape

Implementation:
- Store joystick key states in Gfx::exKeys so they persist for menu polling
- Add testAnyKeyOnce/testAnyKey/releaseAnyKey for unified key testing
- Add testControlOnce/testControl/releaseControl helpers that check both players' configured bindings
- Update all menu states: mainMenuState, weaponMenuState, fileSelectorState, statsState, and the FileSelector component
- InfoBoxState now also dismisses on joystick button press

Closes #11