### PR TITLE
Refresh settings menu after loading a setup from disk

### DIFF
--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -248,6 +248,7 @@ void OptionsSelectorState::enter()
 bool OptionsSelectorState::onSelected(FileNode* node)
 {
 	gfx->loadSettings(node->getFsNode());
+	gfx->settingsMenu.updateItems(*gfx->common);
 	return true;
 }
 


### PR DESCRIPTION
Loading a config via "LOAD SETUP" replaced the Settings object but left the settings menu showing stale cached display strings until an edit triggered a per-item refresh. Mirror the save path by calling updateItems after loadSettings.