### PR TITLE
Fix loop sound

### DIFF
--- a/src/game/mixer/mixer.cpp
+++ b/src/game/mixer/mixer.cpp
@@ -166,7 +166,7 @@ static int find_channel(sfx_mixer* self, void* h)
 
 	for (c = 0; c < CHANNEL_COUNT; )
 	{
-		if (self->channel_states[c].id == h)
+		if (self->channel_states[c].id == h && self->channel_states[c].flags != INACTIVE_FLAGS)
 			return (int)c;
 		++c;
 	}

--- a/src/game/weapon.hpp
+++ b/src/game/weapon.hpp
@@ -66,7 +66,7 @@ struct Weapon
 	/*
 	Loop sound while fire key is pressed and cut off sound as soon as fire key is released. Buggy.
 	*/
-	int loopSound;
+	bool loopSound;
 	/*
 	Sound played when the object explodes. Set -1 for none.
 	*/

--- a/src/game/worm.cpp
+++ b/src/game/worm.cpp
@@ -388,7 +388,7 @@ void Worm::process(Game& game)
 			{
 				fire(game);
 			}
-			else
+			else if(!pressed(Fire) || pressed(Change) || !weapons[currentWeapon].available())
 			{
 				if(weapons[currentWeapon].type->loopSound)
 					game.soundPlayer->stop(&weapons[currentWeapon]);


### PR DESCRIPTION
Two fixes for loopSound:
- it's now a boolean rather than an int, matching its usage
- it now loops sounds correctly.

This seems to fix #41, although it's hard to test since fan and flamer are the only weapons that use the property, and neither of them have any sounds attached.