### PR TITLE
Fix libjuice build failure due to GitHub tarball hash change

### DIFF
--- a/tools/vcpkg/overlay-ports/libjuice/dependencies.diff
+++ b/tools/vcpkg/overlay-ports/libjuice/dependencies.diff
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5712462..dd6c669 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,11 +120,14 @@ if(WIN32)
+ endif()
+
+ if (USE_NETTLE)
+-	find_package(Nettle REQUIRED)
++    find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
++    find_library(NETTLE_LIBRARY_PATH NAMES nettle libnettle NAMES_PER_DIR REQUIRED)
++    target_include_directories(juice PRIVATE ${NETTLE_INCLUDE_PATH})
++    target_include_directories(juice-static PRIVATE ${NETTLE_INCLUDE_PATH})
+     target_compile_definitions(juice PRIVATE USE_NETTLE=1)
+-    target_link_libraries(juice PRIVATE Nettle::Nettle)
++    target_link_libraries(juice PRIVATE ${NETTLE_LIBRARY_PATH})
+     target_compile_definitions(juice-static PRIVATE USE_NETTLE=1)
+-    target_link_libraries(juice-static PRIVATE Nettle::Nettle)
++    target_link_libraries(juice-static PRIVATE ${NETTLE_LIBRARY_PATH})
+ else()
+     target_compile_definitions(juice PRIVATE USE_NETTLE=0)
+     target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
+@@ -137,8 +140,6 @@ endif()
+
+ if(APPLE)
+ 	# This seems to be necessary on MacOS
+-	target_include_directories(juice PRIVATE /usr/local/include)
+-	target_include_directories(juice-static PRIVATE /usr/local/include)
+ endif()
+
+ set_target_properties(juice PROPERTIES EXPORT_NAME LibJuice)
+diff --git a/cmake/LibJuiceConfig.cmake.in b/cmake/LibJuiceConfig.cmake.in
+index 247e53f..f049d9a 100644
+--- a/cmake/LibJuiceConfig.cmake.in
++++ b/cmake/LibJuiceConfig.cmake.in
+@@ -1,4 +1,8 @@
+ @PACKAGE_INIT@
+
++include(CMakeFindDependencyMacro)
++set(THREADS_PREFER_PTHREAD_FLAG ON)
++find_dependency(Threads)
++
+ include("${CMAKE_CURRENT_LIST_DIR}/LibJuiceTargets.cmake")
+

--- a/tools/vcpkg/overlay-ports/libjuice/dependencies.diff
+++ b/tools/vcpkg/overlay-ports/libjuice/dependencies.diff
@@ -4,11 +4,11 @@ index 5712462..dd6c669 100644
 +++ b/CMakeLists.txt
 @@ -120,11 +120,14 @@ if(WIN32)
  endif()
-
+ 
  if (USE_NETTLE)
 -	find_package(Nettle REQUIRED)
 +    find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
-+    find_library(NETTLE_LIBRARY_PATH NAMES nettle libnettle NAMES_PER_DIR REQUIRED)
++    find_library(NETTLE_LIBRARY_PATH NAMES nettle libnettle NAMES_PER_DIR REQUIRED) 
 +    target_include_directories(juice PRIVATE ${NETTLE_INCLUDE_PATH})
 +    target_include_directories(juice-static PRIVATE ${NETTLE_INCLUDE_PATH})
      target_compile_definitions(juice PRIVATE USE_NETTLE=1)
@@ -21,13 +21,13 @@ index 5712462..dd6c669 100644
      target_compile_definitions(juice PRIVATE USE_NETTLE=0)
      target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
 @@ -137,8 +140,6 @@ endif()
-
+ 
  if(APPLE)
  	# This seems to be necessary on MacOS
 -	target_include_directories(juice PRIVATE /usr/local/include)
 -	target_include_directories(juice-static PRIVATE /usr/local/include)
  endif()
-
+ 
  set_target_properties(juice PROPERTIES EXPORT_NAME LibJuice)
 diff --git a/cmake/LibJuiceConfig.cmake.in b/cmake/LibJuiceConfig.cmake.in
 index 247e53f..f049d9a 100644
@@ -35,10 +35,10 @@ index 247e53f..f049d9a 100644
 +++ b/cmake/LibJuiceConfig.cmake.in
 @@ -1,4 +1,8 @@
  @PACKAGE_INIT@
-
+ 
 +include(CMakeFindDependencyMacro)
 +set(THREADS_PREFER_PTHREAD_FLAG ON)
 +find_dependency(Threads)
 +
  include("${CMAKE_CURRENT_LIST_DIR}/LibJuiceTargets.cmake")
-
+ 

--- a/tools/vcpkg/overlay-ports/libjuice/portfile.cmake
+++ b/tools/vcpkg/overlay-ports/libjuice/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO paullouisageneau/libjuice
+    REF "v${VERSION}"
+    SHA512 93c4581e3b3f73221267b245f1db5cddbdcf46ccb17168a7e01d16ac1f4658739a56274c2e177b45c6e873a05dbdc7dd45edd20bf2908e7b3d7cb1ea154fdb8d
+    HEAD_REF master
+    PATCHES
+        dependencies.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        nettle USE_NETTLE
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DNO_TESTS=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/LibJuice)
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/juice/juice.h" "#ifndef JUICE_STATIC" "#if 0")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/tools/vcpkg/overlay-ports/libjuice/vcpkg.json
+++ b/tools/vcpkg/overlay-ports/libjuice/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "libjuice",
+  "version": "1.7.1",
+  "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
+  "homepage": "https://github.com/paullouisageneau/libjuice",
+  "license": "LGPL-2.1-only",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "nettle": {
+      "description": "Use nettle for HMAC computation instead of the Builtin",
+      "dependencies": [
+        "nettle"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- GitHub regenerated the `libjuice` v1.7.1 release tarball after the vcpkg registry portfile was written, causing a SHA512 hash mismatch and a CI build failure
- Adds an overlay port for `libjuice` under `tools/vcpkg/overlay-ports/libjuice/` with the corrected hash (`93c4581e...`)
- The overlay port is otherwise identical to the upstream vcpkg registry port at the pinned baseline — same version, same patch, same build options

## Test plan

- [ ] CI build passes for all platforms (linux, windows, macos, emscripten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)