### PR TITLE
Fix player profile loading after serialization refactor

### DIFF
--- a/data/Profiles/AI (L).toml
+++ b/data/Profiles/AI (L).toml
@@ -1,11 +1,13 @@
-
 name = "AI Joe"
-controller = 2
 health = 100
-controls = [17, 31, 30, 32, 20, 21, 22, 0]
-weapons = [19, 31, 40, 29, 36]
-color = [20, 20, 40]
+controller = 2
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [20, 20, 40]
+weapons = [19, 31, 40, 29, 36]
+controls = [17, 31, 30, 32, 20, 21, 22]
+controlsEx = [17, 31, 30, 32, 20, 21, 22, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/AI (R).toml
+++ b/data/Profiles/AI (R).toml
@@ -1,11 +1,13 @@
-
 name = "AI Jane"
-controller = 2
 health = 100
-controls = [160, 168, 163, 165, 79, 80, 81, 0]
-weapons = [19, 31, 9, 29, 36]
-color = [20, 20, 40]
+controller = 2
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [20, 20, 40]
+weapons = [19, 31, 9, 29, 36]
+controls = [160, 168, 163, 165, 79, 80, 81]
+controlsEx = [160, 168, 163, 165, 79, 80, 81, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Joystick0.toml
+++ b/data/Profiles/Joystick0.toml
@@ -1,11 +1,13 @@
-
 name = "chucky"
-controller = 0
 health = 100
-controls = [19, 33, 32, 34, 29, 42, 56, 0]
-weapons = [1, 1, 1, 1, 1]
-color = [26, 26, 63]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 1
 gamepadName = ""
 gamepadSerial = ""
+rgb = [26, 26, 63]
+weapons = [1, 1, 1, 1, 1]
+controls = [19, 33, 32, 34, 29, 42, 56]
+controlsEx = [19, 33, 32, 34, 29, 42, 56, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Joystick1.toml
+++ b/data/Profiles/Joystick1.toml
@@ -1,11 +1,13 @@
-
 name = "chucky"
-controller = 0
 health = 100
-controls = [160, 33, 32, 34, 29, 42, 56, 0]
-weapons = [1, 1, 1, 1, 1]
-color = [26, 26, 63]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 1
 gamepadName = ""
 gamepadSerial = ""
+rgb = [26, 26, 63]
+weapons = [1, 1, 1, 1, 1]
+controls = [160, 33, 32, 34, 29, 42, 56]
+controlsEx = [160, 33, 32, 34, 29, 42, 56, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Lefty (L).toml
+++ b/data/Profiles/Lefty (L).toml
@@ -1,11 +1,13 @@
-
 name = "etc"
-controller = 0
 health = 100
-controls = [17, 31, 30, 32, 21, 22, 23, 0]
-weapons = [19, 36, 9, 40, 31]
-color = [40, 10, 55]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [40, 10, 55]
+weapons = [19, 36, 9, 40, 31]
+controls = [17, 31, 30, 32, 21, 22, 23]
+controlsEx = [17, 31, 30, 32, 21, 22, 23, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Lefty (R).toml
+++ b/data/Profiles/Lefty (R).toml
@@ -1,11 +1,13 @@
-
 name = "etc"
-controller = 0
 health = 100
-controls = [160, 168, 163, 165, 79, 80, 81, 0]
-weapons = [19, 36, 9, 40, 31]
-color = [40, 10, 55]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [40, 10, 55]
+weapons = [19, 36, 9, 40, 31]
+controls = [160, 168, 163, 165, 79, 80, 81]
+controlsEx = [160, 168, 163, 165, 79, 80, 81, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Righty (L).toml
+++ b/data/Profiles/Righty (L).toml
@@ -1,11 +1,13 @@
-
 name = "poukah"
-controller = 0
 health = 100
-controls = [21, 35, 34, 36, 30, 31, 32, 0]
-weapons = [19, 36, 29, 9, 31]
-color = [4, 8, 32]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [4, 8, 32]
+weapons = [19, 36, 29, 9, 31]
+controls = [21, 35, 34, 36, 30, 31, 32]
+controlsEx = [21, 35, 34, 36, 30, 31, 32, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/data/Profiles/Righty (R).toml
+++ b/data/Profiles/Righty (R).toml
@@ -1,11 +1,13 @@
-
 name = "poukah"
-controller = 0
 health = 100
-controls = [76, 80, 79, 81, 163, 168, 165, 0]
-weapons = [19, 36, 28, 9, 31]
-color = [4, 8, 32]
+controller = 0
+randomName = false
+color = 0
 inputDevice = 0
 gamepadName = ""
 gamepadSerial = ""
+rgb = [4, 8, 32]
+weapons = [19, 36, 28, 9, 31]
+controls = [76, 80, 79, 81, 163, 168, 165]
+controlsEx = [76, 80, 79, 81, 163, 168, 165, 0]
 gamepadControls = [11, 12, 13, 14, 110, 10, 0, 9]

--- a/src/game/worm.cpp
+++ b/src/game/worm.cpp
@@ -49,7 +49,7 @@ std::string WormSettings::toToml() const
 	std::ostringstream ss;
 	{
 		cereal::TomlOutputArchive ar(ss);
-		ar(cereal::make_nvp("ws", const_cast<WormSettings&>(*this)));
+		serializeWormSettingsToml(ar, const_cast<WormSettings&>(*this));
 	}
 	return ss.str();
 }
@@ -58,7 +58,7 @@ void WormSettings::fromToml(std::string const& data)
 {
 	std::istringstream ss(data);
 	cereal::TomlInputArchive ar(ss);
-	ar(cereal::make_nvp("ws", *this));
+	serializeWormSettingsToml(ar, *this);
 }
 
 void WormSettings::saveProfile(FsNode node)


### PR DESCRIPTION
## Summary
- `WormSettings::toToml/fromToml` were wrapping the payload in a `[ws]` table and dispatching to the generic indexed-key serializer (`control0`, `rgb0`, ...), while the bundled profiles in `data/Profiles/*.toml` were still in the original top-level array format (`controls = [...]`, `color = [r,g,b]`). `loadProfile` silently parsed nothing and left every field at its default, so no bundled profile would actually load.
- Switch `toToml/fromToml` to `serializeWormSettingsToml` — the same path `Settings` already uses for its embedded worm settings — and regenerate the bundled profiles in the new schema (split legacy `controls` into `controls`/`controlsEx`, rename `color`→`rgb`, persist `randomName`).

Regression introduced in #74 (the gvl/serialization refactor).

## Test plan
- [x] `test_settings` passes (`WormSettings profile round-trip`, `WormSettings toToml/fromToml round-trip`, `Settings toToml/fromToml round-trip`)
- [x] `test_cereal_types` passes
- [x] All 8 regenerated `data/Profiles/*.toml` parse and have expected key set + array sizes (rgb=3, controls=7, controlsEx=8, weapons=5, gamepadControls=8)
- [x] Manual: load each bundled profile in-game and confirm name, controls, and colors come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)