### PR TITLE
Clang flag-day PR2: adopt Google naming, rename tree

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,9 +4,6 @@
 # game engine port (C arrays, pointer arithmetic, magic tuning numbers).
 #
 # Disabled categories — and why:
-# * readability-identifier-naming: the original Liero codebase is
-#   camelCase / mixedCase; the check has no rules configured here so it
-#   is silent, but listed explicitly for clarity.
 # * readability-identifier-length: math/graphics code uses x, y, dx, i.
 # * readability-magic-numbers / cppcoreguidelines-avoid-magic-numbers:
 #   game tuning constants are everywhere; extracting them gains no real
@@ -44,7 +41,6 @@ Checks: "*,\
   -llvmlibc-*,\
   -modernize-use-nodiscard,\
   -misc-non-private-member-variables-in-classes,\
-  -readability-identifier-naming,\
   -readability-identifier-length,\
   -readability-magic-numbers,\
   -readability-braces-around-statements,\
@@ -121,4 +117,46 @@ CheckOptions:
     value: 'true'
   - key: 'readability-redundant-access-specifiers.CheckFirstDeclaration'
     value: 'true'
+# Identifier naming: Google C++ Style. Cereal ADL hooks (serialize,
+# save, load, save_minimal, load_minimal) are carved out by regex —
+# they are looked up by name via ADL, so renaming them would silently
+# break serialization. The on-disk format uses explicit string literals
+# in `cereal::make_nvp(...)`, so renaming the C++ fields does not
+# change the save/snapshot format.
+  - key: 'readability-identifier-naming.ClassCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.StructCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.EnumCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.FunctionCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.MethodCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.VariableCase'
+    value: 'lower_case'
+  - key: 'readability-identifier-naming.ParameterCase'
+    value: 'lower_case'
+  - key: 'readability-identifier-naming.MemberCase'
+    value: 'lower_case'
+  - key: 'readability-identifier-naming.PrivateMemberSuffix'
+    value: '_'
+  - key: 'readability-identifier-naming.ProtectedMemberSuffix'
+    value: '_'
+  - key: 'readability-identifier-naming.ConstantCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.ConstantPrefix'
+    value: 'k'
+  - key: 'readability-identifier-naming.EnumConstantCase'
+    value: 'CamelCase'
+  - key: 'readability-identifier-naming.EnumConstantPrefix'
+    value: 'k'
+  - key: 'readability-identifier-naming.MacroDefinitionCase'
+    value: 'UPPER_CASE'
+  - key: 'readability-identifier-naming.NamespaceCase'
+    value: 'lower_case'
+  - key: 'readability-identifier-naming.MethodIgnoredRegexp'
+    value: '^(serialize|save|load|save_minimal|load_minimal)$'
+  - key: 'readability-identifier-naming.FunctionIgnoredRegexp'
+    value: '^(serialize|save|load|save_minimal|load_minimal)$'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -156,7 +156,7 @@ CheckOptions:
   - key: 'readability-identifier-naming.NamespaceCase'
     value: 'lower_case'
   - key: 'readability-identifier-naming.MethodIgnoredRegexp'
-    value: '^(serialize|save|load|save_minimal|load_minimal)$'
+    value: '^(serialize|save|load|save_minimal|load_minimal|setNextName|startNode|finishNode|saveValue|loadValue|saveBinaryValue|loadBinaryValue|sizeTag)$'
   - key: 'readability-identifier-naming.FunctionIgnoredRegexp'
-    value: '^(serialize|save|load|save_minimal|load_minimal)$'
+    value: '^(serialize|save|load|save_minimal|load_minimal|prologue|epilogue)$'
 ...

--- a/docs/clang-flag-day.md
+++ b/docs/clang-flag-day.md
@@ -99,11 +99,15 @@ CheckOptions:
   - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }
   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
   # Cereal ADL hooks must keep their lowercase names — they are looked
-  # up by name via ADL, so renaming silently breaks serialization.
+  # up by name, so renaming silently breaks serialization. The set
+  # below was extended during PR2: cereal also calls back into user
+  # archives via setNextName/startNode/finishNode/saveValue/loadValue/
+  # saveBinaryValue/loadBinaryValue/sizeTag, and the free-function
+  # hooks prologue/epilogue via ADL.
   - { key: readability-identifier-naming.MethodIgnoredRegexp,
-      value: '^(serialize|save|load|save_minimal|load_minimal)$' }
+      value: '^(serialize|save|load|save_minimal|load_minimal|setNextName|startNode|finishNode|saveValue|loadValue|saveBinaryValue|loadBinaryValue|sizeTag)$' }
   - { key: readability-identifier-naming.FunctionIgnoredRegexp,
-      value: '^(serialize|save|load|save_minimal|load_minimal)$' }
+      value: '^(serialize|save|load|save_minimal|load_minimal|prologue|epilogue)$' }
 ```
 
 ### What's safe
@@ -246,47 +250,191 @@ in templates.
   renamed consistently — virtual dispatch is name-based, so a
   half-rename silently breaks polymorphism.
 
+### Lessons from PR2 — apply to PR3
+
+These are things the plan didn't anticipate; PR3 will hit the same
+patterns at greater volume because it runs the full check set, not
+just naming.
+
+1. **Use `run-clang-tidy`, not raw `xargs`.** Parallel `xargs -P N -n1
+   clang-tidy --fix` races on shared header rewrites: multiple TUs
+   apply conflicting edits to the same header and the last writer
+   wins. `run-clang-tidy` exports per-file fix YAML and applies them
+   in one serialized pass via `clang-apply-replacements`. Standard
+   invocation:
+   ```bash
+   run-clang-tidy -p build/linux-x64-ci \
+       -header-filter='.*/src/.*' \
+       -fix -j "$(nproc)" -quiet \
+       '/src/.*\.(cpp|cc|cxx)$'
+   ```
+   Iterate until two consecutive runs produce no diff.
+
+2. **Per-preset blind spots.** `compile_commands.json` only contains
+   TUs that the configured preset compiles. linux-x64-ci with default
+   options misses, at minimum:
+   - `#if OPENLIERO_EMSCRIPTEN` blocks (gfx.cpp's main loop, gameEntry)
+   - `#if _WIN32` / `#ifdef _WIN32` blocks (filesystem.cpp's
+     Windows directory iteration, iceBridge.hpp's `kBridgeInvalid`)
+   - `src/video_tool/` (gated on `OPENLIERO_BUILD_VIDEOTOOL=ON`)
+   - `src/tc_tool/` (gated on `OPENLIERO_BUILD_TCTOOL=ON`)
+
+   Mitigation for PR3:
+   - Configure with both tool flags: `cmake --preset linux-x64-ci
+     -DOPENLIERO_BUILD_TESTS=ON -DOPENLIERO_BUILD_VIDEOTOOL=ON
+     -DOPENLIERO_BUILD_TCTOOL=ON`.
+   - Accept that Windows and Emscripten branches will only surface in
+     CI. Plan for a fix-loop after the initial PR push: each platform
+     CI failure is followed by a hand-fix commit. PR2 needed four
+     such commits (emscripten, then Windows three times).
+
+3. **Windows API macro collisions.** `windows.h` `#define`s many
+   identifiers (`FindFirstFile` → `FindFirstFileA`, `DrawText` →
+   `DrawTextA`, `MessageBox`, `CreateWindow`, `LoadImage`,
+   `CopyFile`/`MoveFile`/`DeleteFile`, `GetMessage`, `SendMessage`,
+   `Polygon`, `Rectangle`, etc.). If user code declares an identifier
+   that matches one of these macros, every callsite gets
+   preprocessor-rewritten on Windows. PR2 hit this with the
+   `FindFirstFile`/`FindClose`/`FindNextFile` local wrappers in
+   filesystem.cpp and with `Font::DrawText` (4 overloads, 76
+   callsites). PR3's `modernize-*` checks are unlikely to introduce
+   new collisions, but `readability-*` renames could; grep before
+   merging:
+   ```bash
+   grep -rn -E '\b(FindFirstFile|FindNextFile|DrawText|MessageBox|CreateWindow|LoadImage|CopyFile|MoveFile|DeleteFile|GetMessage|SendMessage|Polygon|Rectangle|Ellipse|GetObject|Yield|GetCurrentTime|GetTickCount)\b' src/
+   ```
+
+4. **`bugprone-reserved-identifier` strips leading underscores.** This
+   check is enabled (it's in the `*` set). It rewrites
+   `_USE_MATH_DEFINES` to `USE_MATH_DEFINES` — but `_USE_MATH_DEFINES`
+   is the exact spelling MSVC's `<cmath>` looks for to expose `M_PI`.
+   Similar hazards: `_ENetHost`/`_ENetPeer` forward declarations
+   (struct tag identity with enet.h's typedef), `_WIN32` (compiler
+   builtin, not affected). After PR3's tree-wide run, grep for
+   stripped underscores in macro `#define`s and struct forward decls;
+   add `// NOLINT(bugprone-reserved-identifier,
+   readability-identifier-naming)` for the load-bearing ones.
+
+5. **Method/type name collisions surface as `[-Wchanges-meaning]`.**
+   If a rename produces `Type Method()` where `Type` is also a class,
+   enum, or typedef in the same scope, the compiler reports
+   "declaration of `Type Foo::Method() const` changes meaning of
+   `Type`". PR2 hand-fixed roughly a dozen of these (SessionState,
+   IceAgent::State, Level::Rect, FileSelector::Menu,
+   RollbackController::GameState, NetTransport::State,
+   SoundPlayer::Common, …). PR3's modernize/bugprone passes shouldn't
+   create new collisions, but if any auto-rename does, the fix is
+   manual: pick a different method name and update callers.
+
+6. **X-macro NOLINT region is already in place.** `constants.hpp`
+   wraps the `LIERO_CDEFS` / `LIERO_SDEFS` / `LIERO_HDEFS` /
+   `LIERO_SOUNDDEFS` block in `NOLINTBEGIN(readability-identifier-naming)`
+   /`NOLINTEND` because tidy's check rewrites the token-paste
+   arguments and silently breaks every callsite. PR3 should leave
+   this region alone — but be aware that other tidy checks may still
+   fire inside it.
+
+7. **Range-for / cereal carve-outs.** `DirectoryListing::begin/end`
+   must stay lower_case for range-for to find them (already NOLINT'd).
+   The cereal carve-out regex in `.clang-tidy` covers all known cases
+   PR2 surfaced — see the config snippet above.
+
 ### PR 3 — Remaining tidy fixes
 
 **Scope:** everything else the existing `.clang-tidy` enables —
 modernize-*, bugprone-*, performance-*, readability-* (minus the
-naming check already in PR2).
+naming check already landed in PR2).
 
-1. Run clang-tidy with `--fix --fix-errors` and the full check list:
+1. Configure with all targets enabled so tidy sees `src/video_tool/`
+   and `src/tc_tool/`:
    ```bash
-   find src -type f \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
-     ! -path 'src/game/metadata.cpp' \
-     | xargs -P "$(nproc)" -n1 clang-tidy -p build/linux-x64-ci \
-       --fix --fix-errors
+   CI=true cmake --preset linux-x64-ci \
+       -DOPENLIERO_BUILD_TESTS=ON \
+       -DOPENLIERO_BUILD_VIDEOTOOL=ON \
+       -DOPENLIERO_BUILD_TCTOOL=ON
+   cmake --build build/linux-x64-ci --config Release --target game
    ```
-2. Many checks have no auto-fix. For those, decide per-warning:
+   (The `CI=true` env is required by the `linux-x64-ci` preset's
+   condition guard.)
+
+2. Run `run-clang-tidy` with the full check list (no `-checks=` ⇒
+   uses `.clang-tidy`'s configured set):
+   ```bash
+   run-clang-tidy -p build/linux-x64-ci \
+       -header-filter='.*/src/.*' \
+       -fix -j "$(nproc)" -quiet \
+       '/src/.*\.(cpp|cc|cxx)$'
+   ```
+   Run iteratively — modernize fixes can unlock further fixes on the
+   next pass. Stop when two consecutive runs produce no diff.
+
+3. Many checks have no auto-fix. For those, decide per-warning:
    either fix by hand or apply `// NOLINT(check-name): rationale` at
    the call site. Avoid file-wide `NOLINTBEGIN/END` unless an entire
    file is genuinely incompatible.
-3. Re-enable clang-tidy CI (PR1 paused it to `workflow_dispatch`)
-   and flip it to tree-wide:
+
+4. Apply NOLINTs for the `bugprone-reserved-identifier` hazards
+   (lesson 4 above) — at least:
+   - `_USE_MATH_DEFINES` in `src/game/ai/predictive_ai.cpp` (already
+     done in PR2)
+   - `_ENetHost`/`_ENetPeer` forward declarations if tidy rewrites
+     them
+
+5. Format pass after the renames settle (modernize-loop-convert and
+   similar checks shift line lengths):
+   ```bash
+   scripts/clang-format-all.sh
+   ```
+   then reformat any files it flags.
+
+6. **Critical verification** — same protocol as PR2, but `modernize-*`
+   checks can change iteration patterns in subtle ways that may
+   affect determinism:
+   - All three local presets (linux-x64, linux-x64-debug,
+     linux-x64-ci) build clean
+   - `ctest --test-dir build/linux-x64-ci --build-config Release`
+     all-green
+   - `test_determinism`, `test_rollback_correctness`,
+     `test_rollback_desync` pass standalone
+   - Replay corpus from before the flag day still plays back (run
+     the `videotool` binary against a known-good `.lrp` file)
+
+7. Re-enable clang-tidy CI and flip it to tree-wide blocking:
    - Restore the `pull_request` trigger in
-     `.github/workflows/clang-tidy.yml`.
+     `.github/workflows/clang-tidy.yml` (it's currently
+     `workflow_dispatch` only).
    - Add `scripts/clang-tidy-all.sh` that runs tidy across all `src/`
      files via the existing `compile_commands.json`.
    - Update `.github/workflows/clang-tidy.yml` to call the new
      script instead of `clang-tidy-diff.sh`.
-4. Add PR3 merge commit SHA to `.git-blame-ignore-revs`.
-5. **Critical verification** (same protocol as PR2) — some `modernize-*`
-   checks change iteration patterns and can subtly affect determinism.
+   - Make sure CI configures with `-DOPENLIERO_BUILD_VIDEOTOOL=ON
+     -DOPENLIERO_BUILD_TCTOOL=ON` so the gate covers the same TUs
+     tidy was run against locally.
 
-**Expected diff:** smaller than PR1/PR2 but more semantic. This is the
-PR that needs the most careful human review per-change.
+8. Expect platform CI to fail on the first push for code paths
+   linux-x64-ci doesn't compile (emscripten + Windows). Fix-loop
+   them as PR2 did — each platform CI failure produces one
+   hand-fix commit. macOS-arm64 was clean in PR2 but should still
+   be watched in PR3.
+
+9. Add PR3 merge commit SHA to `.git-blame-ignore-revs`.
+
+**Expected diff:** smaller than PR1/PR2 but more semantic. This is
+the PR that needs the most careful human review per-change.
 
 ## Verification protocol
 
 Run after PR1 (sanity), and **always** after PR2 and PR3:
 
 ```bash
-# 1. Clean build, all relevant configurations
+# 1. Clean build, all relevant configurations.
+#    linux-x64-ci's condition guard requires CI=true in the env.
 cmake --workflow --preset linux-x64
 cmake --workflow --preset linux-x64-debug
-cmake --preset linux-x64-ci -DOPENLIERO_BUILD_TESTS=ON
+CI=true cmake --preset linux-x64-ci \
+    -DOPENLIERO_BUILD_TESTS=ON \
+    -DOPENLIERO_BUILD_VIDEOTOOL=ON \
+    -DOPENLIERO_BUILD_TCTOOL=ON
 cmake --build build/linux-x64-ci --config Release
 
 # 2. Full test suite
@@ -316,24 +464,29 @@ out of a real regression.
 
 | Risk | Likelihood | Mitigation |
 |------|-----------|------------|
-| Cereal `serialize`/`save`/`load` accidentally renamed | Medium | Carve-out regex in `.clang-tidy`; post-PR2 grep to confirm. |
+| Cereal `serialize`/`save`/`load` accidentally renamed | Medium | Carve-out regex in `.clang-tidy` (broadened during PR2 to also cover archive interface methods + prologue/epilogue); post-PR grep to confirm. |
 | Modernize loops change iteration order → determinism break | Medium | `test_determinism` + `test_rollback_*` in verification. Revert offending check or NOLINT the call site. |
-| Tidy `--fix` corrupts a TU via cross-TU rename race | Low | Run tidy passes iteratively, rebuild between passes, commit between passes so any corruption is bisectable. |
-| Macros with stringified identifiers break | Low | None visible in current grep, but check after PR2. |
+| Tidy `--fix` corrupts a TU via cross-TU rename race | **Was Low, now mitigated** | Use `run-clang-tidy` not raw xargs. PR3 inherits this. |
+| Macros with stringified identifiers break | Low | None surfaced in PR2; remain vigilant for `CEREAL_NVP(x)` sneaking in. |
+| Windows API macro collision (`DrawText` → `DrawTextA`) | **Materialized in PR2** | Grep for known Windows macro names before merging (see PR3 lesson 3). |
+| `bugprone-reserved-identifier` strips load-bearing leading underscores (`_USE_MATH_DEFINES`, `_ENetHost`) | **Materialized in PR2** | NOLINT the affected lines; PR3 should grep `#define` / `struct` forward decls for stripped underscores. |
+| Per-preset blind spots (emscripten + `_WIN32` + tool gates not in linux-x64-ci) | **Materialized 4× in PR2** | Configure with VIDEOTOOL/TCTOOL ON; expect a fix-loop on first CI run for emscripten + Windows. |
 | Long format-day window blocks contributors | High | Land all three PRs within ~3 days. Pre-merge sweep of open PRs. |
 | Reviewer fatigue on huge diffs | High | Three PRs not one. Reviewer's job is "did the tool do the right thing" + verification, not line-by-line. |
 
 ## Post-flag-day cleanup
 
-1. Update `CLAUDE.md`:
-   - Remove "hard tabs at width 4 under `src/game`, `src/tc_tool`,
-     `src/video_tool`. `src/tests/` is 2-space Google-style".
-   - Replace with "Google style, 100-col, naming enforced. One style
-     across all of `src/`."
-   - Remove the reference to `src/tests/.clang-format`.
+PR1 already updated `CLAUDE.md`'s style description and removed
+`src/tests/.clang-format`. PR2 did not need to touch `CLAUDE.md`
+further. After PR3 lands:
+
+1. Update `CLAUDE.md`'s note that "`clang-tidy` CI is temporarily
+   disabled during the clang flag-day window" — remove that line and
+   replace with the new tree-wide gating story.
 2. Confirm `clang-tidy` / `clang-format` CMake targets still work
    tree-wide.
-3. Drop the legacy "clang-format is advisory" comment in the workflow.
+3. Drop the legacy "clang-format is advisory" comment in the workflow
+   (if any remains).
 4. Tag `post-clang-flag-day` so the cutover is easy to reference
    later.
 
@@ -341,8 +494,10 @@ out of a real regression.
 
 - **Server (`server/`)** — Go code, governed by `gofmt`, out of scope
   for this plan.
-- **Emscripten preset** — assumed to follow whatever the Linux-x64
-  build does. If wasm-specific code paths break, address case-by-case.
+- **Emscripten preset** — wasm-specific code paths inside
+  `#if OPENLIERO_EMSCRIPTEN` are invisible to tidy on the linux-x64-ci
+  preset. PR2 fixed them post-hoc via the Emscripten CI failure; PR3
+  should plan for the same fix-loop.
 - **External contributor PRs** — anyone with an in-flight branch will
   have to rebase across all three commits. Communicate the flag day
   via README and any active discussion channels before starting.

--- a/src/game/ai/dijkstra.cpp
+++ b/src/game/ai/dijkstra.cpp
@@ -1,11 +1,11 @@
 #include "dijkstra.hpp"
 
-int const level_cell_offsets[8] = {-1 * dijkstra_level::pitch + 0, 1 * dijkstra_level::pitch + 0,
-                                   0 * dijkstra_level::pitch - 1,  0 * dijkstra_level::pitch + 1,
+int const kLevelCellOffsets[8] = {-1 * DijkstraLevel::kPitch + 0, 1 * DijkstraLevel::kPitch + 0,
+                                   0 * DijkstraLevel::kPitch - 1,  0 * DijkstraLevel::kPitch + 1,
 
-                                   -1 * dijkstra_level::pitch - 1, -1 * dijkstra_level::pitch + 1,
-                                   1 * dijkstra_level::pitch - 1,  1 * dijkstra_level::pitch + 1};
+                                   -1 * DijkstraLevel::kPitch - 1, -1 * DijkstraLevel::kPitch + 1,
+                                   1 * DijkstraLevel::kPitch - 1,  1 * DijkstraLevel::kPitch + 1};
 
-int const level_cell_costs[8] = {256, 256, 256, 256,
+int const kLevelCellCosts[8] = {256, 256, 256, 256,
 
                                  362, 362, 362, 362};

--- a/src/game/ai/dijkstra.cpp
+++ b/src/game/ai/dijkstra.cpp
@@ -1,11 +1,11 @@
 #include "dijkstra.hpp"
 
 int const kLevelCellOffsets[8] = {-1 * DijkstraLevel::kPitch + 0, 1 * DijkstraLevel::kPitch + 0,
-                                   0 * DijkstraLevel::kPitch - 1,  0 * DijkstraLevel::kPitch + 1,
+                                  0 * DijkstraLevel::kPitch - 1,  0 * DijkstraLevel::kPitch + 1,
 
-                                   -1 * DijkstraLevel::kPitch - 1, -1 * DijkstraLevel::kPitch + 1,
-                                   1 * DijkstraLevel::kPitch - 1,  1 * DijkstraLevel::kPitch + 1};
+                                  -1 * DijkstraLevel::kPitch - 1, -1 * DijkstraLevel::kPitch + 1,
+                                  1 * DijkstraLevel::kPitch - 1,  1 * DijkstraLevel::kPitch + 1};
 
 int const kLevelCellCosts[8] = {256, 256, 256, 256,
 
-                                 362, 362, 362, 362};
+                                362, 362, 362, 362};

--- a/src/game/ai/dijkstra.hpp
+++ b/src/game/ai/dijkstra.hpp
@@ -9,24 +9,24 @@
 #include "../common.hpp"
 #include "../level.hpp"
 
-struct path_node {
-  enum { none, open, closed };
+struct PathNode {
+  enum { kNone, kOpen, kClosed };
 
-  path_node() : parent(0), state(none), g(0) {}
+  PathNode() : parent(0), state(kNone), g(0) {}
 
-  void reset() {
-    state = none;
+  void Reset() {
+    state = kNone;
     parent = 0;
   }
 
-  path_node* parent;
+  PathNode* parent;
   int state;
   int g;
 };
 
 template <typename NodeT, typename DerivedT>
-struct dijkstra_state {
-  typedef path_node path_node_t;
+struct DijkstraState {
+  typedef PathNode path_node_t;
 
   // Lazy-deletion min-heap. When a node's cost is lowered, we push a new
   // entry; the stale entry remains in the heap and is skipped at pop time
@@ -40,28 +40,28 @@ struct dijkstra_state {
   };
   std::priority_queue<Entry, std::vector<Entry>, EntryGreater> open_list;
 
-  bool open_empty() const { return open_list.empty(); }
+  bool OpenEmpty() const { return open_list.empty(); }
 
-  void add_open(path_node_t* node) {
+  void AddOpen(path_node_t* node) {
     open_list.push({node->g, node});
-    node->state = path_node_t::open;
+    node->state = path_node_t::kOpen;
   }
 
-  void reset() {
+  void Reset() {
     while (!open_list.empty()) open_list.pop();
   }
 
-  void set_origin(NodeT origin_init) {
+  void SetOrigin(NodeT origin_init) {
     DerivedT& derived = static_cast<DerivedT&>(*this);
 
-    path_node_t* origin_pn = derived.get_node(origin_init);
+    path_node_t* origin_pn = derived.GetNode(origin_init);
     origin_pn->g = 0;
     origin_pn->parent = 0;
-    add_open(origin_pn);
+    AddOpen(origin_pn);
   }
 
   template <typename StopPred, typename SuccessorIter>
-  bool run(StopPred stop, SuccessorIter succ_iter) {
+  bool Run(StopPred stop, SuccessorIter succ_iter) {
     DerivedT& derived = static_cast<DerivedT&>(*this);
 
     while (!open_list.empty() && !stop()) {
@@ -69,25 +69,25 @@ struct dijkstra_state {
       open_list.pop();
 
       // Skip stale entries from prior decreased_key operations.
-      if (e.node->state == path_node_t::closed) continue;
+      if (e.node->state == path_node_t::kClosed) continue;
       if (e.g != e.node->g) continue;
 
       path_node_t* min_pn = e.node;
-      NodeT min = derived.get_node_id(min_pn);
+      NodeT min = derived.GetNodeId(min_pn);
 
-      min_pn->state = path_node_t::closed;
+      min_pn->state = path_node_t::kClosed;
 
-      succ_iter.begin(min);
+      succ_iter.Begin(min);
 
-      while (succ_iter.advance()) {
-        NodeT node = succ_iter.node();
-        path_node_t* pn = derived.get_node(node);
-        if (pn->state != path_node_t::closed) {
-          int g = min_pn->g + succ_iter.cost();
-          if (pn->state != path_node_t::open) {
+      while (succ_iter.Advance()) {
+        NodeT node = succ_iter.Node();
+        path_node_t* pn = derived.GetNode(node);
+        if (pn->state != path_node_t::kClosed) {
+          int g = min_pn->g + succ_iter.Cost();
+          if (pn->state != path_node_t::kOpen) {
             pn->g = g;
             pn->parent = min_pn;
-            add_open(pn);
+            AddOpen(pn);
           } else if (g < pn->g) {
             pn->g = g;
             pn->parent = min_pn;
@@ -102,105 +102,105 @@ struct dijkstra_state {
   }
 };
 
-struct level_cell : path_node {
+struct LevelCell : PathNode {
   int cost;  // 1 = air, 2 = dirt, -1 = rock
 };
 
-extern int const level_cell_offsets[8];
-extern int const level_cell_costs[8];
+extern int const kLevelCellOffsets[8];
+extern int const kLevelCellCosts[8];
 
-struct level_cell_succ {
-  void begin(level_cell* c) {
+struct LevelCellSucc {
+  void Begin(LevelCell* c) {
     i = -1;
     this->c = c;
   }
 
-  bool advance() {
+  bool Advance() {
     do {
       ++i;
       if (i >= 8) return false;
-    } while (cost() < 0);
+    } while (Cost() < 0);
 
     return true;
   }
 
-  level_cell* node() { return &c[level_cell_offsets[i]]; }
+  LevelCell* Node() { return &c[kLevelCellOffsets[i]]; }
 
-  int cost() {
-    level_cell* n = c + level_cell_offsets[i];
-    return level_cell_costs[i] * n->cost;
+  int Cost() {
+    LevelCell* n = c + kLevelCellOffsets[i];
+    return kLevelCellCosts[i] * n->cost;
   }
 
-  level_cell* c;
-  level_cell* target;
+  LevelCell* c;
+  LevelCell* target;
   int i;
 };
 
-struct dijkstra_level : dijkstra_state<level_cell*, dijkstra_level> {
-  static int const full_width = 504;
-  static int const full_height = 350;
+struct DijkstraLevel : DijkstraState<LevelCell*, DijkstraLevel> {
+  static int const kFullWidth = 504;
+  static int const kFullHeight = 350;
 
-  static int const factor = 4;
+  static int const kFactor = 4;
 
-  static int const width = full_width / factor;
-  static int const pitch = width + 2;
-  static int const height = full_height / factor;
+  static int const kWidth = kFullWidth / kFactor;
+  static int const kPitch = kWidth + 2;
+  static int const kHeight = kFullHeight / kFactor;
 
-  level_cell cells[(width + 2) * (height + 2)];
+  LevelCell cells[(kWidth + 2) * (kHeight + 2)];
 
-  path_node_t* get_node(level_cell* c) { return c; }
+  path_node_t* GetNode(LevelCell* c) { return c; }
 
-  level_cell* get_node_id(path_node_t* c) { return static_cast<level_cell*>(c); }
+  LevelCell* GetNodeId(path_node_t* c) { return static_cast<LevelCell*>(c); }
 
-  level_cell* cell(int x, int y) { return &cells[(y + 1) * pitch + x + 1]; }
+  LevelCell* Cell(int x, int y) { return &cells[(y + 1) * kPitch + x + 1]; }
 
-  IVec2 coords(level_cell* c) {
+  IVec2 Coords(LevelCell* c) {
     int offset = (int)(c - cells);
-    int y = offset / pitch;
-    int x = offset % pitch;
+    int y = offset / kPitch;
+    int x = offset % kPitch;
     return IVec2(x - 1, y - 1);
   }
 
-  IVec2 coords_level(level_cell* c) { return coords(c) * factor + IVec2(factor / 2, factor / 2); }
+  IVec2 CoordsLevel(LevelCell* c) { return Coords(c) * kFactor + IVec2(kFactor / 2, kFactor / 2); }
 
-  level_cell* cell_from_px(int x, int y) {
-    x = std::min(std::max(x, 0), full_width - 1);
-    y = std::min(std::max(y, 0), full_height - 1);
-    x /= factor;
-    y /= factor;
-    return cell(x, y);
+  LevelCell* CellFromPx(int x, int y) {
+    x = std::min(std::max(x, 0), kFullWidth - 1);
+    y = std::min(std::max(y, 0), kFullHeight - 1);
+    x /= kFactor;
+    y /= kFactor;
+    return Cell(x, y);
   }
 
-  void build(Level& level, Common& common) {
-    this->reset();
+  void Build(Level& level, Common& common) {
+    this->Reset();
 
     Material* mat = common.materials;
 
-    for (int x = 0; x < width + 2; ++x) {
+    for (int x = 0; x < kWidth + 2; ++x) {
       cells[x].cost = -1;
-      cells[(height + 1) * pitch + x].cost = -1;
+      cells[(kHeight + 1) * kPitch + x].cost = -1;
     }
 
-    for (int y = 0; y < height + 2; ++y) {
-      cells[y * pitch].cost = -1;
-      cells[y * pitch + (width + 1)].cost = -1;
+    for (int y = 0; y < kHeight + 2; ++y) {
+      cells[y * kPitch].cost = -1;
+      cells[y * kPitch + (kWidth + 1)].cost = -1;
     }
 
-    for (int ly = 0; ly < height; ++ly) {
-      for (int lx = 0; lx < width; ++lx) {
+    for (int ly = 0; ly < kHeight; ++ly) {
+      for (int lx = 0; lx < kWidth; ++lx) {
         int cost = 1;
 
-        for (int cy = ly * factor; cy < (ly + 1) * factor; ++cy)
-          for (int cx = lx * factor; cx < (lx + 1) * factor; ++cx) {
-            if (!level.inside(cx, cy)) {
+        for (int cy = ly * kFactor; cy < (ly + 1) * kFactor; ++cy)
+          for (int cx = lx * kFactor; cx < (lx + 1) * kFactor; ++cx) {
+            if (!level.Inside(cx, cy)) {
               cost = -1;
               goto done;
             }
 
-            Material m = mat[level.pixel(cx, cy)];
+            Material m = mat[level.Pixel(cx, cy)];
 
-            if (!m.background()) {
-              if (m.anyDirt()) {
+            if (!m.Background()) {
+              if (m.AnyDirt()) {
                 cost = 2;
               } else {
                 cost = -1;
@@ -210,12 +210,12 @@ struct dijkstra_level : dijkstra_state<level_cell*, dijkstra_level> {
           }
       done:
 
-        level_cell* c = cell(lx, ly);
+        LevelCell* c = Cell(lx, ly);
 
         c->cost = cost;
       }
     }
 
-    for (auto& c : cells) c.reset();
+    for (auto& c : cells) c.Reset();
   }
 };

--- a/src/game/ai/predictive_ai.cpp
+++ b/src/game/ai/predictive_ai.cpp
@@ -262,8 +262,8 @@ double EvaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& context, 
       optimal_dist = 50.0;
     }
 
-    double d =
-        std::max(std::abs(worm_cell->g / 256.0 - optimal_dist) - 10.0, 0.0) * weights.distance_weight;
+    double d = std::max(std::abs(worm_cell->g / 256.0 - optimal_dist) - 10.0, 0.0) *
+               weights.distance_weight;
     len *= Psigmoid(d / 100.0);
   } else {
     len += WormDistance(me, target) / 10.0;
@@ -286,7 +286,8 @@ double EvaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& context, 
   score += me_health * weights.health_weight * weights.defense_weight;
   score -= target_health * weights.health_weight;
 
-  if (game.settings->game_mode == Settings::kGmHoldazone && game.holdazone.holder_idx == me->index) {
+  if (game.settings->game_mode == Settings::kGmHoldazone &&
+      game.holdazone.holder_idx == me->index) {
     double aim_diff = AimingDiff(me, target);
     score -= aim_diff * 2.0 * weights.aim_weight;
   } else {
@@ -363,7 +364,8 @@ void SimpleAI::Process(Game& game, Worm& worm) {
 
     double aim_diff = RadianDiff(angle_to_target, current_aim);
 
-    bool fire = aim_diff >= -tolerance && aim_diff <= tolerance && Obstacles(game, &worm, target) < 4;
+    bool fire =
+        aim_diff >= -tolerance && aim_diff <= tolerance && Obstacles(game, &worm, target) < 4;
     {
       cs = initial;
       cs.Set(Worm::kDown, aim_diff < -tolerance);
@@ -732,7 +734,7 @@ void TransToM(Weights& weights, double& p, int pa, int pb, int pc, int facing_en
   // Jump
   double start_jump = ninjarope_out ? 0.015 : 0.1;
   p *= Select(((pc & 1) << 1) | (pc2 & 1), 1.0 - start_jump, start_jump,  // 0 -> 0, 0 -> 1
-              0.999, 0.001);                                            // 1 -> 0, 1 -> 1
+              0.999, 0.001);                                              // 1 -> 0, 1 -> 1
 }
 
 TransModel::TransModel(Weights& weights, bool testing) {

--- a/src/game/ai/predictive_ai.cpp
+++ b/src/game/ai/predictive_ai.cpp
@@ -1,4 +1,4 @@
-#define _USE_MATH_DEFINES
+#define USE_MATH_DEFINES
 #include "predictive_ai.hpp"
 #include <cmath>
 
@@ -10,91 +10,91 @@
 #include "../gfx/renderer.hpp"
 #include "../stats.hpp"
 
-double totalHealth(Worm* w) {
+double TotalHealth(Worm* w) {
   if (w->lives == 0) return -10000.0;
   int h = std::max(w->health, 0);
   if (!w->visible) h = w->settings->health;
   return w->lives * (w->settings->health * 5.0 / 4.0) + h;
 }
 
-double totalHealthNorm(Worm* w) { return totalHealth(w) * 100.0 / w->settings->health; }
+double TotalHealthNorm(Worm* w) { return TotalHealth(w) * 100.0 / w->settings->health; }
 
 // 0..6*len(w->weapons)
-double totalAmmoWorth(Game& game, Worm* w) {
-  double ammoWorth = 0;
+double TotalAmmoWorth(Game& game, Worm* w) {
+  double ammo_worth = 0;
   for (int i = 0; i < 5; ++i) {
     WormWeapon& weap = w->weapons[i];
     Weapon const& winfo = *weap.type;
 
-    if (weap.loadingLeft > 0)
-      ammoWorth += 3.0 - (weap.loadingLeft * 3.0) / winfo.loadingTime;
+    if (weap.loading_left > 0)
+      ammo_worth += 3.0 - (weap.loading_left * 3.0) / winfo.loading_time;
     else
-      ammoWorth += 3.0 + (weap.ammo * 3.0) / winfo.ammo;
+      ammo_worth += 3.0 + (weap.ammo * 3.0) / winfo.ammo;
   }
 
-  return ammoWorth;
+  return ammo_worth;
 }
 
-int readyWeapons(Game& game, Worm* w) {
+int ReadyWeapons(Game& game, Worm* w) {
   int count = 0;
   for (int i = 0; i < 5; ++i) {
     WormWeapon& weap = w->weapons[i];
 
-    if (weap.loadingLeft == 0 && weap.delayLeft < 70) ++count;
+    if (weap.loading_left == 0 && weap.delay_left < 70) ++count;
   }
 
   return count;
 }
 
-bool hasUsableWeapon(Game& game, Worm* w) {
+bool HasUsableWeapon(Game& game, Worm* w) {
   for (int i = 0; i < 5; ++i) {
     WormWeapon& weap = w->weapons[i];
 
-    if (weap.loadingLeft <= 0) return true;
+    if (weap.loading_left <= 0) return true;
   }
 
   return false;
 }
 
-int wormDistance(Worm* from, Worm* to) {
-  return vectorLength(ftoi(to->pos.x) - ftoi(from->pos.x), ftoi(to->pos.y) - ftoi(from->pos.y));
+int WormDistance(Worm* from, Worm* to) {
+  return VectorLength(Ftoi(to->pos.x) - Ftoi(from->pos.x), Ftoi(to->pos.y) - Ftoi(from->pos.y));
 }
 
 // langle in fixed point 0..128
-double langleToRadians(int langle) {
-  double a = ((langle + itof(32)) & (itof(128) - 1)) * 0.04908738521234051935097880286374 / 65536.0;
+double LangleToRadians(int langle) {
+  double a = ((langle + Itof(32)) & (Itof(128) - 1)) * 0.04908738521234051935097880286374 / 65536.0;
   return a;
 }
 
-inline int normalizedLangle(int langle) {
-  if (langle < itof(64)) langle = itof(128) - langle;
+inline int NormalizedLangle(int langle) {
+  if (langle < Itof(64)) langle = Itof(128) - langle;
   return langle;
 }
 
-inline double radianDiff(double a, double b) {
-  double aimDiff = b - a;
-  while (aimDiff < -M_PI) aimDiff += 2 * M_PI;
-  while (aimDiff > M_PI) aimDiff -= 2 * M_PI;
-  return aimDiff;
+inline double RadianDiff(double a, double b) {
+  double aim_diff = b - a;
+  while (aim_diff < -M_PI) aim_diff += 2 * M_PI;
+  while (aim_diff > M_PI) aim_diff -= 2 * M_PI;
+  return aim_diff;
 }
 
-double aimingDiff(Worm* from, Worm* to) {
+double AimingDiff(Worm* from, Worm* to) {
   double xo = std::abs(to->pos.x - from->pos.x);
   double yo = to->pos.y - from->pos.y;
 
-  double angleToTarget = xo != 0 || yo != 0 ? std::atan2(yo, xo) : 0;
+  double angle_to_target = xo != 0 || yo != 0 ? std::atan2(yo, xo) : 0;
 
-  int aim = normalizedLangle(from->aimingAngle);
+  int aim = NormalizedLangle(from->aiming_angle);
 
-  double currentAim = langleToRadians(aim);
+  double current_aim = LangleToRadians(aim);
 
   double tolerance = M_PI / 8;
-  double aimDiff = std::abs(radianDiff(angleToTarget, currentAim));
+  double aim_diff = std::abs(RadianDiff(angle_to_target, current_aim));
 
-  return std::max(aimDiff - tolerance, 0.0) / 6.0;
+  return std::max(aim_diff - tolerance, 0.0) / 6.0;
 }
 
-int obstacles(Game& game, IVec2 from, IVec2 to) {
+int Obstacles(Game& game, IVec2 from, IVec2 to) {
   typedef BasicVec<double, 2> dvec2;
 
   dvec2 org(from.x, from.y);
@@ -109,10 +109,10 @@ int obstacles(Game& game, IVec2 from, IVec2 to) {
   for (double d = 0; d < l; d += 2.0) {
     dvec2 p = org + dir * d;
 
-    auto m = game.common->materials[game.level.checkedPixelWrap((int)p.x, (int)p.y)];
+    auto m = game.common->materials[game.level.CheckedPixelWrap((int)p.x, (int)p.y)];
 
-    if (!m.background()) {
-      if (m.dirt())
+    if (!m.Background()) {
+      if (m.Dirt())
         obst += 2;
       else
         obst += 3;
@@ -124,26 +124,26 @@ int obstacles(Game& game, IVec2 from, IVec2 to) {
   return obst;
 }
 
-int obstacles(Game& game, Worm* from, Worm* to) {
-  double orgX = from->pos.x / 65536.0;
-  double orgY = from->pos.y / 65536.0;
-  double dirX = (to->pos.x - from->pos.x) / 65536.0;
-  double dirY = (to->pos.y - from->pos.y) / 65536.0;
+int Obstacles(Game& game, Worm* from, Worm* to) {
+  double org_x = from->pos.x / 65536.0;
+  double org_y = from->pos.y / 65536.0;
+  double dir_x = (to->pos.x - from->pos.x) / 65536.0;
+  double dir_y = (to->pos.y - from->pos.y) / 65536.0;
 
-  double l = std::sqrt(dirX * dirX + dirY * dirY);
-  dirX /= l;
-  dirY /= l;
+  double l = std::sqrt(dir_x * dir_x + dir_y * dir_y);
+  dir_x /= l;
+  dir_y /= l;
 
   int obst = 0;
 
   for (double d = 0; d < l; d += 2.0) {
-    double px = orgX + dirX * d;
-    double py = orgY + dirY * d;
+    double px = org_x + dir_x * d;
+    double py = org_y + dir_y * d;
 
-    auto m = game.common->materials[game.level.checkedPixelWrap((int)px, (int)py)];
+    auto m = game.common->materials[game.level.CheckedPixelWrap((int)px, (int)py)];
 
-    if (!m.background()) {
-      if (m.dirt())
+    if (!m.Background()) {
+      if (m.Dirt())
         obst += 2;
       else
         obst += 3;
@@ -155,11 +155,11 @@ int obstacles(Game& game, Worm* from, Worm* to) {
   return obst;
 }
 
-double aimingDiff(AiContext& context, Game& game, Worm* from, level_cell* cell) {
+double AimingDiff(AiContext& context, Game& game, Worm* from, LevelCell* cell) {
   if (!cell || !cell->parent) return 1.0;
 
-  auto org = context.dlevel.coords(cell);
-  auto orgl = context.dlevel.coords_level(cell);
+  auto org = context.dlevel.Coords(cell);
+  auto orgl = context.dlevel.CoordsLevel(cell);
 
   double dirx = 0, diry = 0;
   auto* c = cell;
@@ -169,10 +169,10 @@ double aimingDiff(AiContext& context, Game& game, Worm* from, level_cell* cell) 
     int count = 15;
     dirx = 1;
     while (c->parent && count-- > 0) {
-      c = (level_cell*)c->parent;
-      auto path = context.dlevel.coords_level(c);
+      c = (LevelCell*)c->parent;
+      auto path = context.dlevel.CoordsLevel(c);
 
-      if ((path.x != orgl.x && path.y != orgl.y) && obstacles(game, orgl, path) > 4) break;
+      if ((path.x != orgl.x && path.y != orgl.y) && Obstacles(game, orgl, path) > 4) break;
 
       dirx = std::abs(path.x - orgl.x);
       diry = path.y - orgl.y;
@@ -181,10 +181,10 @@ double aimingDiff(AiContext& context, Game& game, Worm* from, level_cell* cell) 
     int count = 10;
 
     while (count-- > 0) {
-      c = (level_cell*)c->parent;
+      c = (LevelCell*)c->parent;
       if (!c) break;
 
-      auto path = context.dlevel.coords(c);
+      auto path = context.dlevel.Coords(c);
 
       int xdiff = std::abs(path.x - org.x);
       int ydiff = path.y - org.y;
@@ -195,118 +195,118 @@ double aimingDiff(AiContext& context, Game& game, Worm* from, level_cell* cell) 
     }
   }
 
-  int aim = normalizedLangle(from->aimingAngle);
-  double currentAim = langleToRadians(aim);
+  int aim = NormalizedLangle(from->aiming_angle);
+  double current_aim = LangleToRadians(aim);
 
-  double angleToTarget = std::atan2(diry, dirx);
+  double angle_to_target = std::atan2(diry, dirx);
 
   double tolerance = M_PI / 8;
-  double aimDiff = std::abs(radianDiff(angleToTarget, currentAim));
+  double aim_diff = std::abs(RadianDiff(angle_to_target, current_aim));
 
-  return std::max(aimDiff - tolerance, 0.0) / 6.0;
+  return std::max(aim_diff - tolerance, 0.0) / 6.0;
 }
 
-inline int weaponChangeOffset(int wantedWeapon, int currentWeapon) {
-  int offset = wantedWeapon - currentWeapon;
+inline int WeaponChangeOffset(int wanted_weapon, int current_weapon) {
+  int offset = wanted_weapon - current_weapon;
   offset = ((offset + 2 + 5) % 5) - 2;
   return offset;
 }
 
-enum MutationType { MtIdentity, MtRange, MtOptimize };
+enum MutationType { kMtIdentity, kMtRange, kMtOptimize };
 
 struct MutationStrategy {
   MutationStrategy(MutationType type, uint32_t start = 0, uint32_t stop = 0)
       : type(type), start(start), stop(stop) {}
 
-  static MutationStrategy identity() { return MutationStrategy(MtIdentity); }
+  static MutationStrategy Identity() { return MutationStrategy(kMtIdentity); }
 
-  static MutationStrategy optimize() { return MutationStrategy(MtOptimize); }
+  static MutationStrategy Optimize() { return MutationStrategy(kMtOptimize); }
 
   MutationType type;
   uint32_t start;
   uint32_t stop;
 };
 
-InputState generate(FollowAI& ai, Rand& rand, InputContext& prev) {
-  return ai.model.random(prev, rand);
+InputState Generate(FollowAI& ai, Rand& rand, InputContext& prev) {
+  return ai.model.Random(prev, rand);
 }
 
-double sigmoid(double x) { return 1.0 / (1.0 + exp(-x)); }
+double Sigmoid(double x) { return 1.0 / (1.0 + exp(-x)); }
 
 // psigmoid(0) = 0
 // psigmoid(1) ~= 0.5
 // psigmoid(inf) = 1
-double psigmoid(double x) { return (sigmoid(x) - 0.5) * 2.0; }
+double Psigmoid(double x) { return (Sigmoid(x) - 0.5) * 2.0; }
 
-level_cell* AiContext::pathFind(int x, int y) {
-  auto* cell = dlevel.cell_from_px(x, y);
-  bool path = dlevel.run([=] { return cell->state == path_node::closed; }, level_cell_succ());
+LevelCell* AiContext::PathFind(int x, int y) {
+  auto* cell = dlevel.CellFromPx(x, y);
+  bool path = dlevel.Run([=] { return cell->state == PathNode::kClosed; }, LevelCellSucc());
   return path ? cell : 0;
 }
 
-double evaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& context, Worm* target,
-                     Game& orgGame, std::size_t index) {
+double EvaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& context, Worm* target,
+                     Game& org_game, std::size_t index) {
   double score = 0;
 
   Weights weights = ai.weights;
 
-  int posx = ftoi(me->pos.x), posy = ftoi(me->pos.y);
-  auto* wormCell = ai.pathFind(posx, posy);
-  Worm* meOrg = orgGame.wormByIdx(me->index);
+  int posx = Ftoi(me->pos.x), posy = Ftoi(me->pos.y);
+  auto* worm_cell = ai.PathFind(posx, posy);
+  Worm* me_org = org_game.WormByIdx(me->index);
 
   double len = 200.0;
-  if (wormCell) {
-    double optimalDist = 10.0;
+  if (worm_cell) {
+    double optimal_dist = 10.0;
 
-    if (readyWeapons(orgGame, orgGame.wormByIdx(me->index)) <= 1) {
-      optimalDist = 50.0;
+    if (ReadyWeapons(org_game, org_game.WormByIdx(me->index)) <= 1) {
+      optimal_dist = 50.0;
     }
 
     double d =
-        std::max(std::abs(wormCell->g / 256.0 - optimalDist) - 10.0, 0.0) * weights.distanceWeight;
-    len *= psigmoid(d / 100.0);
+        std::max(std::abs(worm_cell->g / 256.0 - optimal_dist) - 10.0, 0.0) * weights.distance_weight;
+    len *= Psigmoid(d / 100.0);
   } else {
-    len += wormDistance(me, target) / 10.0;
+    len += WormDistance(me, target) / 10.0;
   }
 
-  if (meOrg->steerableCount == 1) {
-    auto* missileCell = ai.dlevel.cell_from_px(me->steerableSumX, me->steerableSumY);
-    bool missilePath =
-        ai.dlevel.run([=] { return missileCell->state == path_node::closed; }, level_cell_succ());
+  if (me_org->steerable_count == 1) {
+    auto* missile_cell = ai.dlevel.CellFromPx(me->steerable_sum_x, me->steerable_sum_y);
+    bool missile_path =
+        ai.dlevel.Run([=] { return missile_cell->state == PathNode::kClosed; }, LevelCellSucc());
 
-    if (missilePath && wormCell && missileCell->g < wormCell->g) {
-      double closer = (double)wormCell->g - missileCell->g;
-      score += psigmoid((closer / (double)wormCell->g)) * 100.0 * weights.missileWeight;
+    if (missile_path && worm_cell && missile_cell->g < worm_cell->g) {
+      double closer = (double)worm_cell->g - missile_cell->g;
+      score += Psigmoid((closer / (double)worm_cell->g)) * 100.0 * weights.missile_weight;
     }
   }
 
-  double meHealth = totalHealthNorm(me);
-  double targetHealth = totalHealthNorm(target);
+  double me_health = TotalHealthNorm(me);
+  double target_health = TotalHealthNorm(target);
 
-  score += meHealth * weights.healthWeight * weights.defenseWeight;
-  score -= targetHealth * weights.healthWeight;
+  score += me_health * weights.health_weight * weights.defense_weight;
+  score -= target_health * weights.health_weight;
 
-  if (game.settings->gameMode == Settings::GMHoldazone && game.holdazone.holderIdx == me->index) {
-    double aimDiff = aimingDiff(me, target);
-    score -= aimDiff * 2.0 * weights.aimWeight;
+  if (game.settings->game_mode == Settings::kGmHoldazone && game.holdazone.holder_idx == me->index) {
+    double aim_diff = AimingDiff(me, target);
+    score -= aim_diff * 2.0 * weights.aim_weight;
   } else {
-    double aimDiff = aimingDiff(ai, game, me, wormCell);
-    score -= aimDiff * 2.0 * weights.aimWeight;
+    double aim_diff = AimingDiff(ai, game, me, worm_cell);
+    score -= aim_diff * 2.0 * weights.aim_weight;
   }
 
   {
-    double meAmmoWorth = totalAmmoWorth(game, me);
+    double me_ammo_worth = TotalAmmoWorth(game, me);
 
-    score += meAmmoWorth * 2.0 * weights.ammoWeight;
+    score += me_ammo_worth * 2.0 * weights.ammo_weight;
   }
 
-  if (game.settings->gameMode == Settings::GMHoldazone) {
+  if (game.settings->game_mode == Settings::kGmHoldazone) {
     double scale = 1.0 / 4.0;
-    if (game.holdazone.holderIdx != me->index) scale = 1.0;
+    if (game.holdazone.holder_idx != me->index) scale = 1.0;
 
     score -= len * scale;
-  } else if (game.settings->gameMode == Settings::GMGameOfTag) {
-    if (game.lastKilledIdx >= 0 && game.lastKilledIdx != me->index)
+  } else if (game.settings->game_mode == Settings::kGmGameOfTag) {
+    if (game.last_killed_idx >= 0 && game.last_killed_idx != me->index)
       score += len;
     else
       score -= len;
@@ -318,141 +318,141 @@ double evaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& context, 
   } else if (me->visible) {
   }
 
-  if (game.settings->gameMode == Settings::GMHoldazone) {
-    if (game.holdazone.holderIdx == me->index) score += 50.0;
-    if (game.holdazone.contenderIdx == me->index)
-      score += game.holdazone.contenderFrames * 30.0 / 70.0;
+  if (game.settings->game_mode == Settings::kGmHoldazone) {
+    if (game.holdazone.holder_idx == me->index) score += 50.0;
+    if (game.holdazone.contender_idx == me->index)
+      score += game.holdazone.contender_frames * 30.0 / 70.0;
 
-    if (game.holdazone.holderIdx == target->index) score -= 50.0;
-    if (game.holdazone.contenderIdx == target->index)
-      score -= game.holdazone.contenderFrames * 30.0 / 70.0;
+    if (game.holdazone.holder_idx == target->index) score -= 50.0;
+    if (game.holdazone.contender_idx == target->index)
+      score -= game.holdazone.contender_frames * 30.0 / 70.0;
   }
 
   return score;
 }
 
-double EvaluateResult::weightedScore() const {
+double EvaluateResult::WeightedScore() const {
   double r = 0.0;
 
-  for (std::size_t i = 1; i < scoreOverTime.size(); ++i) {
-    double weight = double(scoreOverTime.size() - i) / scoreOverTime.size();
+  for (std::size_t i = 1; i < score_over_time.size(); ++i) {
+    double weight = double(score_over_time.size() - i) / score_over_time.size();
 
-    double diff = scoreOverTime[i] * weight;
+    double diff = score_over_time[i] * weight;
     r += diff;
   }
 
-  return r + futureScore;
+  return r + future_score;
 }
 
-void SimpleAI::process(Game& game, Worm& worm) {
-  Worm* target = game.wormByIdx(worm.index ^ 1);
+void SimpleAI::Process(Game& game, Worm& worm) {
+  Worm* target = game.WormByIdx(worm.index ^ 1);
 
-  auto cs = worm.controlStates;
+  auto cs = worm.control_states;
 
   if (!worm.visible) {
-    cs.set(Worm::Fire, true);
+    cs.Set(Worm::kFire, true);
   } else {
-    int aim = normalizedLangle(worm.aimingAngle);
-    double currentAim = langleToRadians(aim);
+    int aim = NormalizedLangle(worm.aiming_angle);
+    double current_aim = LangleToRadians(aim);
 
     double dirx = std::abs(target->pos.x - worm.pos.x);
     double diry = target->pos.y - worm.pos.y;
-    double angleToTarget = std::atan2(diry, dirx);
+    double angle_to_target = std::atan2(diry, dirx);
 
     double tolerance = 2 * M_PI / 32.0;
 
-    double aimDiff = radianDiff(angleToTarget, currentAim);
+    double aim_diff = RadianDiff(angle_to_target, current_aim);
 
-    bool fire = aimDiff >= -tolerance && aimDiff <= tolerance && obstacles(game, &worm, target) < 4;
+    bool fire = aim_diff >= -tolerance && aim_diff <= tolerance && Obstacles(game, &worm, target) < 4;
     {
       cs = initial;
-      cs.set(Worm::Down, aimDiff < -tolerance);
-      cs.set(Worm::Up, aimDiff > tolerance);
-      cs.set(Worm::Fire, fire || initial[Worm::Fire]);
-      cs.set(Worm::Change, false);
+      cs.Set(Worm::kDown, aim_diff < -tolerance);
+      cs.Set(Worm::kUp, aim_diff > tolerance);
+      cs.Set(Worm::kFire, fire || initial[Worm::kFire]);
+      cs.Set(Worm::kChange, false);
 
-      if (cs[Worm::Fire] && target->pos.x < worm.pos.x && worm.direction != 0) {
-        cs.set(Worm::Left, true);
-        cs.set(Worm::Right, false);
-      } else if (cs[Worm::Fire] && target->pos.x > worm.pos.x && worm.direction != 1) {
-        cs.set(Worm::Left, false);
-        cs.set(Worm::Right, true);
+      if (cs[Worm::kFire] && target->pos.x < worm.pos.x && worm.direction != 0) {
+        cs.Set(Worm::kLeft, true);
+        cs.Set(Worm::kRight, false);
+      } else if (cs[Worm::kFire] && target->pos.x > worm.pos.x && worm.direction != 1) {
+        cs.Set(Worm::kLeft, false);
+        cs.Set(Worm::kRight, true);
       }
     }
   }
 
-  worm.controlStates = cs;
+  worm.control_states = cs;
 }
 
-void evaluate(EvaluateResult& result, FollowAI& ai, Worm* me, Game& game, Worm* target, Plan& plan,
-              std::size_t planSize, MutationStrategy const& ms) {
+void Evaluate(EvaluateResult& result, FollowAI& ai, Worm* me, Game& game, Worm* target, Plan& plan,
+              std::size_t plan_size, MutationStrategy const& ms) {
   Game copy(game);
-  copy.postClone(game);
-  copy.quickSim = true;
+  copy.PostClone(game);
+  copy.quick_sim = true;
 
-  Worm* meCopy = copy.wormByIdx(me->index);
-  Worm* targetCopy = copy.wormByIdx(target->index);
+  Worm* me_copy = copy.WormByIdx(me->index);
+  Worm* target_copy = copy.WormByIdx(target->index);
 
-  FollowAI* targetAi = 0;
+  FollowAI* target_ai = 0;
 
-  auto context = ai.currentContext;
-  InputContext targetContext;
-  if (targetAi) targetContext = targetAi->currentContext;
+  auto context = ai.current_context;
+  InputContext target_context;
+  if (target_ai) target_context = target_ai->current_context;
 
-  SimpleAI simpleAi;
+  SimpleAI simple_ai;
 
-  simpleAi.initial = targetCopy->controlStates;
+  simple_ai.initial = target_copy->control_states;
 
-  double prevS = evaluateState(ai, meCopy, copy, context, targetCopy, game, 0);
+  double prev_s = EvaluateState(ai, me_copy, copy, context, target_copy, game, 0);
 
-  if (result.scoreOverTime.size() < planSize + 1) result.scoreOverTime.resize(planSize + 1);
-  result.scoreOverTime[0] = 0.0;
+  if (result.score_over_time.size() < plan_size + 1) result.score_over_time.resize(plan_size + 1);
+  result.score_over_time[0] = 0.0;
 
-  std::vector<int> weaponChangesLeft;
-  if (ms.type == MtOptimize) {
-    weaponChangesLeft.resize(planSize);
-    int changesLeft = 0;
-    for (std::size_t j = std::min(planSize, plan.size()); j-- > 0;) {
-      if (plan[j].isFiring()) {
-        changesLeft = 0;
-      } else if (plan[j].isNeutral()) {
-        ++changesLeft;
+  std::vector<int> weapon_changes_left;
+  if (ms.type == kMtOptimize) {
+    weapon_changes_left.resize(plan_size);
+    int changes_left = 0;
+    for (std::size_t j = std::min(plan_size, plan.size()); j-- > 0;) {
+      if (plan[j].IsFiring()) {
+        changes_left = 0;
+      } else if (plan[j].IsNeutral()) {
+        ++changes_left;
       }
-      weaponChangesLeft[j] = changesLeft;
+      weapon_changes_left[j] = changes_left;
     }
   }
 
-  for (std::size_t i = 0; i < planSize; ++i) {
+  for (std::size_t i = 0; i < plan_size; ++i) {
     if (plan.size() <= i) {
-      plan.push_back(generate(ai, ai.rand, context));
+      plan.push_back(Generate(ai, ai.rand, context));
     }
 
-    if (ms.type == MtIdentity) {
+    if (ms.type == kMtIdentity) {
       // Do nothing
-    } else if (ms.type == MtRange) {
+    } else if (ms.type == kMtRange) {
       if (i >= ms.start && i < ms.stop) {
-        plan[i] = generate(ai, ai.rand, context);
+        plan[i] = Generate(ai, ai.rand, context);
       }
-    } else if (ms.type == MtOptimize) {
+    } else if (ms.type == kMtOptimize) {
       // If current InputState is move/jump/fire neutral, make it change weapon to a loading weapon
       // as long as there's time to change back
 
-      if (plan[i].isNeutral() && meCopy->weapons[meCopy->currentWeapon].loadingLeft == 0) {
+      if (plan[i].IsNeutral() && me_copy->weapons[me_copy->current_weapon].loading_left == 0) {
         // Out of all loading weapons that are at most weaponChangesLeft[i] - 1 away from
         // a loaded weapon, pick the one that is closest to loaded.
         for (int w = 0; w < 5; ++w) {
-          if (meCopy->weapons[w].loadingLeft > 0) {
-            int distanceFromCurrent = std::abs(weaponChangeOffset(w, meCopy->currentWeapon));
-            int loadedDistance = 5;
+          if (me_copy->weapons[w].loading_left > 0) {
+            int distance_from_current = std::abs(WeaponChangeOffset(w, me_copy->current_weapon));
+            int loaded_distance = 5;
             for (int lw = 0; lw < 5; ++lw) {
-              if (meCopy->weapons[lw].loadingLeft == 0) {
-                loadedDistance = std::min(loadedDistance, std::abs(weaponChangeOffset(lw, w)));
+              if (me_copy->weapons[lw].loading_left == 0) {
+                loaded_distance = std::min(loaded_distance, std::abs(WeaponChangeOffset(lw, w)));
               }
             }
 
-            int totalDistance = distanceFromCurrent + loadedDistance;
-            if (totalDistance <= weaponChangesLeft[i]) {
-              plan[i] = InputState::compose(InputState::ChangeWeapon, w, 0, 0);
+            int total_distance = distance_from_current + loaded_distance;
+            if (total_distance <= weapon_changes_left[i]) {
+              plan[i] = InputState::Compose(InputState::kChangeWeapon, w, 0, 0);
               break;
             }
           }
@@ -460,44 +460,44 @@ void evaluate(EvaluateResult& result, FollowAI& ai, Worm* me, Game& game, Worm* 
       }
     }
 
-    meCopy->controlStates = context.update(plan[i], copy, meCopy, ai);
+    me_copy->control_states = context.Update(plan[i], copy, me_copy, ai);
 
-    if (targetAi && targetAi->best && i < targetAi->best->plan.size())
-      targetCopy->controlStates =
-          targetContext.update(targetAi->best->plan[i], copy, targetCopy, *targetAi);
+    if (target_ai && target_ai->best && i < target_ai->best->plan.size())
+      target_copy->control_states =
+          target_context.Update(target_ai->best->plan[i], copy, target_copy, *target_ai);
     else
-      simpleAi.process(copy, *targetCopy);
+      simple_ai.Process(copy, *target_copy);
 
-    copy.processFrame();
+    copy.ProcessFrame();
 
-    double s = evaluateState(ai, meCopy, copy, context, targetCopy, game, i + 1);
+    double s = EvaluateState(ai, me_copy, copy, context, target_copy, game, i + 1);
 
-    if (game.settings->aiTraces) {
-      int t = 119 - (int)(i * (119 - 104 + 1) / planSize);
+    if (game.settings->ai_traces) {
+      int t = 119 - (int)(i * (119 - 104 + 1) / plan_size);
 
-      ai.evaluatePositions.push_back(std::make_tuple(IVec2(meCopy->pos.x, meCopy->pos.y), t));
+      ai.evaluate_positions.push_back(std::make_tuple(IVec2(me_copy->pos.x, me_copy->pos.y), t));
     }
 
-    result.scoreOverTime[i + 1] = s - prevS;
+    result.score_over_time[i + 1] = s - prev_s;
 
-    prevS = s;
+    prev_s = s;
   }
 }
 
-void mutate(EvaluateResult& result, FollowAI& ai, Game& game, Worm& worm, Worm* target,
-            Plan& candidate, EvaluateResult const& prevResult) {
-  MutationStrategy ms(MtRange, 0, (uint32_t)candidate.size());
+void Mutate(EvaluateResult& result, FollowAI& ai, Game& game, Worm& worm, Worm* target,
+            Plan& candidate, EvaluateResult const& prev_result) {
+  MutationStrategy ms(kMtRange, 0, (uint32_t)candidate.size());
 
   {
     // Find the minimum suffix sum
-    uint32_t j = uint32_t(prevResult.scoreOverTime.size() - 1);
+    uint32_t j = uint32_t(prev_result.score_over_time.size() - 1);
 
-    double sum = prevResult.scoreOverTime[j];
+    double sum = prev_result.score_over_time[j];
     double min = sum;
     auto minj = j;
 
     while (j-- > 0) {
-      sum += prevResult.scoreOverTime[j];
+      sum += prev_result.score_over_time[j];
       if (sum < min) {
         minj = j;
         min = sum;
@@ -513,15 +513,15 @@ void mutate(EvaluateResult& result, FollowAI& ai, Game& game, Worm& worm, Worm* 
     }
   }
 
-  evaluate(result, ai, &worm, game, target, candidate, game.settings->aiFrames, ms);
+  Evaluate(result, ai, &worm, game, target, candidate, game.settings->ai_frames, ms);
 }
 
-void FollowAI::drawDebug(Game& game, Worm const& worm, Renderer& renderer, int offsX, int offsY) {
-  for (auto& p : evaluatePositions) {
+void FollowAI::DrawDebug(Game& game, Worm const& worm, Renderer& renderer, int offs_x, int offs_y) {
+  for (auto& p : evaluate_positions) {
     IVec2 v;
     PalIdx t;
     std::tie(v, t) = p;
-    renderer.bmp.setPixel(ftoi(v.x) + offsX, ftoi(v.y) + offsY, t);
+    renderer.bmp.SetPixel(Ftoi(v.x) + offs_x, Ftoi(v.y) + offs_y, t);
   }
 }
 
@@ -554,61 +554,61 @@ struct MutateWork : Work {
 
 #endif
 
-void FollowAI::process(Game& game, Worm& worm) {
+void FollowAI::Process(Game& game, Worm& worm) {
   Common& common = *game.common;
 
   Worm* target = game.worms[worm.index ^ 1].get();
 
   {
-    int targetx = ftoi(target->pos.x), targety = ftoi(target->pos.y);
+    int targetx = Ftoi(target->pos.x), targety = Ftoi(target->pos.y);
 
-    if (game.settings->gameMode == Settings::GMHoldazone) {
-      targetx = game.holdazone.rect.center_x();
-      targety = game.holdazone.rect.center_y();
+    if (game.settings->game_mode == Settings::kGmHoldazone) {
+      targetx = game.holdazone.rect.CenterX();
+      targety = game.holdazone.rect.CenterY();
     }
 
-    dlevel.build(game.level, common);
-    auto* targetCell = dlevel.cell_from_px(targetx, targety);
-    targetCell->cost = 1;
-    dlevel.set_origin(targetCell);
+    dlevel.Build(game.level, common);
+    auto* target_cell = dlevel.CellFromPx(targetx, targety);
+    target_cell->cost = 1;
+    dlevel.SetOrigin(target_cell);
   }
 
-  update(*this, worm);
+  Update(*this, worm);
 
-  double bestScore = -std::numeric_limits<double>::infinity();
-  evaluatePositions.clear();
+  double best_score = -std::numeric_limits<double>::infinity();
+  evaluate_positions.clear();
 
   {
-    unsigned int candIdx;
+    unsigned int cand_idx;
 
-    evaluationBudget += (game.settings->aiMutations + 1) * game.settings->aiFrames;
+    evaluation_budget += (game.settings->ai_mutations + 1) * game.settings->ai_frames;
 
     std::vector<std::pair<double, int>> prio;
 
-    for (candIdx = 0; candIdx < candPlan.size(); ++candIdx) {
-      auto& cand = candPlan[candIdx];
+    for (cand_idx = 0; cand_idx < cand_plan.size(); ++cand_idx) {
+      auto& cand = cand_plan[cand_idx];
 
-      if (cand.prevResultAge < 2 && !cand.prevResult.scoreOverTime.empty()) {
-      } else if (cand.prevResult.scoreOverTime.empty()) {
-        evaluate(cand.prevResult, *this, &worm, game, target, cand.plan, game.settings->aiFrames,
-                 testing ? MutationStrategy::optimize() : MutationStrategy::identity());
-        evaluationBudget -= game.settings->aiFrames;
-        cand.prevResultAge = 0;
+      if (cand.prev_result_age < 2 && !cand.prev_result.score_over_time.empty()) {
+      } else if (cand.prev_result.score_over_time.empty()) {
+        Evaluate(cand.prev_result, *this, &worm, game, target, cand.plan, game.settings->ai_frames,
+                 testing ? MutationStrategy::Optimize() : MutationStrategy::Identity());
+        evaluation_budget -= game.settings->ai_frames;
+        cand.prev_result_age = 0;
       } else {
-        evaluate(cand.prevResult, *this, &worm, game, target, cand.plan,
-                 game.settings->aiFrames / 2,
-                 testing ? MutationStrategy::optimize() : MutationStrategy::identity());
-        evaluationBudget -= game.settings->aiFrames / 2;
-        cand.prevResultAge = 0;
+        Evaluate(cand.prev_result, *this, &worm, game, target, cand.plan,
+                 game.settings->ai_frames / 2,
+                 testing ? MutationStrategy::Optimize() : MutationStrategy::Identity());
+        evaluation_budget -= game.settings->ai_frames / 2;
+        cand.prev_result_age = 0;
       }
 
-      double weightedScore = cand.prevResult.weightedScore();
-      if (weightedScore >= bestScore) {
-        bestScore = weightedScore;
+      double weighted_score = cand.prev_result.WeightedScore();
+      if (weighted_score >= best_score) {
+        best_score = weighted_score;
         best = &cand;
       }
 
-      prio.push_back(std::make_pair(weightedScore, candIdx));
+      prio.push_back(std::make_pair(weighted_score, cand_idx));
     }
 
     std::sort(prio.begin(), prio.end(),
@@ -616,179 +616,179 @@ void FollowAI::process(Game& game, Worm& worm) {
                 return a.first > b.first;
               });
 
-    for (candIdx = 0; evaluationBudget > 0;) {
-      auto& cand = candPlan[prio[candIdx].second];
+    for (cand_idx = 0; evaluation_budget > 0;) {
+      auto& cand = cand_plan[prio[cand_idx].second];
       auto candidate = cand.plan;
       EvaluateResult result;
-      mutate(result, *this, game, worm, target, candidate, cand.prevResult);
-      evaluationBudget -= game.settings->aiFrames;
+      Mutate(result, *this, game, worm, target, candidate, cand.prev_result);
+      evaluation_budget -= game.settings->ai_frames;
 
-      double weightedScore = result.weightedScore();
-      if (weightedScore > bestScore) {
+      double weighted_score = result.WeightedScore();
+      if (weighted_score > best_score) {
         cand.plan = std::move(candidate);
         best = &cand;
-        bestScore = weightedScore;
-        cand.prevResult = std::move(result);
-        cand.prevResultAge = 0;
+        best_score = weighted_score;
+        cand.prev_result = std::move(result);
+        cand.prev_result_age = 0;
       } else {
-        candIdx = (candIdx + 1) % candPlan.size();
+        cand_idx = (cand_idx + 1) % cand_plan.size();
       }
     }
   }
 
-  worm.controlStates = currentContext.update(best->plan[0], game, &worm, *this);
+  worm.control_states = current_context.Update(best->plan[0], game, &worm, *this);
 
   if (frame < 70 * 2 * 60) {
-    model.update(currentContext, best->plan[0]);
+    model.Update(current_context, best->plan[0]);
   }
 
-  for (auto& p : candPlan) {
+  for (auto& p : cand_plan) {
     p.plan.erase(p.plan.begin());
 
     // Shift result
-    p.prevResult.scoreOverTime.erase(p.prevResult.scoreOverTime.begin());
-    p.prevResult.scoreOverTime.push_back(0.0);
-    ++p.prevResultAge;
+    p.prev_result.score_over_time.erase(p.prev_result.score_over_time.begin());
+    p.prev_result.score_over_time.push_back(0.0);
+    ++p.prev_result_age;
   }
 
   ++frame;
 }
 
-Worm::ControlState InputContext::update(InputState newState, Game& game, Worm* worm,
-                                        AiContext& aiContext) {
+Worm::ControlState InputContext::Update(InputState new_state, Game& game, Worm* worm,
+                                        AiContext& ai_context) {
   Worm::ControlState cs;
 
-  if (worm->visible && wantedWeapon != worm->currentWeapon) {
-    int offset = weaponChangeOffset(wantedWeapon, worm->currentWeapon);
-    cs.set(Worm::Left, offset < 0);
-    cs.set(Worm::Right, offset > 0);
-    cs.set(Worm::Change, true);
+  if (worm->visible && wanted_weapon != worm->current_weapon) {
+    int offset = WeaponChangeOffset(wanted_weapon, worm->current_weapon);
+    cs.Set(Worm::kLeft, offset < 0);
+    cs.Set(Worm::kRight, offset > 0);
+    cs.Set(Worm::kChange, true);
   } else {
     int pa, pb, pc;
-    switch (newState.decompose(pa, pb, pc)) {
-      case InputState::MoveJumpFire: {
-        cs.set(Worm::Up, (pa >> 1) & 1);
-        cs.set(Worm::Down, pa & 1);
-        cs.set(Worm::Left, (pb >> 1) & 1);
-        cs.set(Worm::Right, pb & 1);
-        cs.set(Worm::Fire, (pc >> 1) & 1);
-        cs.set(Worm::Jump, pc & 1);
+    switch (new_state.Decompose(pa, pb, pc)) {
+      case InputState::kMoveJumpFire: {
+        cs.Set(Worm::kUp, (pa >> 1) & 1);
+        cs.Set(Worm::kDown, pa & 1);
+        cs.Set(Worm::kLeft, (pb >> 1) & 1);
+        cs.Set(Worm::kRight, pb & 1);
+        cs.Set(Worm::kFire, (pc >> 1) & 1);
+        cs.Set(Worm::kJump, pc & 1);
         break;
       }
 
-      case InputState::ChangeWeapon: {
-        if (wantedWeapon != pa) {
-          wantedWeapon = pa;
-          cs.set(Worm::Change, true);
+      case InputState::kChangeWeapon: {
+        if (wanted_weapon != pa) {
+          wanted_weapon = pa;
+          cs.Set(Worm::kChange, true);
         }
         break;
       }
 
-      case InputState::RopeUpDown: {
-        cs.set(Worm::Up, (pa >> 1) & 1);
-        cs.set(Worm::Down, pa & 1);
-        cs.set(Worm::Change, 1);
-        if (pa == 0) cs.set(Worm::Jump, 1);
+      case InputState::kRopeUpDown: {
+        cs.Set(Worm::kUp, (pa >> 1) & 1);
+        cs.Set(Worm::kDown, pa & 1);
+        cs.Set(Worm::kChange, 1);
+        if (pa == 0) cs.Set(Worm::kJump, 1);
         break;
       }
     }
   }
 
-  currentState = newState;
+  current_state = new_state;
 
   if (!worm->visible && !worm->ready)
-    ++hiddenFrames;
+    ++hidden_frames;
   else
-    hiddenFrames = 0;
+    hidden_frames = 0;
 
-  facingEnemy = (game.worms[worm->index ^ 1]->pos.x > worm->pos.x) == worm->direction;
-  ninjaropeOut = worm->ninjarope.out;
+  facing_enemy = (game.worms[worm->index ^ 1]->pos.x > worm->pos.x) == worm->direction;
+  ninjarope_out = worm->ninjarope.out;
 
   return cs;
 }
 
-void transToM(Weights& weights, double& p, int pa, int pb, int pc, int facingEnemy,
-              int ninjaropeOut, int pa2, int pb2, int pc2) {
+void TransToM(Weights& weights, double& p, int pa, int pb, int pc, int facing_enemy,
+              int ninjarope_out, int pa2, int pb2, int pc2) {
   assert(pa < 3 && pb < 4 && pc < 4);
   assert(pa2 < 3 && pb2 < 4 && pc2 < 4);
-  assert(facingEnemy < 2 && ninjaropeOut < 2);
+  assert(facing_enemy < 2 && ninjarope_out < 2);
 
-  if (pa == 0) p *= select(pa2, 0.1, 0.45, 0.45);    // Start aiming
-  if (pa == 1) p *= select(pa2, 0.025, 0.9, 0.075);  // Aiming down
-  if (pa == 2) p *= select(pa2, 0.025, 0.075, 0.9);  // Aiming up
+  if (pa == 0) p *= Select(pa2, 0.1, 0.45, 0.45);    // Start aiming
+  if (pa == 1) p *= Select(pa2, 0.025, 0.9, 0.075);  // Aiming down
+  if (pa == 2) p *= Select(pa2, 0.025, 0.075, 0.9);  // Aiming up
 
-  if (pb == 0) p *= select(pb2, 0.05, 0.4, 0.4, 0.15);  // Not moving
+  if (pb == 0) p *= Select(pb2, 0.05, 0.4, 0.4, 0.15);  // Not moving
 
-  if (pb == 1) p *= select(pb2, 0.005, 0.965, 0.005, 0.025);  // Moving right
-  if (pb == 2) p *= select(pb2, 0.005, 0.005, 0.965, 0.025);  // Moving left
-  if (pb == 3) p *= select(pb2, 0.1, 0.35, 0.35, 0.2);        // Digging
+  if (pb == 1) p *= Select(pb2, 0.005, 0.965, 0.005, 0.025);  // Moving right
+  if (pb == 2) p *= Select(pb2, 0.005, 0.005, 0.965, 0.025);  // Moving left
+  if (pb == 3) p *= Select(pb2, 0.1, 0.35, 0.35, 0.2);        // Digging
 
   // Fire
-  double startShootFacingP = 0.15 * weights.firingWeight;
-  double startShootUnfacingP = 0.03 * weights.firingWeight;
-  double startShootP = facingEnemy ? startShootFacingP : startShootUnfacingP;
-  p *= select((pc & 2) | ((pc2 & 2) >> 1), 1.0 - startShootP, startShootP, 0.4, 0.6);
+  double start_shoot_facing_p = 0.15 * weights.firing_weight;
+  double start_shoot_unfacing_p = 0.03 * weights.firing_weight;
+  double start_shoot_p = facing_enemy ? start_shoot_facing_p : start_shoot_unfacing_p;
+  p *= Select((pc & 2) | ((pc2 & 2) >> 1), 1.0 - start_shoot_p, start_shoot_p, 0.4, 0.6);
 
   // Jump
-  double startJump = ninjaropeOut ? 0.015 : 0.1;
-  p *= select(((pc & 1) << 1) | (pc2 & 1), 1.0 - startJump, startJump,  // 0 -> 0, 0 -> 1
+  double start_jump = ninjarope_out ? 0.015 : 0.1;
+  p *= Select(((pc & 1) << 1) | (pc2 & 1), 1.0 - start_jump, start_jump,  // 0 -> 0, 0 -> 1
               0.999, 0.001);                                            // 1 -> 0, 1 -> 1
 }
 
 TransModel::TransModel(Weights& weights, bool testing) {
-  for (int i = 0; i < this->states; ++i) {
-    int facingEnemy, ninjaropeOut;
-    auto prev = InputContext::unpack(i, facingEnemy, ninjaropeOut);
+  for (int i = 0; i < this->kStates; ++i) {
+    int facing_enemy, ninjarope_out;
+    auto prev = InputContext::Unpack(i, facing_enemy, ninjarope_out);
     int pa, pb, pc;
-    auto type = prev.decompose(pa, pb, pc);
+    auto type = prev.Decompose(pa, pb, pc);
 
     double sum2 = 0.0;
 
-    for (int j = 0; j < this->freeStates; ++j) {
+    for (int j = 0; j < this->kFreeStates; ++j) {
       int pa2, pb2, pc2;
-      auto type2 = InputState(j).decompose(pa2, pb2, pc2);
+      auto type2 = InputState(j).Decompose(pa2, pb2, pc2);
 
       double p = 1;
 
-      if (type == InputState::MoveJumpFire) {
+      if (type == InputState::kMoveJumpFire) {
         double m = 0.95, c = 0.03, r = 0.02;
 
         c += 0.03;
         m -= 0.03;
 
-        if (type2 == InputState::MoveJumpFire) {
+        if (type2 == InputState::kMoveJumpFire) {
           p *= m;
-          transToM(weights, p, pa, pb, pc, facingEnemy, ninjaropeOut, pa2, pb2, pc2);
-        } else if (type2 == InputState::ChangeWeapon) {
+          TransToM(weights, p, pa, pb, pc, facing_enemy, ninjarope_out, pa2, pb2, pc2);
+        } else if (type2 == InputState::kChangeWeapon) {
           p *= c;
           p *= 1.0 / 5.0;  // Each weapon has equal probability
-        } else if (type2 == InputState::RopeUpDown) {
+        } else if (type2 == InputState::kRopeUpDown) {
           p *= r;
-          p *= select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
+          p *= Select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
         }
-      } else if (type == InputState::ChangeWeapon) {
-        if (type2 == InputState::MoveJumpFire) {
+      } else if (type == InputState::kChangeWeapon) {
+        if (type2 == InputState::kMoveJumpFire) {
           // Same as from the idle m-state
           p *= 0.97;
-          transToM(weights, p, 0, 0, 0, facingEnemy, ninjaropeOut, pa2, pb2, pc2);
-        } else if (type2 == InputState::ChangeWeapon) {
+          TransToM(weights, p, 0, 0, 0, facing_enemy, ninjarope_out, pa2, pb2, pc2);
+        } else if (type2 == InputState::kChangeWeapon) {
           p *= 0.001;      // Very little chance
           p *= 1.0 / 5.0;  // Each weapon has equal probability
-        } else if (type2 == InputState::RopeUpDown) {
+        } else if (type2 == InputState::kRopeUpDown) {
           p *= 0.029;
-          p *= select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
+          p *= Select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
         }
-      } else if (type == InputState::RopeUpDown) {
-        if (type2 == InputState::MoveJumpFire) {
+      } else if (type == InputState::kRopeUpDown) {
+        if (type2 == InputState::kMoveJumpFire) {
           // Same as from the idle state
           p *= 0.95;
-          transToM(weights, p, 0, 0, 0, facingEnemy, ninjaropeOut, pa2, pb2, pc2);
-        } else if (type2 == InputState::ChangeWeapon) {
+          TransToM(weights, p, 0, 0, 0, facing_enemy, ninjarope_out, pa2, pb2, pc2);
+        } else if (type2 == InputState::kChangeWeapon) {
           p *= 0.049;
           p *= 1.0 / 5.0;  // Each weapon has equal probability
-        } else if (type2 == InputState::RopeUpDown) {
+        } else if (type2 == InputState::kRopeUpDown) {
           p *= 0.001;                          // Very little chance
-          p *= select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
+          p *= Select(pa2, 0.98, 0.01, 0.01);  // TODO: Rope out
         }
       }
 
@@ -798,29 +798,29 @@ TransModel::TransModel(Weights& weights, bool testing) {
     }
 
     auto& v = trans[i];
-    double sum = std::accumulate(v, v + this->freeStates, 0.0);
+    double sum = std::accumulate(v, v + this->kFreeStates, 0.0);
 
     if (sum < 0.999 || sum > 1.0001) printf("%d: %f\n", i, sum);
   }
 }
 
-void AiContext::update(FollowAI& ai, Worm& worm) {
+void AiContext::Update(FollowAI& ai, Worm& worm) {
   double presence = 0, damage = 0;
 
   if (worm.visible) {
     presence = 4.0 / (70.0 * 5.0);
   }
 
-  double hp = totalHealthNorm(&worm);
+  double hp = TotalHealthNorm(&worm);
 
-  if (hp < prevHp) {
-    damage = (prevHp - hp);
+  if (hp < prev_hp) {
+    damage = (prev_hp - hp);
   }
 
-  incArea(worm.pos.x, worm.pos.y, presence, damage);
+  IncArea(worm.pos.x, worm.pos.y, presence, damage);
 
-  for (int y = 0; y < height; ++y)
-    for (int x = 0; x < width; ++x) {
+  for (int y = 0; y < kHeight; ++y)
+    for (int x = 0; x < kWidth; ++x) {
       state[x][y].presence = std::max(state[x][y].presence - 0.5 / (70.0 * 5.0), 0.0);
     }
 }

--- a/src/game/ai/predictive_ai.cpp
+++ b/src/game/ai/predictive_ai.cpp
@@ -1,4 +1,9 @@
-#define USE_MATH_DEFINES
+// MSVC requires _USE_MATH_DEFINES before <cmath> to expose M_PI. The
+// leading underscore is mandatory — it's the macro spelling MSVC
+// looks for. NOLINT keeps clang-tidy's macro-naming rule from
+// stripping the underscore.
+// NOLINTNEXTLINE(readability-identifier-naming, bugprone-reserved-identifier)
+#define _USE_MATH_DEFINES
 #include "predictive_ai.hpp"
 #include <cmath>
 

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -14,25 +14,25 @@
 
 struct InputState {
   enum Type {
-    MoveJumpFire = 0,  // 48, aabb0cc, a != 3
-    ChangeWeapon = 1,  // 5,  aaa, 0..4, translated to 0010100 or 0001100
-    RopeUpDown = 2,    // 3,  aa00110, a != 3
+    kMoveJumpFire = 0,  // 48, aabb0cc, a != 3
+    kChangeWeapon = 1,  // 5,  aaa, 0..4, translated to 0010100 or 0001100
+    kRopeUpDown = 2,    // 3,  aa00110, a != 3
   };
 
   InputState(Worm* w) {
-    auto cs = w->controlStates;
-    auto v = cs.pack();
+    auto cs = w->control_states;
+    auto v = cs.Pack();
 
-    if (!cs[Worm::Change]) {
+    if (!cs[Worm::kChange]) {
       // MoveJumpFire
       idx = (v >> 2) << 1;
       if (idx > 48) idx -= (1 << 5);
       idx = 2;
       idx |= (v & 1);
     } else {
-      if (!cs[Worm::Jump]) {
+      if (!cs[Worm::kJump]) {
         // ChangeWeapon
-        idx = 48 + w->currentWeapon;
+        idx = 48 + w->current_weapon;
       } else {
         // RopeUpDown
         idx = 48 + 5 + (v >> 5);
@@ -44,56 +44,56 @@ struct InputState {
 
   int idx;  // 0..56
 
-  bool isNeutral() const {
+  bool IsNeutral() const {
     int pa, pb, pc;
-    auto type = decompose(pa, pb, pc);
-    return type == ChangeWeapon;
+    auto type = Decompose(pa, pb, pc);
+    return type == kChangeWeapon;
   }
 
-  bool isFiring() const {
+  bool IsFiring() const {
     int dummy, pc;
-    return decompose(dummy, dummy, pc) == MoveJumpFire && ((pc >> 1) & 1);
+    return Decompose(dummy, dummy, pc) == kMoveJumpFire && ((pc >> 1) & 1);
   }
 
-  Type decompose(int& pa, int& pb, int& pc) const {
+  Type Decompose(int& pa, int& pb, int& pc) const {
     int i = idx;
     if (i < 48) {
       pa = i >> 4;
       pb = (i >> 2) & 3;
       pc = i & 3;
-      return MoveJumpFire;
+      return kMoveJumpFire;
     }
     i -= 48;
 
     if (i < 5) {
       pa = i;
-      return ChangeWeapon;
+      return kChangeWeapon;
     }
     i -= 5;
 
     if (i < 3) {
       pa = i;
-      return RopeUpDown;
+      return kRopeUpDown;
     }
 
     assert(false);
-    return MoveJumpFire;
+    return kMoveJumpFire;
   }
 
-  static InputState compose(Type type, int pa, int pb, int pc) {
+  static InputState Compose(Type type, int pa, int pb, int pc) {
     int idx = 0;
     switch (type) {
-      case MoveJumpFire: {
+      case kMoveJumpFire: {
         idx = (pa << 4) | (pb << 2) | pc;
         break;
       }
 
-      case ChangeWeapon: {
+      case kChangeWeapon: {
         idx = 48 + pa;
         break;
       }
 
-      case RopeUpDown: {
+      case kRopeUpDown: {
         idx = 48 + 5 + pa;
         break;
       }
@@ -106,76 +106,76 @@ struct InputState {
 typedef std::vector<InputState> Plan;
 
 template <typename T>
-inline T select(int n, T first) {
+inline T Select(int n, T first) {
   assert(n == 0);
   return first;
 }
 
 template <typename T>
-inline T select(int n, T first, T a) {
+inline T Select(int n, T first, T a) {
   if (n == 0) return first;
-  return select(n - 1, a);
+  return Select(n - 1, a);
 }
 
 template <typename T>
-inline T select(int n, T first, T a, T b) {
+inline T Select(int n, T first, T a, T b) {
   if (n == 0) return first;
-  return select(n - 1, a, b);
+  return Select(n - 1, a, b);
 }
 
 template <typename T>
-inline T select(int n, T first, T a, T b, T c) {
+inline T Select(int n, T first, T a, T b, T c) {
   if (n == 0) return first;
-  return select(n - 1, a, b, c);
+  return Select(n - 1, a, b, c);
 }
 
 struct AiContext;
 
 struct InputContext {
-  InputContext() : wantedWeapon(0), hiddenFrames(0), facingEnemy(0), ninjaropeOut(0) {}
+  InputContext() : wanted_weapon(0), hidden_frames(0), facing_enemy(0), ninjarope_out(0) {}
 
-  Worm::ControlState update(InputState newState, Game& game, Worm* worm, AiContext& aiContext);
+  Worm::ControlState Update(InputState new_state, Game& game, Worm* worm, AiContext& ai_context);
 
-  int pack() {
-    int i = ninjaropeOut;
-    i = i * 2 + facingEnemy;
-    i = i * 56 + currentState.idx;
+  int Pack() {
+    int i = ninjarope_out;
+    i = i * 2 + facing_enemy;
+    i = i * 56 + current_state.idx;
     return i;
   }
 
-  static InputState unpack(int idx, int& facingEnemy, int& ninjaropeOut) {
+  static InputState Unpack(int idx, int& facing_enemy, int& ninjarope_out) {
     int s = idx % 56;
     idx /= 56;
-    facingEnemy = idx % 2;
+    facing_enemy = idx % 2;
     idx /= 2;
-    ninjaropeOut = idx;
+    ninjarope_out = idx;
     return InputState(s);
   }
 
-  static int const Size = 56 * 2 * 2;
+  static int const kSize = 56 * 2 * 2;
 
   // Free part
-  InputState currentState;
+  InputState current_state;
 
   // Dependent part
-  int wantedWeapon;
-  int hiddenFrames;
-  int facingEnemy;
-  int ninjaropeOut;
+  int wanted_weapon;
+  int hidden_frames;
+  int facing_enemy;
+  int ninjarope_out;
 };
 
 template <int States, int FreeStates>
 struct Model {
-  static int const states = States;
-  static int const freeStates = FreeStates;
+  static int const kStates = States;
+  static int const kFreeStates = FreeStates;
   double trans[States][FreeStates];
 
-  int random(int context, Rand& rand) {
+  int Random(int context, Rand& rand) {
     assert(context < States);
     auto& v = trans[context];
 
     double max = std::accumulate(v, v + FreeStates, 0.0);
-    double el = rand.get_double(max);
+    double el = rand.GetDouble(max);
 
     for (int i = 0; i < FreeStates; ++i) {
       el -= v[i];
@@ -188,25 +188,25 @@ struct Model {
 
 struct Weights {
   Weights()
-      : healthWeight(1.0),
-        aimWeight(1.0),
-        distanceWeight(1.0),
-        ammoWeight(1.0),
-        missileWeight(1.0),
-        defenseWeight(1.3),
-        firingWeight(1.0) {}
+      : health_weight(1.0),
+        aim_weight(1.0),
+        distance_weight(1.0),
+        ammo_weight(1.0),
+        missile_weight(1.0),
+        defense_weight(1.3),
+        firing_weight(1.0) {}
 
-  double healthWeight, aimWeight, distanceWeight, ammoWeight, missileWeight;
-  double defenseWeight, firingWeight;
+  double health_weight, aim_weight, distance_weight, ammo_weight, missile_weight;
+  double defense_weight, firing_weight;
 };
 
-struct TransModel : Model<InputContext::Size, 56> {
+struct TransModel : Model<InputContext::kSize, 56> {
   TransModel(Weights& weights, bool testing);
 
-  void update(InputContext context, InputState v) { trans[context.pack()][v.idx] += 0.005; }
+  void Update(InputContext context, InputState v) { trans[context.Pack()][v.idx] += 0.005; }
 
-  InputState random(InputContext context, Rand& rand) {
-    return InputState(Model<InputContext::Size, 56>::random(context.pack(), rand));
+  InputState Random(InputContext context, Rand& rand) {
+    return InputState(Model<InputContext::kSize, 56>::Random(context.Pack(), rand));
   }
 };
 
@@ -218,62 +218,62 @@ struct CellState {
 struct FollowAI;
 
 struct AiContext {
-  static int const width = (504 + 31) >> 5;
-  static int const height = (350 + 31) >> 5;
+  static int const kWidth = (504 + 31) >> 5;
+  static int const kHeight = (350 + 31) >> 5;
 
-  AiContext() : prevHp(0), maxDamage(0), maxPresence(0) {}
+  AiContext() : prev_hp(0), max_damage(0), max_presence(0) {}
 
-  dijkstra_level dlevel;
+  DijkstraLevel dlevel;
 
-  CellState state[width][height];
+  CellState state[kWidth][kHeight];
 
-  int prevHp;
-  double maxDamage, maxPresence;
+  int prev_hp;
+  double max_damage, max_presence;
 
-  void incArea(int fx, int fy, double presence, double damage) {
-    int wx = ftoi(fx) >> 5;
-    int wy = ftoi(fy) >> 5;
+  void IncArea(int fx, int fy, double presence, double damage) {
+    int wx = Ftoi(fx) >> 5;
+    int wy = Ftoi(fy) >> 5;
 
     for (int y = wy - 1; y <= wy + 1; ++y)
       for (int x = wx - 1; x <= wx + 1; ++x) {
-        if (y >= 0 && y < height && x >= 0 && x < width) {
+        if (y >= 0 && y < kHeight && x >= 0 && x < kWidth) {
           double d = 1.0;
           if (x != wx) d *= 0.5;
           if (y != wy) d *= 0.5;
           auto& c = state[x][y];
           c.presence = d * presence;
           c.damage += d * damage;
-          maxDamage = std::max(maxDamage, c.damage);
-          maxPresence = std::max(maxPresence, c.presence);
+          max_damage = std::max(max_damage, c.damage);
+          max_presence = std::max(max_presence, c.presence);
         }
       }
   }
 
-  CellState& cell(int fx, int fy) {
-    int wx = ftoi(fx) >> 5;
-    int wy = ftoi(fy) >> 5;
+  CellState& Cell(int fx, int fy) {
+    int wx = Ftoi(fx) >> 5;
+    int wy = Ftoi(fy) >> 5;
 
-    wx = std::max(std::min(wx, width), 0);
-    wy = std::max(std::min(wy, height), 0);
+    wx = std::max(std::min(wx, kWidth), 0);
+    wy = std::max(std::min(wy, kHeight), 0);
 
     return state[wx][wy];
   }
 
-  void update(FollowAI& ai, Worm& worm);
-  level_cell* pathFind(int x, int y);
+  void Update(FollowAI& ai, Worm& worm);
+  LevelCell* PathFind(int x, int y);
 };
 
 struct EvaluateResult {
-  EvaluateResult() : futureScore(0.0) {}
+  EvaluateResult() : future_score(0.0) {}
 
-  double weightedScore() const;
+  double WeightedScore() const;
 
-  std::vector<double> scoreOverTime;
-  double futureScore;
+  std::vector<double> score_over_time;
+  double future_score;
 };
 
 struct SimpleAI : WormAI {
-  void process(Game& game, Worm& worm);
+  void Process(Game& game, Worm& worm);
 
   Worm::ControlState initial;
 };
@@ -285,21 +285,21 @@ struct AIThread {
 };
 
 struct CandPlan {
-  CandPlan() : prevResultAge(0) {}
+  CandPlan() : prev_result_age(0) {}
 
   Plan plan;
-  EvaluateResult prevResult;
-  int prevResultAge;
+  EvaluateResult prev_result;
+  int prev_result_age;
 };
 
 struct FollowAI : WormAI, AiContext {
-  FollowAI(Weights weights, int candPopSize, bool testing, FollowAI* targetAiInit = 0)
+  FollowAI(Weights weights, int cand_pop_size, bool testing, FollowAI* target_ai_init = 0)
       : frame(0),
         model(weights, testing),
-        evaluationBudget(0),
-        effectScaler(0),
-        targetAi(targetAiInit),
-        candPlan(candPopSize),
+        evaluation_budget(0),
+        effect_scaler(0),
+        target_ai(target_ai_init),
+        cand_plan(cand_pop_size),
         best(0),
         testing(testing),
         weights(weights)
@@ -312,24 +312,24 @@ struct FollowAI : WormAI, AiContext {
 
   ~FollowAI() {}
 
-  void process(Game& game, Worm& worm);
+  void Process(Game& game, Worm& worm);
 
-  void drawDebug(Game& game, Worm const& worm, Renderer& renderer, int offsX, int offsY);
+  void DrawDebug(Game& game, Worm const& worm, Renderer& renderer, int offs_x, int offs_y);
 
   Rand rand;
   int frame;
-  InputContext currentContext;
+  InputContext current_context;
   TransModel model;
-  int evaluationBudget;
+  int evaluation_budget;
 
-  std::vector<std::tuple<IVec2, PalIdx>> evaluatePositions;
+  std::vector<std::tuple<IVec2, PalIdx>> evaluate_positions;
 
-  std::vector<double> negEffect, posEffect;
-  int effectScaler;
+  std::vector<double> neg_effect, pos_effect;
+  int effect_scaler;
 
-  FollowAI* targetAi;
+  FollowAI* target_ai;
 
-  std::vector<CandPlan> candPlan;
+  std::vector<CandPlan> cand_plan;
   CandPlan* best;
 
   bool testing;

--- a/src/game/ai/work_queue.hpp
+++ b/src/game/ai/work_queue.hpp
@@ -14,66 +14,66 @@ struct LockMutex {
 };
 
 struct Work {
-  Work() : done_(false) {
+  Work() : done(false) {
     mutex = SDL_CreateMutex();
-    stateCond = SDL_CreateCondition();
+    state_cond = SDL_CreateCondition();
   }
 
   virtual ~Work() {
     SDL_DestroyMutex(mutex);
-    SDL_DestroyCondition(stateCond);
+    SDL_DestroyCondition(state_cond);
   }
 
-  bool waitDone() {
+  bool WaitDone() {
     LockMutex m(mutex);
 
-    while (!done_) SDL_WaitCondition(stateCond, mutex);
+    while (!done) SDL_WaitCondition(state_cond, mutex);
 
-    return done_;
+    return done;
   }
 
-  bool done_;
+  bool done;
   SDL_Mutex* mutex;
-  SDL_Condition* stateCond;
+  SDL_Condition* state_cond;
 
-  void run() {
-    doRun();
+  void Run() {
+    DoRun();
 
     {
       LockMutex m(mutex);
 
       SDL_MemoryBarrierAcquire();
-      done_ = true;
+      done = true;
       SDL_MemoryBarrierRelease();
 
-      SDL_SignalCondition(stateCond);
+      SDL_SignalCondition(state_cond);
     }
   }
 
-  virtual void doRun() = 0;
+  virtual void DoRun() = 0;
 };
 
 struct StopWorker {};
 
 struct WorkQueue {
-  WorkQueue(int threadCount) : queueAlive(true) {
-    queueMutex = SDL_CreateMutex();
-    queueCond = SDL_CreateCondition();
+  WorkQueue(int thread_count) : queue_alive(true) {
+    queue_mutex = SDL_CreateMutex();
+    queue_cond = SDL_CreateCondition();
 
     std::memset(threads, 0, sizeof(threads));
-    for (int i = 0; i < threadCount; ++i) {
+    for (int i = 0; i < thread_count; ++i) {
       std::stringstream thread_name;
       thread_name << "ai_" << i;
-      threads[i] = SDL_CreateThread(worker, thread_name.str().c_str(), this);
+      threads[i] = SDL_CreateThread(Worker, thread_name.str().c_str(), this);
     }
   }
 
   ~WorkQueue() {
     {
-      LockMutex m(queueMutex);
+      LockMutex m(queue_mutex);
 
-      queueAlive = false;
-      SDL_BroadcastCondition(queueCond);
+      queue_alive = false;
+      SDL_BroadcastCondition(queue_cond);
     }
 
     for (int i = 0; i < 8; ++i) {
@@ -81,36 +81,36 @@ struct WorkQueue {
       if (threads[i]) SDL_WaitThread(threads[i], &status);
     }
 
-    SDL_DestroyMutex(queueMutex);
-    SDL_DestroyCondition(queueCond);
+    SDL_DestroyMutex(queue_mutex);
+    SDL_DestroyCondition(queue_cond);
   }
 
-  void add(std::unique_ptr<Work> work) {
-    LockMutex m(queueMutex);
+  void Add(std::unique_ptr<Work> work) {
+    LockMutex m(queue_mutex);
     queue.push_back(std::move(work));
-    SDL_SignalCondition(queueCond);
+    SDL_SignalCondition(queue_cond);
   }
 
-  std::unique_ptr<Work> waitForWork() {
-    LockMutex m(queueMutex);
+  std::unique_ptr<Work> WaitForWork() {
+    LockMutex m(queue_mutex);
 
-    while (queue.empty() && queueAlive) SDL_WaitCondition(queueCond, queueMutex);
+    while (queue.empty() && queue_alive) SDL_WaitCondition(queue_cond, queue_mutex);
 
-    if (!queueAlive) throw StopWorker();
+    if (!queue_alive) throw StopWorker();
 
     auto ret = std::move(queue[0]);
     queue.erase(queue.begin());
     return ret;
   }
 
-  static int SDLCALL worker(void* self) {
+  static int SDLCALL Worker(void* self) {
     try {
       WorkQueue* queue = static_cast<WorkQueue*>(self);
 
       while (true) {
-        auto work = queue->waitForWork();
+        auto work = queue->WaitForWork();
 
-        work->run();
+        work->Run();
       }
     } catch (StopWorker&) {
     }
@@ -118,10 +118,10 @@ struct WorkQueue {
     return 0;
   }
 
-  SDL_Mutex* queueMutex;
-  SDL_Condition* queueCond;
+  SDL_Mutex* queue_mutex;
+  SDL_Condition* queue_cond;
   std::vector<std::unique_ptr<Work>> queue;
-  bool queueAlive;
+  bool queue_alive;
 
   SDL_Thread* threads[8];
 };

--- a/src/game/bobject.cpp
+++ b/src/game/bobject.cpp
@@ -4,40 +4,40 @@
 #include "game.hpp"
 #include "gfx/color.hpp"
 
-void Game::createBObject(fixedvec pos, fixedvec vel) {
+void Game::CreateBObject(fixedvec pos, fixedvec vel) {
   Common& common = *this->common;
 
-  BObject& obj = *bobjects.newObjectReuse();
+  BObject& obj = *bobjects.NewObjectReuse();
 
   obj.color = rand(LC(NumBloodColours)) + LC(FirstBloodColour);
   obj.pos = pos;
   obj.vel = vel;
 }
 
-bool BObject::process(Game& game) {
+bool BObject::Process(Game& game) {
   Common& common = *game.common;
 
   pos += vel;
 
-  auto ipos = ftoi(pos);
+  auto ipos = Ftoi(pos);
 
-  if (!game.level.inside(ipos)) {
+  if (!game.level.Inside(ipos)) {
     return false;
   } else {
-    PalIdx c = game.level.pixel(ipos);
-    Material m = game.level.mat(ipos);
+    PalIdx c = game.level.Pixel(ipos);
+    Material m = game.level.Mat(ipos);
 
-    if (m.background()) vel.y += LC(BObjGravity);
+    if (m.Background()) vel.y += LC(BObjGravity);
 
     if ((c >= 1 && c <= 2) || (c >= 77 && c <= 79))  // TODO: Read from EXE
     {
-      game.level.setPixel(ipos, 77 + game.rand(3), common);
+      game.level.SetPixel(ipos, 77 + game.rand(3), common);
       return false;
-    } else if (m.anyDirt()) {
-      game.level.setPixel(ipos, 82 + game.rand(3), common);
+    } else if (m.AnyDirt()) {
+      game.level.SetPixel(ipos, 82 + game.rand(3), common);
       return false;
-    } else if (m.rock()) {
-      game.level.setPixel(ipos, 85 + game.rand(3), common);
+    } else if (m.Rock()) {
+      game.level.SetPixel(ipos, 85 + game.rand(3), common);
       return false;
     }
   }

--- a/src/game/bobject.hpp
+++ b/src/game/bobject.hpp
@@ -9,7 +9,7 @@ struct Game;
  * Blood Object
  */
 struct BObject {
-  bool process(Game& game);
+  bool Process(Game& game);
 
   fixedvec pos, vel;
   int color;

--- a/src/game/bonus.cpp
+++ b/src/game/bonus.cpp
@@ -3,29 +3,29 @@
 #include "constants.hpp"
 #include "game.hpp"
 
-void Bonus::process(Game& game) {
+void Bonus::Process(Game& game) {
   Common& common = *game.common;
 
-  y += velY;
+  y += vel_y;
 
-  int ix = ftoi(x), iy = ftoi(y);
+  int ix = Ftoi(x), iy = Ftoi(y);
 
   assert(ix >= 0 && ix < game.level.width);
 
-  if (game.level.inside(ix, iy + 1) && game.level.mat(ix, iy + 1).background()) {
-    velY += LC(BonusGravity);
+  if (game.level.Inside(ix, iy + 1) && game.level.Mat(ix, iy + 1).Background()) {
+    vel_y += LC(BonusGravity);
   }
 
-  int inewY = ftoi(y + velY);
-  if (inewY < 0 || inewY >= game.level.height - 1 || game.level.mat(ix, inewY).dirtRock()) {
-    velY = -(velY * LC(BonusBounceMul)) / LC(BonusBounceDiv);
+  int inew_y = Ftoi(y + vel_y);
+  if (inew_y < 0 || inew_y >= game.level.height - 1 || game.level.Mat(ix, inew_y).DirtRock()) {
+    vel_y = -(vel_y * LC(BonusBounceMul)) / LC(BonusBounceDiv);
 
-    if (std::abs(velY) < 100)  // TODO: Read from EXE
-      velY = 0;
+    if (std::abs(vel_y) < 100)  // TODO: Read from EXE
+      vel_y = 0;
   }
 
   if (--timer <= 0) {
-    common.sobjectTypes[common.bonusSObjects[frame]].create(game, ix, iy, 0, 0);
-    if (used) game.bonuses.free(this);
+    common.sobject_types[common.bonus_s_objects[frame]].Create(game, ix, iy, 0, 0);
+    if (used) game.bonuses.Free(this);
   }
 }

--- a/src/game/bonus.hpp
+++ b/src/game/bonus.hpp
@@ -6,14 +6,14 @@
 struct Game;
 
 struct Bonus : ExactObjectListBase {
-  Bonus() : frame(-1), x(0), y(0), velY(0), timer(0), weapon(0) {}
+  Bonus() : frame(-1), x(0), y(0), vel_y(0), timer(0), weapon(0) {}
 
   fixed x;
   fixed y;
-  fixed velY;
+  fixed vel_y;
   int frame;
   int timer;
   int weapon;
 
-  void process(Game& game);
+  void Process(Game& game);
 };

--- a/src/game/common.cpp
+++ b/src/game/common.cpp
@@ -12,15 +12,15 @@
 #include "rand.hpp"
 #include "worm.hpp"
 
-int Common::fireConeOffset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
+int Common::fire_cone_offset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
                           [FIRE_CONE_OFFSET_XY] = {
                               {{-3, 1}, {-4, 0}, {-4, -2}, {-4, -4}, {-3, -5}, {-2, -6}, {0, -6}},
                               {{3, 1}, {4, 0}, {4, -2}, {4, -4}, {3, -5}, {2, -6}, {0, -6}},
 };
 
-int stoneTab[3][4] = {{98, 60, 61, 62}, {63, 75, 85, 86}, {89, 90, 97, 96}};
+int stone_tab[3][4] = {{98, 60, 61, 62}, {63, 75, 85, 86}, {89, 90, 97, 96}};
 
-char const* Texts::keyNames[177] = {
+char const* Texts::key_names[177] = {
     "",
     "Esc",
     "1",
@@ -201,10 +201,10 @@ char const* Texts::keyNames[177] = {
 };
 
 Texts::Texts() {
-  gameModes[Settings::GameModes::GMKillEmAll] = "Kill'em All";
-  gameModes[Settings::GameModes::GMGameOfTag] = "Game of Tag";
-  gameModes[Settings::GameModes::GMHoldazone] = "Holdazone";
-  gameModes[Settings::GameModes::GMScalesOfJustice] = "Scales of Justice";
+  game_modes[Settings::GameModes::kGmKillEmAll] = "Kill'em All";
+  game_modes[Settings::GameModes::kGmGameOfTag] = "Game of Tag";
+  game_modes[Settings::GameModes::kGmHoldazone] = "Holdazone";
+  game_modes[Settings::GameModes::kGmScalesOfJustice] = "Scales of Justice";
 
   onoff[0] = "OFF";
   onoff[1] = "ON";
@@ -213,23 +213,23 @@ Texts::Texts() {
   controllers[1] = "CPU";
   controllers[2] = "AI";
 
-  inputDevices[0] = "Keyboard";
-  inputDevices[1] = "Joystick 1";
-  inputDevices[2] = "Joystick 2";
+  input_devices[0] = "Keyboard";
+  input_devices[1] = "Joystick 1";
+  input_devices[2] = "Joystick 2";
 
-  weapStates[0] = "Menu";
-  weapStates[1] = "Bonus";
-  weapStates[2] = "Banned";
+  weap_states[0] = "Menu";
+  weap_states[1] = "Bonus";
+  weap_states[2] = "Banned";
 
-  copyrightBarFormat = 64;
+  copyright_bar_format = 64;
 }
 
-void Common::drawTextSmall(Bitmap& scr, char const* str, int x, int y) {
+void Common::DrawTextSmall(Bitmap& scr, char const* str, int x, int y) {
   for (; *str; ++str) {
     unsigned char c = *str - 'A';
 
     if (c < 26) {
-      blitImage(scr, textSprites[c], x, y);
+      BlitImage(scr, text_sprites[c], x, y);
     }
 
     x += 4;
@@ -239,47 +239,47 @@ void Common::drawTextSmall(Bitmap& scr, char const* str, int x, int y) {
 #define CHECK(c) \
   if (!(c)) goto fail
 
-int readSpriteTga(io::Reader& r, int destImageWidth, int destImageHeight, int destCount,
+int ReadSpriteTga(io::Reader& r, int dest_image_width, int dest_image_height, int dest_count,
                   uint8_t* data, Palette* pal) {
-  auto idLen = r.get();
-  CHECK(r.get() == 1);
-  CHECK(r.get() == 1);
+  auto id_len = r.Get();
+  CHECK(r.Get() == 1);
+  CHECK(r.Get() == 1);
 
   // Palette spec
-  CHECK(io::read_uint16_le(r) == 0);
-  CHECK(io::read_uint16_le(r) == 256);
-  CHECK(r.get() == 24);
+  CHECK(io::ReadUint16Le(r) == 0);
+  CHECK(io::ReadUint16Le(r) == 256);
+  CHECK(r.Get() == 24);
 
-  int imageWidth, imageHeight;
+  int image_width, image_height;
 
-  CHECK(io::read_uint16_le(r) == 0);
-  CHECK(io::read_uint16_le(r) == 0);
+  CHECK(io::ReadUint16Le(r) == 0);
+  CHECK(io::ReadUint16Le(r) == 0);
 
-  imageWidth = io::read_uint16_le(r);
-  imageHeight = io::read_uint16_le(r);
-  CHECK(r.get() == 8);
-  CHECK(r.get() == 0);
+  image_width = io::ReadUint16Le(r);
+  image_height = io::ReadUint16Le(r);
+  CHECK(r.Get() == 8);
+  CHECK(r.Get() == 0);
 
-  r.try_skip(idLen);  // Skip ID
+  r.TrySkip(id_len);  // Skip ID
 
   // TODO: Support more sprites?
-  CHECK(imageWidth == destImageWidth);
-  CHECK(imageHeight == destImageHeight);
+  CHECK(image_width == dest_image_width);
+  CHECK(image_height == dest_image_height);
 
   if (pal) {
     for (auto& entry : pal->entries) {
-      entry.b = r.get() >> 2;
-      entry.g = r.get() >> 2;
-      entry.r = r.get() >> 2;
+      entry.b = r.Get() >> 2;
+      entry.g = r.Get() >> 2;
+      entry.r = r.Get() >> 2;
     }
   } else {
-    r.try_skip(256 * 3);  // Ignore palette
+    r.TrySkip(256 * 3);  // Ignore palette
   }
 
   // Bottom to top
-  for (std::size_t y = (std::size_t)imageHeight; y-- > 0;) {
-    auto* src = &data[y * imageWidth];
-    r.get((uint8_t*)src, imageWidth);
+  for (std::size_t y = (std::size_t)image_height; y-- > 0;) {
+    auto* src = &data[y * image_width];
+    r.Get((uint8_t*)src, image_width);
   }
 
   return 1;
@@ -288,65 +288,65 @@ fail:
   return 0;
 }
 
-int readSpriteTga(io::Reader& r, SpriteSet& ss, Palette* pal) {
-  return readSpriteTga(r, ss.width, ss.count * ss.height, ss.count, &ss.data[0], pal);
+int ReadSpriteTga(io::Reader& r, SpriteSet& ss, Palette* pal) {
+  return ReadSpriteTga(r, ss.width, ss.count * ss.height, ss.count, &ss.data[0], pal);
 }
 
 #undef CHECK
 
-inline uint32_t quad(char a, char b, char c, char d) {
+inline uint32_t Quad(char a, char b, char c, char d) {
   return (uint32_t)a + ((uint32_t)b << 8) + ((uint32_t)c << 16) + ((uint32_t)d << 24);
 }
 
 void Common::load(FsNode node) {
   {
-    auto textReader_ptr = (node / "tc.cfg").toReader();
-    io::Reader& textReader = *textReader_ptr;
+    auto text_reader_ptr = (node / "tc.cfg").ToReader();
+    io::Reader& text_reader = *text_reader_ptr;
     // Read entire content into a string for istringstream
     std::string content;
     try {
-      for (;;) content.push_back(static_cast<char>(textReader.get()));
+      for (;;) content.push_back(static_cast<char>(text_reader.Get()));
     } catch (std::runtime_error&) {
     }
     std::istringstream is(content);
-    loadTcConfig(*this, is);
+    LoadTcConfig(*this, is);
   }
 
   for (auto& s : sounds) {
     auto dir = node / "sounds";
 
-    auto wavNode = dir / (s.name + ".wav");
-    if (!wavNode.exists()) {
+    auto wav_node = dir / (s.name + ".wav");
+    if (!wav_node.Exists()) {
       // Missing WAV on disk: keep the slot (preserving stable indices for
       // siblings) but leave sound == nullptr so play paths treat it as a
       // silent no-op. Matches the disabled-slot behavior of tc_tool's
       // loadSfx (see issue #44).
-      Console::writeWarning("Sound file missing, slot will be silent: " + s.name + ".wav");
+      console::WriteWarning("Sound file missing, slot will be silent: " + s.name + ".wav");
       continue;
     }
-    auto r_ptr = wavNode.toReader();
+    auto r_ptr = wav_node.ToReader();
     io::Reader& r = *r_ptr;
 
-    if (io::read_uint32_le(r) == quad('R', 'I', 'F', 'F')) {
-      std::size_t roundedSize = io::read_uint32_le(r) + 8;
+    if (io::ReadUint32Le(r) == Quad('R', 'I', 'F', 'F')) {
+      std::size_t rounded_size = io::ReadUint32Le(r) + 8;
 
-      (void)roundedSize;  // Ignore
+      (void)rounded_size;  // Ignore
 
-      if (io::read_uint32_le(r) == quad('W', 'A', 'V', 'E') &&
-          io::read_uint32_le(r) == quad('f', 'm', 't', ' ') && io::read_uint32_le(r) == 16 &&
-          io::read_uint16_le(r) == 1 && io::read_uint16_le(r) == 1 &&
-          io::read_uint32_le(r) == 22050 && io::read_uint32_le(r) == 22050 * 1 * 1 &&
-          io::read_uint16_le(r) == 1 * 1 && io::read_uint16_le(r) == 8 &&
-          io::read_uint32_le(r) == quad('d', 'a', 't', 'a')) {
-        std::size_t dataSize = io::read_uint32_le(r);
+      if (io::ReadUint32Le(r) == Quad('W', 'A', 'V', 'E') &&
+          io::ReadUint32Le(r) == Quad('f', 'm', 't', ' ') && io::ReadUint32Le(r) == 16 &&
+          io::ReadUint16Le(r) == 1 && io::ReadUint16Le(r) == 1 &&
+          io::ReadUint32Le(r) == 22050 && io::ReadUint32Le(r) == 22050 * 1 * 1 &&
+          io::ReadUint16Le(r) == 1 * 1 && io::ReadUint16Le(r) == 8 &&
+          io::ReadUint32Le(r) == Quad('d', 'a', 't', 'a')) {
+        std::size_t data_size = io::ReadUint32Le(r);
 
-        s.originalData.resize(dataSize);
+        s.original_data.resize(data_size);
 
-        for (auto& z : s.originalData) z = r.get() - 128;
+        for (auto& z : s.original_data) z = r.Get() - 128;
 
-        s.sound = sfx_new_sound(dataSize * 2);
+        s.sound = SfxNewSound(data_size * 2);
 
-        s.createSound();
+        s.CreateSound();
       }
     }
   }
@@ -354,36 +354,36 @@ void Common::load(FsNode node) {
   {
     auto dir = node / "sprites";
 
-    largeSprites.allocate(16, 16, 110);
-    smallSprites.allocate(7, 7, 130);
-    textSprites.allocate(4, 4, 26);
+    large_sprites.Allocate(16, 16, 110);
+    small_sprites.Allocate(7, 7, 130);
+    text_sprites.Allocate(4, 4, 26);
 
     {
-      auto r_ptr = (dir / "small.tga").toReader();
+      auto r_ptr = (dir / "small.tga").ToReader();
       io::Reader& r = *r_ptr;
 
-      readSpriteTga(r, smallSprites, &exepal);
+      ReadSpriteTga(r, small_sprites, &exepal);
     }
 
     {
-      auto r_ptr = (dir / "large.tga").toReader();
+      auto r_ptr = (dir / "large.tga").ToReader();
       io::Reader& r = *r_ptr;
-      readSpriteTga(r, largeSprites, 0);
+      ReadSpriteTga(r, large_sprites, 0);
     }
 
     {
-      auto r_ptr = (dir / "text.tga").toReader();
+      auto r_ptr = (dir / "text.tga").ToReader();
       io::Reader& r = *r_ptr;
-      readSpriteTga(r, textSprites, 0);
+      ReadSpriteTga(r, text_sprites, 0);
     }
 
     {
-      auto r_ptr = (dir / "font.tga").toReader();
+      auto r_ptr = (dir / "font.tga").ToReader();
       io::Reader& r = *r_ptr;
 
       std::vector<uint8_t> data(font.chars.size() * 7 * 8, 10);
 
-      readSpriteTga(r, 7, (int)font.chars.size() * 8, (int)font.chars.size(), &data[0], 0);
+      ReadSpriteTga(r, 7, (int)font.chars.size() * 8, (int)font.chars.size(), &data[0], 0);
 
       for (std::size_t i = 0; i < font.chars.size(); ++i) {
         Font::Char& ch = font.chars[i];
@@ -410,112 +410,112 @@ void Common::load(FsNode node) {
   for (auto& w : weapons) {
     auto dir = node / "weapons";
 
-    auto wReader_ptr = (dir / (w.idStr + ".cfg")).toReader();
-    io::Reader& wReader = *wReader_ptr;
+    auto w_reader_ptr = (dir / (w.id_str + ".cfg")).ToReader();
+    io::Reader& w_reader = *w_reader_ptr;
     std::string content;
     try {
-      for (;;) content.push_back(static_cast<char>(wReader.get()));
+      for (;;) content.push_back(static_cast<char>(w_reader.Get()));
     } catch (std::runtime_error&) {
     }
     std::istringstream is(content);
-    loadWeaponConfig(*this, w, is);
+    LoadWeaponConfig(*this, w, is);
   }
 
-  for (auto& w : nobjectTypes) {
+  for (auto& w : nobject_types) {
     auto dir = node / "nobjects";
 
-    auto nReader_ptr = (dir / (w.idStr + ".cfg")).toReader();
-    io::Reader& nReader = *nReader_ptr;
+    auto n_reader_ptr = (dir / (w.id_str + ".cfg")).ToReader();
+    io::Reader& n_reader = *n_reader_ptr;
     std::string content;
     try {
-      for (;;) content.push_back(static_cast<char>(nReader.get()));
+      for (;;) content.push_back(static_cast<char>(n_reader.Get()));
     } catch (std::runtime_error&) {
     }
     std::istringstream is(content);
-    loadNObjectConfig(*this, w, is);
+    LoadNObjectConfig(*this, w, is);
   }
 
-  for (auto& w : sobjectTypes) {
+  for (auto& w : sobject_types) {
     auto dir = node / "sobjects";
 
-    auto sReader_ptr = (dir / (w.idStr + ".cfg")).toReader();
-    io::Reader& sReader = *sReader_ptr;
+    auto s_reader_ptr = (dir / (w.id_str + ".cfg")).ToReader();
+    io::Reader& s_reader = *s_reader_ptr;
     std::string content;
     try {
-      for (;;) content.push_back(static_cast<char>(sReader.get()));
+      for (;;) content.push_back(static_cast<char>(s_reader.Get()));
     } catch (std::runtime_error&) {
     }
     std::istringstream is(content);
-    loadSObjectConfig(*this, w, is);
+    LoadSObjectConfig(*this, w, is);
   }
 
-  precompute();
+  Precompute();
 }
 
-void Common::precompute() {
-  weapOrder.resize(weapons.size());
+void Common::Precompute() {
+  weap_order.resize(weapons.size());
   for (int i = 0; i < (int)weapons.size(); ++i) {
-    weapOrder[i] = i;
+    weap_order[i] = i;
     weapons[i].id = i;
   }
 
-  std::sort(weapOrder.begin(), weapOrder.end(),
+  std::sort(weap_order.begin(), weap_order.end(),
             [&](int a, int b) { return this->weapons[a].name < this->weapons[b].name; });
 
-  for (int i = 0; i < (int)nobjectTypes.size(); ++i) {
-    nobjectTypes[i].id = i;
+  for (int i = 0; i < (int)nobject_types.size(); ++i) {
+    nobject_types[i].id = i;
   }
 
-  for (int i = 0; i < (int)sobjectTypes.size(); ++i) {
-    sobjectTypes[i].id = i;
+  for (int i = 0; i < (int)sobject_types.size(); ++i) {
+    sobject_types[i].id = i;
   }
 
   // Precompute sprites
-  wormSprites.allocate(16, 16, 2 * 2 * 21);
+  worm_sprites.Allocate(16, 16, 2 * 2 * 21);
 
   for (int i = 0; i < 21; ++i) {
     for (int y = 0; y < 16; ++y)
       for (int x = 0; x < 16; ++x) {
-        PalIdx pix = (largeSprites.spritePtr(16 + i) + y * 16)[x];
+        PalIdx pix = (large_sprites.SpritePtr(16 + i) + y * 16)[x];
 
-        (wormSprite(i, 1, 0) + y * 16)[x] = pix;
+        (WormSprite(i, 1, 0) + y * 16)[x] = pix;
         if (x == 15)
-          (wormSprite(i, 0, 0) + y * 16)[15] = 0;
+          (WormSprite(i, 0, 0) + y * 16)[15] = 0;
         else
-          (wormSprite(i, 0, 0) + y * 16)[14 - x] = pix;
+          (WormSprite(i, 0, 0) + y * 16)[14 - x] = pix;
 
         if (pix >= 30 && pix <= 34) pix += 9;  // Change worm color
 
-        (wormSprite(i, 1, 1) + y * 16)[x] = pix;
+        (WormSprite(i, 1, 1) + y * 16)[x] = pix;
 
         if (x == 15)
-          (wormSprite(i, 0, 1) + y * 16)[15] = 0;  // A bit haxy, but works
+          (WormSprite(i, 0, 1) + y * 16)[15] = 0;  // A bit haxy, but works
         else
-          (wormSprite(i, 0, 1) + y * 16)[14 - x] = pix;
+          (WormSprite(i, 0, 1) + y * 16)[14 - x] = pix;
       }
   }
 
-  fireConeSprites.allocate(16, 16, 2 * 7);
+  fire_cone_sprites.Allocate(16, 16, 2 * 7);
 
   for (int i = 0; i < 7; ++i) {
     for (int y = 0; y < 16; ++y)
       for (int x = 0; x < 16; ++x) {
-        PalIdx pix = (largeSprites.spritePtr(9 + i) + y * 16)[x];
+        PalIdx pix = (large_sprites.SpritePtr(9 + i) + y * 16)[x];
 
-        (fireConeSprite(i, 1) + y * 16)[x] = pix;
+        (FireConeSprite(i, 1) + y * 16)[x] = pix;
 
         if (x == 15)
-          (fireConeSprite(i, 0) + y * 16)[15] = 0;
+          (FireConeSprite(i, 0) + y * 16)[15] = 0;
         else
-          (fireConeSprite(i, 0) + y * 16)[14 - x] = pix;
+          (FireConeSprite(i, 0) + y * 16)[14 - x] = pix;
       }
   }
 }
 
 Common::Common() {}
 
-std::string Common::guessName() const {
-  std::string const& cp = S[SCopyright2];
+std::string Common::GuessName() const {
+  std::string const& cp = s[SCopyright2];
   auto p = cp.find('(');
   if (p == std::string::npos) p = cp.size();
 
@@ -524,24 +524,24 @@ std::string Common::guessName() const {
   return cp.substr(0, p);
 }
 
-int Common::soundIndex(std::string_view name) const {
+int Common::SoundIndex(std::string_view name) const {
   for (std::size_t i = 0; i < sounds.size(); ++i) {
     if (sounds[i].name == name) return static_cast<int>(i);
   }
   return -1;
 }
 
-void SfxSample::createSound() {
-  if (originalData.empty()) return;
+void SfxSample::CreateSound() {
+  if (original_data.empty()) return;
 
-  std::vector<int16_t>& samples = sfx_sound_data(sound);
+  std::vector<int16_t>& samples = SfxSoundData(sound);
   samples.clear();
 
-  int prev = static_cast<int8_t>(originalData[0]) * 30;
+  int prev = static_cast<int8_t>(original_data[0]) * 30;
   samples.push_back(prev);
 
-  for (std::size_t j = 1; j < originalData.size(); ++j) {
-    int cur = static_cast<int8_t>(originalData[j]) * 30;
+  for (std::size_t j = 1; j < original_data.size(); ++j) {
+    int cur = static_cast<int8_t>(original_data[j]) * 30;
     samples.push_back((prev + cur) / 2);
     samples.push_back(cur);
     prev = cur;

--- a/src/game/common.cpp
+++ b/src/game/common.cpp
@@ -13,9 +13,9 @@
 #include "worm.hpp"
 
 int Common::fire_cone_offset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
-                          [FIRE_CONE_OFFSET_XY] = {
-                              {{-3, 1}, {-4, 0}, {-4, -2}, {-4, -4}, {-3, -5}, {-2, -6}, {0, -6}},
-                              {{3, 1}, {4, 0}, {4, -2}, {4, -4}, {3, -5}, {2, -6}, {0, -6}},
+                            [FIRE_CONE_OFFSET_XY] = {
+                                {{-3, 1}, {-4, 0}, {-4, -2}, {-4, -4}, {-3, -5}, {-2, -6}, {0, -6}},
+                                {{3, 1}, {4, 0}, {4, -2}, {4, -4}, {3, -5}, {2, -6}, {0, -6}},
 };
 
 int stone_tab[3][4] = {{98, 60, 61, 62}, {63, 75, 85, 86}, {89, 90, 97, 96}};
@@ -334,10 +334,9 @@ void Common::load(FsNode node) {
 
       if (io::ReadUint32Le(r) == Quad('W', 'A', 'V', 'E') &&
           io::ReadUint32Le(r) == Quad('f', 'm', 't', ' ') && io::ReadUint32Le(r) == 16 &&
-          io::ReadUint16Le(r) == 1 && io::ReadUint16Le(r) == 1 &&
-          io::ReadUint32Le(r) == 22050 && io::ReadUint32Le(r) == 22050 * 1 * 1 &&
-          io::ReadUint16Le(r) == 1 * 1 && io::ReadUint16Le(r) == 8 &&
-          io::ReadUint32Le(r) == Quad('d', 'a', 't', 'a')) {
+          io::ReadUint16Le(r) == 1 && io::ReadUint16Le(r) == 1 && io::ReadUint32Le(r) == 22050 &&
+          io::ReadUint32Le(r) == 22050 * 1 * 1 && io::ReadUint16Le(r) == 1 * 1 &&
+          io::ReadUint16Le(r) == 8 && io::ReadUint32Le(r) == Quad('d', 'a', 't', 'a')) {
         std::size_t data_size = io::ReadUint32Le(r);
 
         s.original_data.resize(data_size);

--- a/src/game/common.hpp
+++ b/src/game/common.hpp
@@ -38,15 +38,15 @@ materials on the map (especially with dirt).
 */
 struct Texture {
   bool n_draw_back;  // 1C208; causes Liero not to draw the anti-alias edges on the background.
-                   // Normally turned "false" for creating dirt and rock & turned "true" for
-                   // cleaning dirt.
-  int m_frame;      // 1C1EA; controls which sprite is used to cut a hole (= determines the size and
-                   // shape of the hole).
-  int s_frame;      // 1C1F4; the texture the map change will leave behind (= which sprite is used to
-                   // fill the hole).
-  int r_frame;  // 1C1FE; the amount of sprites to use to fill the hole (starting from sFrame). Note:
-               // if you set 0 or 1, then only 1 sprite will be used to fill the hole (the one
-               // indicated in sFrame).
+                     // Normally turned "false" for creating dirt and rock & turned "true" for
+                     // cleaning dirt.
+  int m_frame;  // 1C1EA; controls which sprite is used to cut a hole (= determines the size and
+                // shape of the hole).
+  int s_frame;  // 1C1F4; the texture the map change will leave behind (= which sprite is used to
+                // fill the hole).
+  int r_frame;  // 1C1FE; the amount of sprites to use to fill the hole (starting from sFrame).
+                // Note: if you set 0 or 1, then only 1 sprite will be used to fill the hole (the
+                // one indicated in sFrame).
 };
 
 struct Texts {
@@ -126,7 +126,7 @@ struct Common {
   ~Common() {}
 
   static int fire_cone_offset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
-                           [FIRE_CONE_OFFSET_XY];
+                             [FIRE_CONE_OFFSET_XY];
 
   void load(FsNode node);
   void DrawTextSmall(Bitmap& scr, char const* str, int x, int y);

--- a/src/game/common.hpp
+++ b/src/game/common.hpp
@@ -27,7 +27,7 @@
 #define NUM_GAME_MODES 4
 #define NUM_ON_OFF 2
 
-extern int stoneTab[3][4];
+extern int stone_tab[3][4];
 
 /* Textures sourced from [[constants.textures]] in tc.cfg */
 /*
@@ -37,14 +37,14 @@ all objects (wObjects, nObjects, sObjects) and worm (via dirtEffect 0 and 7) int
 materials on the map (especially with dirt).
 */
 struct Texture {
-  bool nDrawBack;  // 1C208; causes Liero not to draw the anti-alias edges on the background.
+  bool n_draw_back;  // 1C208; causes Liero not to draw the anti-alias edges on the background.
                    // Normally turned "false" for creating dirt and rock & turned "true" for
                    // cleaning dirt.
-  int mFrame;      // 1C1EA; controls which sprite is used to cut a hole (= determines the size and
+  int m_frame;      // 1C1EA; controls which sprite is used to cut a hole (= determines the size and
                    // shape of the hole).
-  int sFrame;      // 1C1F4; the texture the map change will leave behind (= which sprite is used to
+  int s_frame;      // 1C1F4; the texture the map change will leave behind (= which sprite is used to
                    // fill the hole).
-  int rFrame;  // 1C1FE; the amount of sprites to use to fill the hole (starting from sFrame). Note:
+  int r_frame;  // 1C1FE; the amount of sprites to use to fill the hole (starting from sFrame). Note:
                // if you set 0 or 1, then only 1 sprite will be used to fill the hole (the one
                // indicated in sFrame).
 };
@@ -52,16 +52,16 @@ struct Texture {
 struct Texts {
   Texts();
 
-  std::string gameModes[Settings::GameModes::MaxGameModes];
+  std::string game_modes[Settings::GameModes::kMaxGameModes];
   std::string onoff[NUM_ON_OFF];
   std::string controllers[3];
-  std::string inputDevices[3];
+  std::string input_devices[3];
 
-  static char const* keyNames[177];
+  static char const* key_names[177];
 
-  std::string weapStates[NUM_WEAPON_STATES];
+  std::string weap_states[NUM_WEAPON_STATES];
 
-  int copyrightBarFormat;
+  int copyright_bar_format;
 };
 
 /* Colour animations sourced from [[constants.colorAnim]] in tc.cfg */
@@ -84,7 +84,7 @@ struct SfxSample {
   SfxSample(SfxSample&& other)
       : name(std::move(other.name)),
         sound(other.sound),
-        originalData(std::move(other.originalData)) {
+        original_data(std::move(other.original_data)) {
     other.sound = 0;
   }
 
@@ -92,27 +92,27 @@ struct SfxSample {
     name = std::move(other.name);
     sound = other.sound;
     sound = 0;
-    originalData = std::move(other.originalData);
+    original_data = std::move(other.original_data);
     return *this;
   }
 
   SfxSample(std::string name, int length)
-      : name(std::move(name)), sound(nullptr), originalData(length) {
+      : name(std::move(name)), sound(nullptr), original_data(length) {
     // A zero-length sample is a "disabled" slot. Leave `sound` null so
     // the slot survives in `Common::sounds` without occupying audio
     // memory, and so play paths can treat it as a silent no-op.
-    if (length > 0) sound = sfx_new_sound(length * 2);
+    if (length > 0) sound = SfxNewSound(length * 2);
   }
 
   ~SfxSample() {
-    if (sound) sfx_free_sound(sound);
+    if (sound) SfxFreeSound(sound);
   }
 
-  void createSound();
+  void CreateSound();
 
   std::string name;
   sfx_sound* sound;
-  std::vector<uint8_t> originalData;
+  std::vector<uint8_t> original_data;
 };
 
 struct Bitmap;
@@ -125,65 +125,65 @@ struct Common {
 
   ~Common() {}
 
-  static int fireConeOffset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
+  static int fire_cone_offset[FIRE_CONE_OFFSET_DIRECTION][FIRE_CONE_OFFSET_ANGLE_FRAME]
                            [FIRE_CONE_OFFSET_XY];
 
   void load(FsNode node);
-  void drawTextSmall(Bitmap& scr, char const* str, int x, int y);
-  void precompute();
+  void DrawTextSmall(Bitmap& scr, char const* str, int x, int y);
+  void Precompute();
 
-  std::string guessName() const;
+  std::string GuessName() const;
 
   // Returns the index of the named sound in `sounds`, or -1 if absent.
   // -1 is the existing "no sound" sentinel used at play sites.
-  int soundIndex(std::string_view name) const;
+  int SoundIndex(std::string_view name) const;
 
-  PalIdx* wormSprite(int f, int dir, int w) {
-    return wormSprites.spritePtr(f + dir * 7 * 3 + w * 2 * 7 * 3);
+  PalIdx* WormSprite(int f, int dir, int w) {
+    return worm_sprites.SpritePtr(f + dir * 7 * 3 + w * 2 * 7 * 3);
   }
 
-  Sprite wormSpriteObj(int f, int dir, int w) {
-    return wormSprites[f + dir * 7 * 3 + w * 2 * 7 * 3];
+  Sprite WormSpriteObj(int f, int dir, int w) {
+    return worm_sprites[f + dir * 7 * 3 + w * 2 * 7 * 3];
   }
 
-  PalIdx* fireConeSprite(int f, int dir) { return fireConeSprites.spritePtr(f + dir * 7); }
+  PalIdx* FireConeSprite(int f, int dir) { return fire_cone_sprites.SpritePtr(f + dir * 7); }
 
   // Computed
   Texts texts;
-  vector<int> weapOrder;
-  SpriteSet wormSprites;
-  SpriteSet fireConeSprites;
+  vector<int> weap_order;
+  SpriteSet worm_sprites;
+  SpriteSet fire_cone_sprites;
 
   Material materials[MAX_MATERIALS];
   Texture textures[NUM_TEXTURES];
   vector<Weapon> weapons;
-  vector<SObjectType> sobjectTypes;
-  vector<NObjectType> nobjectTypes;
+  vector<SObjectType> sobject_types;
+  vector<NObjectType> nobject_types;
   /* Randomized timer values for Bonus SObjects. Sourced from
    * [[constants.bonuses]] in tc.cfg (timer/timerV) */
-  int bonusRandTimer[NUM_BONUS_SOBJECTS][NUM_BONUS_TIMER_VALUES];
+  int bonus_rand_timer[NUM_BONUS_SOBJECTS][NUM_BONUS_TIMER_VALUES];
   /* Bonus SObjects. Sourced from [[constants.bonuses]] in tc.cfg (sobj) */
-  int bonusSObjects[NUM_BONUS_SOBJECTS];
+  int bonus_s_objects[NUM_BONUS_SOBJECTS];
   /* AI parameters. Sourced from [[constants.aiparams.$KEY]] in tc.cfg */
-  AIParams aiParams;
+  AIParams ai_params;
   /* Colour Animations. Sourced from [[constants.colorAnim]] in tc.cfg (from/to) */
-  ColourAnim colorAnim[NUM_COLOR_ANIM];
+  ColourAnim color_anim[NUM_COLOR_ANIM];
   /* Bonus frames. Sourced from [[constants.bonuses]] in tc.cfg (frame) */
-  int bonusFrames[NUM_BONUS_SOBJECTS];
+  int bonus_frames[NUM_BONUS_SOBJECTS];
   // all sprite sets sourced from TC/$NAME/sprites
 
-  SpriteSet smallSprites;  // 7x7, sprites 110-239
-  SpriteSet largeSprites;  // 16x16, sprites 0-109
-  SpriteSet textSprites;   // 4x4, sprites 240-265
+  SpriteSet small_sprites;  // 7x7, sprites 110-239
+  SpriteSet large_sprites;  // 16x16, sprites 0-109
+  SpriteSet text_sprites;   // 4x4, sprites 240-265
   Palette exepal;
   Font font;
   vector<SfxSample> sounds;
 
-  int32_t C[CONST_DEF_T::MaxC];
-  std::string S[STRING_DEF_T::MaxS];
-  bool H[HACK_DEF_T::MaxH];
+  int32_t c[ConstDefT::kMaxC];
+  std::string s[StringDefT::kMaxS];
+  bool h[HackDefT::kMaxH];
   // Indices into `sounds` for engine-played sounds. -1 if not configured.
-  int soundHook[SOUND_DEF_T::MaxSound] = {
+  int sound_hook[SoundDefT::kMaxSound] = {
 #define INIT_SOUNDHOOK(n) -1,
       LIERO_SOUNDDEFS(INIT_SOUNDHOOK)
 #undef INIT_SOUNDHOOK

--- a/src/game/common_model.hpp
+++ b/src/game/common_model.hpp
@@ -13,314 +13,314 @@
 
 // Cross-reference resolution helpers
 template <typename T>
-inline std::string objRefToStr(int idx, std::vector<T> const& vec) {
+inline std::string ObjRefToStr(int idx, std::vector<T> const& vec) {
   if (idx < 0 || idx >= (int)vec.size()) return "";
-  return vec[idx].idStr;
+  return vec[idx].id_str;
 }
 
 template <typename T>
-inline int objRefFromStr(std::string const& str, std::vector<T> const& vec) {
+inline int ObjRefFromStr(std::string const& str, std::vector<T> const& vec) {
   if (str.empty()) return -1;
   for (std::size_t i = 0; i < vec.size(); ++i)
-    if (vec[i].idStr == str) return (int)i;
+    if (vec[i].id_str == str) return (int)i;
   return 0;
 }
 
 // Sound-ref helpers: distinct from objRefFromStr because an unknown
 // non-empty name must resolve to -1 (no sound), not 0 (would spuriously
 // play the first sound).
-inline std::string soundRefToStr(int idx, Common const& common) {
+inline std::string SoundRefToStr(int idx, Common const& common) {
   if (idx < 0 || idx >= (int)common.sounds.size()) return "";
   return common.sounds[idx].name;
 }
 
-inline int soundRefFromStr(std::string const& str, Common const& common) {
+inline int SoundRefFromStr(std::string const& str, Common const& common) {
   if (str.empty()) return -1;
-  return common.soundIndex(str);
+  return common.SoundIndex(str);
 }
 
 // Save/load NObjectType config (individual .cfg file)
-inline void saveNObjectConfig(Common const& common, NObjectType const& n, std::ostream& os) {
+inline void SaveNObjectConfig(Common const& common, NObjectType const& n, std::ostream& os) {
   cereal::TomlOutputArchive ar(os);
-  ar(cereal::make_nvp("wormExplode", n.wormExplode));
-  ar(cereal::make_nvp("explGround", n.explGround));
-  ar(cereal::make_nvp("wormDestroy", n.wormDestroy));
-  ar(cereal::make_nvp("drawOnMap", n.drawOnMap));
-  ar(cereal::make_nvp("affectByExplosions", n.affectByExplosions));
-  ar(cereal::make_nvp("bloodTrail", n.bloodTrail));
-  ar(cereal::make_nvp("detectDistance", n.detectDistance));
+  ar(cereal::make_nvp("wormExplode", n.worm_explode));
+  ar(cereal::make_nvp("explGround", n.expl_ground));
+  ar(cereal::make_nvp("wormDestroy", n.worm_destroy));
+  ar(cereal::make_nvp("drawOnMap", n.draw_on_map));
+  ar(cereal::make_nvp("affectByExplosions", n.affect_by_explosions));
+  ar(cereal::make_nvp("bloodTrail", n.blood_trail));
+  ar(cereal::make_nvp("detectDistance", n.detect_distance));
   ar(cereal::make_nvp("gravity", n.gravity));
   ar(cereal::make_nvp("speed", n.speed));
-  ar(cereal::make_nvp("speedV", n.speedV));
+  ar(cereal::make_nvp("speedV", n.speed_v));
   ar(cereal::make_nvp("distribution", n.distribution));
-  ar(cereal::make_nvp("blowAway", n.blowAway));
+  ar(cereal::make_nvp("blowAway", n.blow_away));
   ar(cereal::make_nvp("bounce", n.bounce));
-  ar(cereal::make_nvp("hitDamage", n.hitDamage));
-  ar(cereal::make_nvp("bloodOnHit", n.bloodOnHit));
-  ar(cereal::make_nvp("startFrame", n.startFrame));
-  ar(cereal::make_nvp("numFrames", n.numFrames));
-  ar(cereal::make_nvp("colorBullets", n.colorBullets));
+  ar(cereal::make_nvp("hitDamage", n.hit_damage));
+  ar(cereal::make_nvp("bloodOnHit", n.blood_on_hit));
+  ar(cereal::make_nvp("startFrame", n.start_frame));
+  ar(cereal::make_nvp("numFrames", n.num_frames));
+  ar(cereal::make_nvp("colorBullets", n.color_bullets));
   {
-    std::string ref = objRefToStr(n.createOnExp, common.sobjectTypes);
+    std::string ref = ObjRefToStr(n.create_on_exp, common.sobject_types);
     ar(cereal::make_nvp("createOnExp", ref));
   }
-  ar(cereal::make_nvp("dirtEffect", n.dirtEffect));
-  ar(cereal::make_nvp("splinterAmount", n.splinterAmount));
-  ar(cereal::make_nvp("splinterColour", n.splinterColour));
+  ar(cereal::make_nvp("dirtEffect", n.dirt_effect));
+  ar(cereal::make_nvp("splinterAmount", n.splinter_amount));
+  ar(cereal::make_nvp("splinterColour", n.splinter_colour));
   {
-    std::string ref = objRefToStr(n.splinterType, common.nobjectTypes);
+    std::string ref = ObjRefToStr(n.splinter_type, common.nobject_types);
     ar(cereal::make_nvp("splinterType", ref));
   }
-  ar(cereal::make_nvp("bloodTrailDelay", n.bloodTrailDelay));
+  ar(cereal::make_nvp("bloodTrailDelay", n.blood_trail_delay));
   {
-    std::string ref = objRefToStr(n.leaveObj, common.sobjectTypes);
+    std::string ref = ObjRefToStr(n.leave_obj, common.sobject_types);
     ar(cereal::make_nvp("leaveObj", ref));
   }
-  ar(cereal::make_nvp("leaveObjDelay", n.leaveObjDelay));
-  ar(cereal::make_nvp("timeToExplo", n.timeToExplo));
-  ar(cereal::make_nvp("timeToExploV", n.timeToExploV));
+  ar(cereal::make_nvp("leaveObjDelay", n.leave_obj_delay));
+  ar(cereal::make_nvp("timeToExplo", n.time_to_explo));
+  ar(cereal::make_nvp("timeToExploV", n.time_to_explo_v));
 }
 
-inline void loadNObjectConfig(Common& common, NObjectType& n, std::istream& is) {
+inline void LoadNObjectConfig(Common& common, NObjectType& n, std::istream& is) {
   cereal::TomlInputArchive ar(is);
-  ar(cereal::make_nvp("wormExplode", n.wormExplode));
-  ar(cereal::make_nvp("explGround", n.explGround));
-  ar(cereal::make_nvp("wormDestroy", n.wormDestroy));
-  ar(cereal::make_nvp("drawOnMap", n.drawOnMap));
-  ar(cereal::make_nvp("affectByExplosions", n.affectByExplosions));
-  ar(cereal::make_nvp("bloodTrail", n.bloodTrail));
-  ar(cereal::make_nvp("detectDistance", n.detectDistance));
+  ar(cereal::make_nvp("wormExplode", n.worm_explode));
+  ar(cereal::make_nvp("explGround", n.expl_ground));
+  ar(cereal::make_nvp("wormDestroy", n.worm_destroy));
+  ar(cereal::make_nvp("drawOnMap", n.draw_on_map));
+  ar(cereal::make_nvp("affectByExplosions", n.affect_by_explosions));
+  ar(cereal::make_nvp("bloodTrail", n.blood_trail));
+  ar(cereal::make_nvp("detectDistance", n.detect_distance));
   ar(cereal::make_nvp("gravity", n.gravity));
   ar(cereal::make_nvp("speed", n.speed));
-  ar(cereal::make_nvp("speedV", n.speedV));
+  ar(cereal::make_nvp("speedV", n.speed_v));
   ar(cereal::make_nvp("distribution", n.distribution));
-  ar(cereal::make_nvp("blowAway", n.blowAway));
+  ar(cereal::make_nvp("blowAway", n.blow_away));
   ar(cereal::make_nvp("bounce", n.bounce));
-  ar(cereal::make_nvp("hitDamage", n.hitDamage));
-  ar(cereal::make_nvp("bloodOnHit", n.bloodOnHit));
-  ar(cereal::make_nvp("startFrame", n.startFrame));
-  ar(cereal::make_nvp("numFrames", n.numFrames));
-  ar(cereal::make_nvp("colorBullets", n.colorBullets));
+  ar(cereal::make_nvp("hitDamage", n.hit_damage));
+  ar(cereal::make_nvp("bloodOnHit", n.blood_on_hit));
+  ar(cereal::make_nvp("startFrame", n.start_frame));
+  ar(cereal::make_nvp("numFrames", n.num_frames));
+  ar(cereal::make_nvp("colorBullets", n.color_bullets));
   {
     std::string ref;
     ar(cereal::make_nvp("createOnExp", ref));
-    n.createOnExp = objRefFromStr(ref, common.sobjectTypes);
+    n.create_on_exp = ObjRefFromStr(ref, common.sobject_types);
   }
-  ar(cereal::make_nvp("dirtEffect", n.dirtEffect));
-  ar(cereal::make_nvp("splinterAmount", n.splinterAmount));
-  ar(cereal::make_nvp("splinterColour", n.splinterColour));
+  ar(cereal::make_nvp("dirtEffect", n.dirt_effect));
+  ar(cereal::make_nvp("splinterAmount", n.splinter_amount));
+  ar(cereal::make_nvp("splinterColour", n.splinter_colour));
   {
     std::string ref;
     ar(cereal::make_nvp("splinterType", ref));
-    n.splinterType = objRefFromStr(ref, common.nobjectTypes);
+    n.splinter_type = ObjRefFromStr(ref, common.nobject_types);
   }
-  ar(cereal::make_nvp("bloodTrailDelay", n.bloodTrailDelay));
+  ar(cereal::make_nvp("bloodTrailDelay", n.blood_trail_delay));
   {
     std::string ref;
     ar(cereal::make_nvp("leaveObj", ref));
-    n.leaveObj = objRefFromStr(ref, common.sobjectTypes);
+    n.leave_obj = ObjRefFromStr(ref, common.sobject_types);
   }
-  ar(cereal::make_nvp("leaveObjDelay", n.leaveObjDelay));
-  ar(cereal::make_nvp("timeToExplo", n.timeToExplo));
-  ar(cereal::make_nvp("timeToExploV", n.timeToExploV));
+  ar(cereal::make_nvp("leaveObjDelay", n.leave_obj_delay));
+  ar(cereal::make_nvp("timeToExplo", n.time_to_explo));
+  ar(cereal::make_nvp("timeToExploV", n.time_to_explo_v));
 }
 
 // Save/load SObjectType config
-inline void saveSObjectConfig(Common const& common, SObjectType const& s, std::ostream& os) {
+inline void SaveSObjectConfig(Common const& common, SObjectType const& s, std::ostream& os) {
   cereal::TomlOutputArchive ar(os);
   ar(cereal::make_nvp("shadow", s.shadow));
   {
-    std::string ref = soundRefToStr(s.startSound, common);
+    std::string ref = SoundRefToStr(s.start_sound, common);
     ar(cereal::make_nvp("startSound", ref));
   }
-  ar(cereal::make_nvp("numSounds", s.numSounds));
-  ar(cereal::make_nvp("animDelay", s.animDelay));
-  ar(cereal::make_nvp("startFrame", s.startFrame));
-  ar(cereal::make_nvp("numFrames", s.numFrames));
-  ar(cereal::make_nvp("detectRange", s.detectRange));
+  ar(cereal::make_nvp("numSounds", s.num_sounds));
+  ar(cereal::make_nvp("animDelay", s.anim_delay));
+  ar(cereal::make_nvp("startFrame", s.start_frame));
+  ar(cereal::make_nvp("numFrames", s.num_frames));
+  ar(cereal::make_nvp("detectRange", s.detect_range));
   ar(cereal::make_nvp("damage", s.damage));
-  ar(cereal::make_nvp("blowAway", s.blowAway));
+  ar(cereal::make_nvp("blowAway", s.blow_away));
   ar(cereal::make_nvp("shake", s.shake));
   ar(cereal::make_nvp("flash", s.flash));
-  ar(cereal::make_nvp("dirtEffect", s.dirtEffect));
+  ar(cereal::make_nvp("dirtEffect", s.dirt_effect));
 }
 
-inline void loadSObjectConfig(Common const& common, SObjectType& s, std::istream& is) {
+inline void LoadSObjectConfig(Common const& common, SObjectType& s, std::istream& is) {
   cereal::TomlInputArchive ar(is);
   ar(cereal::make_nvp("shadow", s.shadow));
   {
     std::string ref;
     ar(cereal::make_nvp("startSound", ref));
-    s.startSound = soundRefFromStr(ref, common);
+    s.start_sound = SoundRefFromStr(ref, common);
   }
-  ar(cereal::make_nvp("numSounds", s.numSounds));
-  ar(cereal::make_nvp("animDelay", s.animDelay));
-  ar(cereal::make_nvp("startFrame", s.startFrame));
-  ar(cereal::make_nvp("numFrames", s.numFrames));
-  ar(cereal::make_nvp("detectRange", s.detectRange));
+  ar(cereal::make_nvp("numSounds", s.num_sounds));
+  ar(cereal::make_nvp("animDelay", s.anim_delay));
+  ar(cereal::make_nvp("startFrame", s.start_frame));
+  ar(cereal::make_nvp("numFrames", s.num_frames));
+  ar(cereal::make_nvp("detectRange", s.detect_range));
   ar(cereal::make_nvp("damage", s.damage));
-  ar(cereal::make_nvp("blowAway", s.blowAway));
+  ar(cereal::make_nvp("blowAway", s.blow_away));
   ar(cereal::make_nvp("shake", s.shake));
   ar(cereal::make_nvp("flash", s.flash));
-  ar(cereal::make_nvp("dirtEffect", s.dirtEffect));
+  ar(cereal::make_nvp("dirtEffect", s.dirt_effect));
 }
 
 // Save/load Weapon config
-inline void saveWeaponConfig(Common const& common, Weapon const& w, std::ostream& os) {
+inline void SaveWeaponConfig(Common const& common, Weapon const& w, std::ostream& os) {
   cereal::TomlOutputArchive ar(os);
   ar(cereal::make_nvp("name", w.name));
-  ar(cereal::make_nvp("affectByWorm", w.affectByWorm));
+  ar(cereal::make_nvp("affectByWorm", w.affect_by_worm));
   ar(cereal::make_nvp("shadow", w.shadow));
-  ar(cereal::make_nvp("laserSight", w.laserSight));
-  ar(cereal::make_nvp("playReloadSound", w.playReloadSound));
-  ar(cereal::make_nvp("wormExplode", w.wormExplode));
-  ar(cereal::make_nvp("explGround", w.explGround));
-  ar(cereal::make_nvp("wormCollide", w.wormCollide));
-  ar(cereal::make_nvp("collideWithObjects", w.collideWithObjects));
-  ar(cereal::make_nvp("affectByExplosions", w.affectByExplosions));
-  ar(cereal::make_nvp("loopAnim", w.loopAnim));
-  ar(cereal::make_nvp("detectDistance", w.detectDistance));
-  ar(cereal::make_nvp("blowAway", w.blowAway));
+  ar(cereal::make_nvp("laserSight", w.laser_sight));
+  ar(cereal::make_nvp("playReloadSound", w.play_reload_sound));
+  ar(cereal::make_nvp("wormExplode", w.worm_explode));
+  ar(cereal::make_nvp("explGround", w.expl_ground));
+  ar(cereal::make_nvp("wormCollide", w.worm_collide));
+  ar(cereal::make_nvp("collideWithObjects", w.collide_with_objects));
+  ar(cereal::make_nvp("affectByExplosions", w.affect_by_explosions));
+  ar(cereal::make_nvp("loopAnim", w.loop_anim));
+  ar(cereal::make_nvp("detectDistance", w.detect_distance));
+  ar(cereal::make_nvp("blowAway", w.blow_away));
   ar(cereal::make_nvp("gravity", w.gravity));
   {
-    std::string ref = soundRefToStr(w.launchSound, common);
+    std::string ref = SoundRefToStr(w.launch_sound, common);
     ar(cereal::make_nvp("launchSound", ref));
   }
   {
-    std::string ref = soundRefToStr(w.loopSound, common);
+    std::string ref = SoundRefToStr(w.loop_sound, common);
     ar(cereal::make_nvp("loopSound", ref));
   }
   {
-    std::string ref = soundRefToStr(w.exploSound, common);
+    std::string ref = SoundRefToStr(w.explo_sound, common);
     ar(cereal::make_nvp("exploSound", ref));
   }
   ar(cereal::make_nvp("speed", w.speed));
-  ar(cereal::make_nvp("addSpeed", w.addSpeed));
+  ar(cereal::make_nvp("addSpeed", w.add_speed));
   ar(cereal::make_nvp("distribution", w.distribution));
   ar(cereal::make_nvp("parts", w.parts));
   ar(cereal::make_nvp("recoil", w.recoil));
-  ar(cereal::make_nvp("multSpeed", w.multSpeed));
+  ar(cereal::make_nvp("multSpeed", w.mult_speed));
   ar(cereal::make_nvp("delay", w.delay));
-  ar(cereal::make_nvp("loadingTime", w.loadingTime));
+  ar(cereal::make_nvp("loadingTime", w.loading_time));
   ar(cereal::make_nvp("ammo", w.ammo));
-  ar(cereal::make_nvp("dirtEffect", w.dirtEffect));
-  ar(cereal::make_nvp("leaveShells", w.leaveShells));
-  ar(cereal::make_nvp("leaveShellDelay", w.leaveShellDelay));
-  ar(cereal::make_nvp("fireCone", w.fireCone));
+  ar(cereal::make_nvp("dirtEffect", w.dirt_effect));
+  ar(cereal::make_nvp("leaveShells", w.leave_shells));
+  ar(cereal::make_nvp("leaveShellDelay", w.leave_shell_delay));
+  ar(cereal::make_nvp("fireCone", w.fire_cone));
   ar(cereal::make_nvp("bounce", w.bounce));
-  ar(cereal::make_nvp("timeToExplo", w.timeToExplo));
-  ar(cereal::make_nvp("timeToExploV", w.timeToExploV));
-  ar(cereal::make_nvp("hitDamage", w.hitDamage));
-  ar(cereal::make_nvp("bloodOnHit", w.bloodOnHit));
-  ar(cereal::make_nvp("startFrame", w.startFrame));
-  ar(cereal::make_nvp("numFrames", w.numFrames));
-  ar(cereal::make_nvp("shotType", w.shotType));
-  ar(cereal::make_nvp("colorBullets", w.colorBullets));
-  ar(cereal::make_nvp("splinterAmount", w.splinterAmount));
-  ar(cereal::make_nvp("splinterColour", w.splinterColour));
+  ar(cereal::make_nvp("timeToExplo", w.time_to_explo));
+  ar(cereal::make_nvp("timeToExploV", w.time_to_explo_v));
+  ar(cereal::make_nvp("hitDamage", w.hit_damage));
+  ar(cereal::make_nvp("bloodOnHit", w.blood_on_hit));
+  ar(cereal::make_nvp("startFrame", w.start_frame));
+  ar(cereal::make_nvp("numFrames", w.num_frames));
+  ar(cereal::make_nvp("shotType", w.shot_type));
+  ar(cereal::make_nvp("colorBullets", w.color_bullets));
+  ar(cereal::make_nvp("splinterAmount", w.splinter_amount));
+  ar(cereal::make_nvp("splinterColour", w.splinter_colour));
   {
-    std::string ref = objRefToStr(w.splinterType, common.nobjectTypes);
+    std::string ref = ObjRefToStr(w.splinter_type, common.nobject_types);
     ar(cereal::make_nvp("splinterType", ref));
   }
-  ar(cereal::make_nvp("splinterScatter", w.splinterScatter));
+  ar(cereal::make_nvp("splinterScatter", w.splinter_scatter));
   {
-    std::string ref = objRefToStr(w.objTrailType, common.sobjectTypes);
+    std::string ref = ObjRefToStr(w.obj_trail_type, common.sobject_types);
     ar(cereal::make_nvp("objTrailType", ref));
   }
-  ar(cereal::make_nvp("objTrailDelay", w.objTrailDelay));
-  ar(cereal::make_nvp("partTrailType", w.partTrailType));
+  ar(cereal::make_nvp("objTrailDelay", w.obj_trail_delay));
+  ar(cereal::make_nvp("partTrailType", w.part_trail_type));
   {
-    std::string ref = objRefToStr(w.partTrailObj, common.nobjectTypes);
+    std::string ref = ObjRefToStr(w.part_trail_obj, common.nobject_types);
     ar(cereal::make_nvp("partTrailObj", ref));
   }
-  ar(cereal::make_nvp("partTrailDelay", w.partTrailDelay));
+  ar(cereal::make_nvp("partTrailDelay", w.part_trail_delay));
   {
-    std::string ref = objRefToStr(w.createOnExp, common.sobjectTypes);
+    std::string ref = ObjRefToStr(w.create_on_exp, common.sobject_types);
     ar(cereal::make_nvp("createOnExp", ref));
   }
-  ar(cereal::make_nvp("chainExplosion", w.chainExplosion));
+  ar(cereal::make_nvp("chainExplosion", w.chain_explosion));
 }
 
-inline void loadWeaponConfig(Common& common, Weapon& w, std::istream& is) {
+inline void LoadWeaponConfig(Common& common, Weapon& w, std::istream& is) {
   cereal::TomlInputArchive ar(is);
   ar(cereal::make_nvp("name", w.name));
-  ar(cereal::make_nvp("affectByWorm", w.affectByWorm));
+  ar(cereal::make_nvp("affectByWorm", w.affect_by_worm));
   ar(cereal::make_nvp("shadow", w.shadow));
-  ar(cereal::make_nvp("laserSight", w.laserSight));
-  ar(cereal::make_nvp("playReloadSound", w.playReloadSound));
-  ar(cereal::make_nvp("wormExplode", w.wormExplode));
-  ar(cereal::make_nvp("explGround", w.explGround));
-  ar(cereal::make_nvp("wormCollide", w.wormCollide));
-  ar(cereal::make_nvp("collideWithObjects", w.collideWithObjects));
-  ar(cereal::make_nvp("affectByExplosions", w.affectByExplosions));
-  ar(cereal::make_nvp("loopAnim", w.loopAnim));
-  ar(cereal::make_nvp("detectDistance", w.detectDistance));
-  ar(cereal::make_nvp("blowAway", w.blowAway));
+  ar(cereal::make_nvp("laserSight", w.laser_sight));
+  ar(cereal::make_nvp("playReloadSound", w.play_reload_sound));
+  ar(cereal::make_nvp("wormExplode", w.worm_explode));
+  ar(cereal::make_nvp("explGround", w.expl_ground));
+  ar(cereal::make_nvp("wormCollide", w.worm_collide));
+  ar(cereal::make_nvp("collideWithObjects", w.collide_with_objects));
+  ar(cereal::make_nvp("affectByExplosions", w.affect_by_explosions));
+  ar(cereal::make_nvp("loopAnim", w.loop_anim));
+  ar(cereal::make_nvp("detectDistance", w.detect_distance));
+  ar(cereal::make_nvp("blowAway", w.blow_away));
   ar(cereal::make_nvp("gravity", w.gravity));
   {
     std::string ref;
     ar(cereal::make_nvp("launchSound", ref));
-    w.launchSound = soundRefFromStr(ref, common);
+    w.launch_sound = SoundRefFromStr(ref, common);
   }
   {
     std::string ref;
     ar(cereal::make_nvp("loopSound", ref));
-    w.loopSound = soundRefFromStr(ref, common);
+    w.loop_sound = SoundRefFromStr(ref, common);
   }
   {
     std::string ref;
     ar(cereal::make_nvp("exploSound", ref));
-    w.exploSound = soundRefFromStr(ref, common);
+    w.explo_sound = SoundRefFromStr(ref, common);
   }
   ar(cereal::make_nvp("speed", w.speed));
-  ar(cereal::make_nvp("addSpeed", w.addSpeed));
+  ar(cereal::make_nvp("addSpeed", w.add_speed));
   ar(cereal::make_nvp("distribution", w.distribution));
   ar(cereal::make_nvp("parts", w.parts));
   ar(cereal::make_nvp("recoil", w.recoil));
-  ar(cereal::make_nvp("multSpeed", w.multSpeed));
+  ar(cereal::make_nvp("multSpeed", w.mult_speed));
   ar(cereal::make_nvp("delay", w.delay));
-  ar(cereal::make_nvp("loadingTime", w.loadingTime));
+  ar(cereal::make_nvp("loadingTime", w.loading_time));
   ar(cereal::make_nvp("ammo", w.ammo));
-  ar(cereal::make_nvp("dirtEffect", w.dirtEffect));
-  ar(cereal::make_nvp("leaveShells", w.leaveShells));
-  ar(cereal::make_nvp("leaveShellDelay", w.leaveShellDelay));
-  ar(cereal::make_nvp("fireCone", w.fireCone));
+  ar(cereal::make_nvp("dirtEffect", w.dirt_effect));
+  ar(cereal::make_nvp("leaveShells", w.leave_shells));
+  ar(cereal::make_nvp("leaveShellDelay", w.leave_shell_delay));
+  ar(cereal::make_nvp("fireCone", w.fire_cone));
   ar(cereal::make_nvp("bounce", w.bounce));
-  ar(cereal::make_nvp("timeToExplo", w.timeToExplo));
-  ar(cereal::make_nvp("timeToExploV", w.timeToExploV));
-  ar(cereal::make_nvp("hitDamage", w.hitDamage));
-  ar(cereal::make_nvp("bloodOnHit", w.bloodOnHit));
-  ar(cereal::make_nvp("startFrame", w.startFrame));
-  ar(cereal::make_nvp("numFrames", w.numFrames));
-  ar(cereal::make_nvp("shotType", w.shotType));
-  ar(cereal::make_nvp("colorBullets", w.colorBullets));
-  ar(cereal::make_nvp("splinterAmount", w.splinterAmount));
-  ar(cereal::make_nvp("splinterColour", w.splinterColour));
+  ar(cereal::make_nvp("timeToExplo", w.time_to_explo));
+  ar(cereal::make_nvp("timeToExploV", w.time_to_explo_v));
+  ar(cereal::make_nvp("hitDamage", w.hit_damage));
+  ar(cereal::make_nvp("bloodOnHit", w.blood_on_hit));
+  ar(cereal::make_nvp("startFrame", w.start_frame));
+  ar(cereal::make_nvp("numFrames", w.num_frames));
+  ar(cereal::make_nvp("shotType", w.shot_type));
+  ar(cereal::make_nvp("colorBullets", w.color_bullets));
+  ar(cereal::make_nvp("splinterAmount", w.splinter_amount));
+  ar(cereal::make_nvp("splinterColour", w.splinter_colour));
   {
     std::string ref;
     ar(cereal::make_nvp("splinterType", ref));
-    w.splinterType = objRefFromStr(ref, common.nobjectTypes);
+    w.splinter_type = ObjRefFromStr(ref, common.nobject_types);
   }
-  ar(cereal::make_nvp("splinterScatter", w.splinterScatter));
+  ar(cereal::make_nvp("splinterScatter", w.splinter_scatter));
   {
     std::string ref;
     ar(cereal::make_nvp("objTrailType", ref));
-    w.objTrailType = objRefFromStr(ref, common.sobjectTypes);
+    w.obj_trail_type = ObjRefFromStr(ref, common.sobject_types);
   }
-  ar(cereal::make_nvp("objTrailDelay", w.objTrailDelay));
-  ar(cereal::make_nvp("partTrailType", w.partTrailType));
+  ar(cereal::make_nvp("objTrailDelay", w.obj_trail_delay));
+  ar(cereal::make_nvp("partTrailType", w.part_trail_type));
   {
     std::string ref;
     ar(cereal::make_nvp("partTrailObj", ref));
-    w.partTrailObj = objRefFromStr(ref, common.nobjectTypes);
+    w.part_trail_obj = ObjRefFromStr(ref, common.nobject_types);
   }
-  ar(cereal::make_nvp("partTrailDelay", w.partTrailDelay));
+  ar(cereal::make_nvp("partTrailDelay", w.part_trail_delay));
   {
     std::string ref;
     ar(cereal::make_nvp("createOnExp", ref));
-    w.createOnExp = objRefFromStr(ref, common.sobjectTypes);
+    w.create_on_exp = ObjRefFromStr(ref, common.sobject_types);
   }
-  ar(cereal::make_nvp("chainExplosion", w.chainExplosion));
+  ar(cereal::make_nvp("chainExplosion", w.chain_explosion));
 }
 
 // --- Helper structs for tc.cfg serialization (must be at file scope for templates) ---
@@ -342,13 +342,13 @@ struct Types {
 
 struct BonusEntry {
   int32_t timer = 0;
-  int32_t timerV = 0;
+  int32_t timer_v = 0;
   int32_t frame = 0;
   std::string sobj;
   template <typename Archive>
   void serialize(Archive& ar) {
     ar(cereal::make_nvp("timer", timer));
-    ar(cereal::make_nvp("timerV", timerV));
+    ar(cereal::make_nvp("timerV", timer_v));
     ar(cereal::make_nvp("frame", frame));
     ar(cereal::make_nvp("sobj", sobj));
   }
@@ -405,7 +405,7 @@ struct AiParamsS {
 struct Constants {
   std::vector<BonusEntry> bonuses;
   std::vector<TextureEntry> textures;
-  std::vector<ColourAnimEntry> colorAnim;
+  std::vector<ColourAnimEntry> color_anim;
   std::vector<int32_t> materials;
   AiParamsS aiparams;
 #define DECL_FIELD_C(n) int32_t n = 0;
@@ -416,7 +416,7 @@ struct Constants {
   void serialize(Archive& ar) {
     ar(cereal::make_nvp("bonuses", bonuses));
     ar(cereal::make_nvp("textures", textures));
-    ar(cereal::make_nvp("colorAnim", colorAnim));
+    ar(cereal::make_nvp("colorAnim", color_anim));
     ar(cereal::make_nvp("materials", materials));
     ar(cereal::make_nvp("aiparams", aiparams));
 #define SER_FIELD_C(n) ar(cereal::make_nvp(#n, n));
@@ -464,69 +464,69 @@ struct Sounds {
 }  // namespace tc_cfg
 
 // Save/load tc.cfg (top-level Common config)
-inline void saveTcConfig(Common const& common, std::ostream& os) {
+inline void SaveTcConfig(Common const& common, std::ostream& os) {
   tc_cfg::Types types;
   for (auto& s : common.sounds) types.sounds.push_back(s.name);
-  for (auto& w : common.weapons) types.weapons.push_back(w.idStr);
-  for (auto& n : common.nobjectTypes) types.nobjects.push_back(n.idStr);
-  for (auto& s : common.sobjectTypes) types.sobjects.push_back(s.idStr);
+  for (auto& w : common.weapons) types.weapons.push_back(w.id_str);
+  for (auto& n : common.nobject_types) types.nobjects.push_back(n.id_str);
+  for (auto& s : common.sobject_types) types.sobjects.push_back(s.id_str);
 
   tc_cfg::Constants constants;
   for (int i = 0; i < NUM_BONUS_SOBJECTS; ++i) {
     tc_cfg::BonusEntry be;
-    be.timer = common.bonusRandTimer[i][0];
-    be.timerV = common.bonusRandTimer[i][1];
-    be.frame = common.bonusFrames[i];
-    be.sobj = objRefToStr(common.bonusSObjects[i], common.sobjectTypes);
+    be.timer = common.bonus_rand_timer[i][0];
+    be.timer_v = common.bonus_rand_timer[i][1];
+    be.frame = common.bonus_frames[i];
+    be.sobj = ObjRefToStr(common.bonus_s_objects[i], common.sobject_types);
     constants.bonuses.push_back(be);
   }
   for (int i = 0; i < NUM_TEXTURES; ++i) {
     tc_cfg::TextureEntry te;
-    te.mframe = common.textures[i].mFrame;
-    te.rframe = common.textures[i].rFrame;
-    te.sframe = common.textures[i].sFrame;
-    te.ndrawback = common.textures[i].nDrawBack;
+    te.mframe = common.textures[i].m_frame;
+    te.rframe = common.textures[i].r_frame;
+    te.sframe = common.textures[i].s_frame;
+    te.ndrawback = common.textures[i].n_draw_back;
     constants.textures.push_back(te);
   }
   for (int i = 0; i < NUM_COLOR_ANIM; ++i) {
     tc_cfg::ColourAnimEntry ce;
-    ce.from = common.colorAnim[i].from;
-    ce.to = common.colorAnim[i].to;
-    constants.colorAnim.push_back(ce);
+    ce.from = common.color_anim[i].from;
+    ce.to = common.color_anim[i].to;
+    constants.color_anim.push_back(ce);
   }
   for (int i = 0; i < MAX_MATERIALS; ++i) constants.materials.push_back(common.materials[i].flags);
 
-  auto fillAiKey = [&](tc_cfg::AiKey& k, int idx) {
-    k.on = common.aiParams.k[1][idx];
-    k.off = common.aiParams.k[0][idx];
+  auto fill_ai_key = [&](tc_cfg::AiKey& k, int idx) {
+    k.on = common.ai_params.k[1][idx];
+    k.off = common.ai_params.k[0][idx];
   };
-  fillAiKey(constants.aiparams.up, 0);
-  fillAiKey(constants.aiparams.down, 1);
-  fillAiKey(constants.aiparams.left, 2);
-  fillAiKey(constants.aiparams.right, 3);
-  fillAiKey(constants.aiparams.fire, 4);
-  fillAiKey(constants.aiparams.change, 5);
-  fillAiKey(constants.aiparams.jump, 6);
+  fill_ai_key(constants.aiparams.up, 0);
+  fill_ai_key(constants.aiparams.down, 1);
+  fill_ai_key(constants.aiparams.left, 2);
+  fill_ai_key(constants.aiparams.right, 3);
+  fill_ai_key(constants.aiparams.fire, 4);
+  fill_ai_key(constants.aiparams.change, 5);
+  fill_ai_key(constants.aiparams.jump, 6);
 
-#define COPY_FIELD_C(n) constants.n = common.C[C##n];
+#define COPY_FIELD_C(n) constants.n = common.c[C##n];
   LIERO_CDEFS(COPY_FIELD_C)
 #undef COPY_FIELD_C
 
   tc_cfg::TextsS texts;
-#define COPY_FIELD_S(n) texts.n = common.S[S##n];
+#define COPY_FIELD_S(n) texts.n = common.s[S##n];
   LIERO_SDEFS(COPY_FIELD_S)
 #undef COPY_FIELD_S
 
   tc_cfg::Hacks hacks;
-#define COPY_FIELD_H(n) hacks.n = common.H[H##n];
+#define COPY_FIELD_H(n) hacks.n = common.h[H##n];
   LIERO_HDEFS(COPY_FIELD_H)
 #undef COPY_FIELD_H
 
   tc_cfg::Sounds sounds;
 #define COPY_FIELD_SO(n)                                                                          \
   sounds.n =                                                                                      \
-      (common.soundHook[Sound##n] >= 0 && common.soundHook[Sound##n] < (int)common.sounds.size()) \
-          ? common.sounds[common.soundHook[Sound##n]].name                                        \
+      (common.sound_hook[Sound##n] >= 0 && common.sound_hook[Sound##n] < (int)common.sounds.size()) \
+          ? common.sounds[common.sound_hook[Sound##n]].name                                        \
           : std::string();
   LIERO_SOUNDDEFS(COPY_FIELD_SO)
 #undef COPY_FIELD_SO
@@ -539,7 +539,7 @@ inline void saveTcConfig(Common const& common, std::ostream& os) {
   ar(cereal::make_nvp("sounds", sounds));
 }
 
-inline void loadTcConfig(Common& common, std::istream& is) {
+inline void LoadTcConfig(Common& common, std::istream& is) {
   tc_cfg::Types types;
   tc_cfg::Constants constants;
   tc_cfg::TextsS texts;
@@ -559,61 +559,61 @@ inline void loadTcConfig(Common& common, std::istream& is) {
   for (std::size_t i = 0; i < types.sounds.size(); ++i) common.sounds[i].name = types.sounds[i];
 
   common.weapons.resize(types.weapons.size());
-  for (std::size_t i = 0; i < types.weapons.size(); ++i) common.weapons[i].idStr = types.weapons[i];
+  for (std::size_t i = 0; i < types.weapons.size(); ++i) common.weapons[i].id_str = types.weapons[i];
 
-  common.nobjectTypes.resize(types.nobjects.size());
+  common.nobject_types.resize(types.nobjects.size());
   for (std::size_t i = 0; i < types.nobjects.size(); ++i)
-    common.nobjectTypes[i].idStr = types.nobjects[i];
+    common.nobject_types[i].id_str = types.nobjects[i];
 
-  common.sobjectTypes.resize(types.sobjects.size());
+  common.sobject_types.resize(types.sobjects.size());
   for (std::size_t i = 0; i < types.sobjects.size(); ++i)
-    common.sobjectTypes[i].idStr = types.sobjects[i];
+    common.sobject_types[i].id_str = types.sobjects[i];
 
   // Constants
   for (std::size_t i = 0; i < constants.bonuses.size() && i < NUM_BONUS_SOBJECTS; ++i) {
-    common.bonusRandTimer[i][0] = constants.bonuses[i].timer;
-    common.bonusRandTimer[i][1] = constants.bonuses[i].timerV;
-    common.bonusFrames[i] = constants.bonuses[i].frame;
-    common.bonusSObjects[i] = objRefFromStr(constants.bonuses[i].sobj, common.sobjectTypes);
+    common.bonus_rand_timer[i][0] = constants.bonuses[i].timer;
+    common.bonus_rand_timer[i][1] = constants.bonuses[i].timer_v;
+    common.bonus_frames[i] = constants.bonuses[i].frame;
+    common.bonus_s_objects[i] = ObjRefFromStr(constants.bonuses[i].sobj, common.sobject_types);
   }
 
   for (std::size_t i = 0; i < constants.textures.size() && i < NUM_TEXTURES; ++i) {
-    common.textures[i].mFrame = constants.textures[i].mframe;
-    common.textures[i].rFrame = constants.textures[i].rframe;
-    common.textures[i].sFrame = constants.textures[i].sframe;
-    common.textures[i].nDrawBack = constants.textures[i].ndrawback;
+    common.textures[i].m_frame = constants.textures[i].mframe;
+    common.textures[i].r_frame = constants.textures[i].rframe;
+    common.textures[i].s_frame = constants.textures[i].sframe;
+    common.textures[i].n_draw_back = constants.textures[i].ndrawback;
   }
 
-  for (std::size_t i = 0; i < constants.colorAnim.size() && i < NUM_COLOR_ANIM; ++i) {
-    common.colorAnim[i].from = constants.colorAnim[i].from;
-    common.colorAnim[i].to = constants.colorAnim[i].to;
+  for (std::size_t i = 0; i < constants.color_anim.size() && i < NUM_COLOR_ANIM; ++i) {
+    common.color_anim[i].from = constants.color_anim[i].from;
+    common.color_anim[i].to = constants.color_anim[i].to;
   }
 
   for (std::size_t i = 0; i < constants.materials.size() && i < MAX_MATERIALS; ++i) {
     common.materials[i].flags = (uint8_t)(constants.materials[i] & 0xff);
   }
 
-  auto readAiKey = [&](tc_cfg::AiKey const& k, int idx) {
-    common.aiParams.k[1][idx] = k.on;
-    common.aiParams.k[0][idx] = k.off;
+  auto read_ai_key = [&](tc_cfg::AiKey const& k, int idx) {
+    common.ai_params.k[1][idx] = k.on;
+    common.ai_params.k[0][idx] = k.off;
   };
-  readAiKey(constants.aiparams.up, 0);
-  readAiKey(constants.aiparams.down, 1);
-  readAiKey(constants.aiparams.left, 2);
-  readAiKey(constants.aiparams.right, 3);
-  readAiKey(constants.aiparams.fire, 4);
-  readAiKey(constants.aiparams.change, 5);
-  readAiKey(constants.aiparams.jump, 6);
+  read_ai_key(constants.aiparams.up, 0);
+  read_ai_key(constants.aiparams.down, 1);
+  read_ai_key(constants.aiparams.left, 2);
+  read_ai_key(constants.aiparams.right, 3);
+  read_ai_key(constants.aiparams.fire, 4);
+  read_ai_key(constants.aiparams.change, 5);
+  read_ai_key(constants.aiparams.jump, 6);
 
-#define COPY_FIELD_C2(n) common.C[C##n] = constants.n;
+#define COPY_FIELD_C2(n) common.c[C##n] = constants.n;
   LIERO_CDEFS(COPY_FIELD_C2)
 #undef COPY_FIELD_C2
 
-#define COPY_FIELD_S2(n) common.S[S##n] = texts.n;
+#define COPY_FIELD_S2(n) common.s[S##n] = texts.n;
   LIERO_SDEFS(COPY_FIELD_S2)
 #undef COPY_FIELD_S2
 
-#define COPY_FIELD_H2(n) common.H[H##n] = hacks.n;
+#define COPY_FIELD_H2(n) common.h[H##n] = hacks.n;
   LIERO_HDEFS(COPY_FIELD_H2)
 #undef COPY_FIELD_H2
 
@@ -622,30 +622,30 @@ inline void loadTcConfig(Common& common, std::istream& is) {
   // for that hook (so TCs whose tc.cfg predates the [sounds] section
   // still get menu/round/bump/reload sounds). Names that don't match
   // any loaded sound get a warning and resolve to -1.
-  auto resolveHook = [&](SOUND_DEF_T hook, std::string const& configured, char const* defaultName,
-                         char const* hookLabel) {
+  auto resolveHook = [&](SoundDefT hook, std::string const& configured, char const* default_name,
+                         char const* hook_label) {
     if (!configured.empty()) {
-      int idx = common.soundIndex(configured);
+      int idx = common.SoundIndex(configured);
       if (idx < 0)
-        Console::writeWarning(std::string("[sounds] ") + hookLabel +
+        console::WriteWarning(std::string("[sounds] ") + hook_label +
                               " references unknown sound \"" + configured + "\"");
-      common.soundHook[hook] = idx;
+      common.sound_hook[hook] = idx;
     } else {
-      common.soundHook[hook] = common.soundIndex(defaultName);
+      common.sound_hook[hook] = common.SoundIndex(default_name);
     }
   };
-#define COPY_FIELD_SO2(n) resolveHook(Sound##n, sounds.n, defaultSound##n, #n);
+#define COPY_FIELD_SO2(n) resolveHook(Sound##n, sounds.n, kDefaultSound##n, #n);
   // Canonical Liero sound names per hook. Kept in sync with tctool's
   // extracted sound table; serves as the fallback when [sounds] is
   // missing from tc.cfg.
-  constexpr char const* defaultSoundMenuMoveUp = "moveup";
-  constexpr char const* defaultSoundMenuMoveDown = "movedown";
-  constexpr char const* defaultSoundMenuSelect = "select";
-  constexpr char const* defaultSoundBump = "bump";
-  constexpr char const* defaultSoundBegin = "begin";
-  constexpr char const* defaultSoundReloaded = "reloaded";
-  constexpr char const* defaultSoundAlive = "alive";
-  constexpr char const* defaultSoundNinjaropeThrow = "throw";
+  constexpr char const* kDefaultSoundMenuMoveUp = "moveup";
+  constexpr char const* kDefaultSoundMenuMoveDown = "movedown";
+  constexpr char const* kDefaultSoundMenuSelect = "select";
+  constexpr char const* kDefaultSoundBump = "bump";
+  constexpr char const* kDefaultSoundBegin = "begin";
+  constexpr char const* kDefaultSoundReloaded = "reloaded";
+  constexpr char const* kDefaultSoundAlive = "alive";
+  constexpr char const* kDefaultSoundNinjaropeThrow = "throw";
   LIERO_SOUNDDEFS(COPY_FIELD_SO2)
 #undef COPY_FIELD_SO2
 }

--- a/src/game/common_model.hpp
+++ b/src/game/common_model.hpp
@@ -523,11 +523,11 @@ inline void SaveTcConfig(Common const& common, std::ostream& os) {
 #undef COPY_FIELD_H
 
   tc_cfg::Sounds sounds;
-#define COPY_FIELD_SO(n)                                                                          \
-  sounds.n =                                                                                      \
-      (common.sound_hook[Sound##n] >= 0 && common.sound_hook[Sound##n] < (int)common.sounds.size()) \
-          ? common.sounds[common.sound_hook[Sound##n]].name                                        \
-          : std::string();
+#define COPY_FIELD_SO(n)                                               \
+  sounds.n = (common.sound_hook[Sound##n] >= 0 &&                      \
+              common.sound_hook[Sound##n] < (int)common.sounds.size()) \
+                 ? common.sounds[common.sound_hook[Sound##n]].name     \
+                 : std::string();
   LIERO_SOUNDDEFS(COPY_FIELD_SO)
 #undef COPY_FIELD_SO
 
@@ -559,7 +559,8 @@ inline void LoadTcConfig(Common& common, std::istream& is) {
   for (std::size_t i = 0; i < types.sounds.size(); ++i) common.sounds[i].name = types.sounds[i];
 
   common.weapons.resize(types.weapons.size());
-  for (std::size_t i = 0; i < types.weapons.size(); ++i) common.weapons[i].id_str = types.weapons[i];
+  for (std::size_t i = 0; i < types.weapons.size(); ++i)
+    common.weapons[i].id_str = types.weapons[i];
 
   common.nobject_types.resize(types.nobjects.size());
   for (std::size_t i = 0; i < types.nobjects.size(); ++i)

--- a/src/game/console.cpp
+++ b/src/game/console.cpp
@@ -1,16 +1,16 @@
 #include "console.hpp"
 #include <cstdio>
 
-namespace Console {
-void write(std::string const& str) { std::fputs(str.c_str(), stdout); }
+namespace console {
+void Write(std::string const& str) { std::fputs(str.c_str(), stdout); }
 
-void writeLine(std::string const& str) {
+void WriteLine(std::string const& str) {
   std::fputs(str.c_str(), stdout);
   std::fputs("\n", stdout);
 }
 
-void writeWarning(std::string const& str) {
-  Console::write("WARNING: ");
-  Console::writeLine(str);
+void WriteWarning(std::string const& str) {
+  console::Write("WARNING: ");
+  console::WriteLine(str);
 }
 }  // namespace Console

--- a/src/game/console.cpp
+++ b/src/game/console.cpp
@@ -13,4 +13,4 @@ void WriteWarning(std::string const& str) {
   console::Write("WARNING: ");
   console::WriteLine(str);
 }
-}  // namespace Console
+}  // namespace console

--- a/src/game/console.hpp
+++ b/src/game/console.hpp
@@ -2,8 +2,8 @@
 
 #include <string>
 
-namespace Console {
-void write(std::string const& str);
-void writeLine(std::string const& str);
-void writeWarning(std::string const& str);
+namespace console {
+void Write(std::string const& str);
+void WriteLine(std::string const& str);
+void WriteWarning(std::string const& str);
 }  // namespace Console

--- a/src/game/console.hpp
+++ b/src/game/console.hpp
@@ -6,4 +6,4 @@ namespace console {
 void Write(std::string const& str);
 void WriteLine(std::string const& str);
 void WriteWarning(std::string const& str);
-}  // namespace Console
+}  // namespace console

--- a/src/game/constants.hpp
+++ b/src/game/constants.hpp
@@ -2,6 +2,15 @@
 
 #include <string>
 
+// The token names inside LIERO_*DEFS(_) are concatenated with single-
+// letter prefixes via DEFENUMC/S/H/SO to construct enum constants
+// like CBonusFlickerTime, SOk, HRemExp, SoundMenuSelect. Callers reach
+// them through the LC(name) / LS(name) macros below, which themselves
+// token-paste the prefix. Renaming any token here silently breaks
+// every callsite. NOLINT keeps clang-tidy's identifier-naming check
+// away from this expansion machinery.
+// NOLINTBEGIN(readability-identifier-naming)
+
 // Variables sourced from [constants] in tc.cfg
 #define LIERO_CDEFS(_)      \
   _(NRInitialLength)        \
@@ -150,28 +159,28 @@
 #define DEFENUMH(x) H##x,
 #define DEFENUMSO(x) Sound##x,
 
-enum CONST_DEF_T {
+enum ConstDefT {
   LIERO_CDEFS(DEFENUMC)
   /* Maximum quantity of constants in CONST_DEF_T. */
-  MaxC
+  kMaxC
 };
 
-enum STRING_DEF_T {
+enum StringDefT {
   LIERO_SDEFS(DEFENUMS)
   /* Maximum quantity of strings in STRING_DEF_T. */
-  MaxS
+  kMaxS
 };
 
-enum HACK_DEF_T {
+enum HackDefT {
   LIERO_HDEFS(DEFENUMH)
   /* Maximum quantity of hacks in HACK_DEF_T. */
-  MaxH
+  kMaxH
 };
 
-enum SOUND_DEF_T {
+enum SoundDefT {
   LIERO_SOUNDDEFS(DEFENUMSO)
   /* Maximum quantity of sound hooks in SOUND_DEF_T. */
-  MaxSound
+  kMaxSound
 };
 
 #undef DEFENUMS
@@ -179,7 +188,8 @@ enum SOUND_DEF_T {
 #undef DEFENUMH
 #undef DEFENUMSO
 
-#define LC(name) (common.C[C##name])
-#define LS(name) (common.S[S##name])
+#define LC(name) (common.c[C##name])
+#define LS(name) (common.s[S##name])
+// NOLINTEND(readability-identifier-naming)
 
 // TODO: Move these to Common

--- a/src/game/controller/commonController.cpp
+++ b/src/game/controller/commonController.cpp
@@ -2,34 +2,34 @@
 
 #include "../gfx.hpp"
 
-CommonController::CommonController() : frameSkip(1), inverseFrameSkip(false), cycles(0) {}
+CommonController::CommonController() : frame_skip(1), inverse_frame_skip(false), cycles(0) {}
 
-bool CommonController::process() {
-  int newFrameSkip = 0;
-  if (gfx.testSDLKeyOnce(SDL_SCANCODE_1))
-    newFrameSkip = 1;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_2))
-    newFrameSkip = 2;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_3))
-    newFrameSkip = 4;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_4))
-    newFrameSkip = 8;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_5))
-    newFrameSkip = 16;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_6))
-    newFrameSkip = 32;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_7))
-    newFrameSkip = 64;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_8))
-    newFrameSkip = 128;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_9))
-    newFrameSkip = 256;
-  else if (gfx.testSDLKeyOnce(SDL_SCANCODE_0))
-    newFrameSkip = 512;
+bool CommonController::Process() {
+  int new_frame_skip = 0;
+  if (gfx.TestSdlKeyOnce(SDL_SCANCODE_1))
+    new_frame_skip = 1;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_2))
+    new_frame_skip = 2;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_3))
+    new_frame_skip = 4;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_4))
+    new_frame_skip = 8;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_5))
+    new_frame_skip = 16;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_6))
+    new_frame_skip = 32;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_7))
+    new_frame_skip = 64;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_8))
+    new_frame_skip = 128;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_9))
+    new_frame_skip = 256;
+  else if (gfx.TestSdlKeyOnce(SDL_SCANCODE_0))
+    new_frame_skip = 512;
 
-  if (newFrameSkip) {
-    inverseFrameSkip = (gfx.testSDLKey(SDL_SCANCODE_RCTRL) || gfx.testSDLKey(SDL_SCANCODE_LCTRL));
-    frameSkip = newFrameSkip;
+  if (new_frame_skip) {
+    inverse_frame_skip = (gfx.TestSdlKey(SDL_SCANCODE_RCTRL) || gfx.TestSdlKey(SDL_SCANCODE_LCTRL));
+    frame_skip = new_frame_skip;
   }
 
   ++cycles;

--- a/src/game/controller/commonController.hpp
+++ b/src/game/controller/commonController.hpp
@@ -4,9 +4,9 @@
 
 struct CommonController : Controller {
   CommonController();
-  bool process();
+  bool Process();
 
-  int frameSkip;
-  bool inverseFrameSkip;
+  int frame_skip;
+  bool inverse_frame_skip;
   int cycles;
 };

--- a/src/game/controller/controller.hpp
+++ b/src/game/controller/controller.hpp
@@ -9,41 +9,41 @@ struct Controller {
 
   // Returns true if this controller is controlling a replay, false if it is
   // an actual match
-  virtual bool isReplay() { return false; };
+  virtual bool IsReplay() { return false; };
 
   // Called when a key event is forwarded to the controller
-  virtual void onKey(int key, bool state) = 0;
+  virtual void OnKey(int key, bool state) = 0;
 
   // Called when the controller loses focus. When not focused, it will not receive key events among
   // other things.
-  virtual void unfocus() = 0;
+  virtual void Unfocus() = 0;
 
   // Called when the controller gets focus.
-  virtual void focus() = 0;
+  virtual void Focus() = 0;
 
-  virtual bool process() = 0;
+  virtual bool Process() = 0;
 
-  virtual void draw(Renderer& renderer, bool useSpectatorViewports) = 0;
+  virtual void Draw(Renderer& renderer, bool use_spectator_viewports) = 0;
 
   // Returns true if the game is still running. The menu should check this to decide whether to show
   // the resume option.
-  virtual bool running() = 0;
+  virtual bool Running() = 0;
 
   // Notify the controller that any underlying session it depended on
   // is gone (peer left, socket closed, etc.) so it can stop reporting
   // itself as resumable. Default no-op for single-player controllers.
-  virtual void markUnresumable() {}
+  virtual void MarkUnresumable() {}
 
-  virtual Level* currentLevel() = 0;
+  virtual Level* CurrentLevel() = 0;
 
-  virtual Game* currentGame() = 0;
+  virtual Game* CurrentGame() = 0;
 
   // Game whose statsRecorder holds the post-match player-facing stats.
   // For single-player and replay this is the live game. For rollback
   // multiplayer it's the shadow Game that follows confirmed frames,
   // because the live game's processFrame fires speculatively and would
   // over-count (the live recorder is intentionally a no-op).
-  virtual Game* statsGame() { return currentGame(); }
+  virtual Game* StatsGame() { return CurrentGame(); }
 
-  virtual void swapLevel(Level& newLevel) = 0;
+  virtual void SwapLevel(Level& new_level) = 0;
 };

--- a/src/game/controller/localController.cpp
+++ b/src/game/controller/localController.cpp
@@ -13,206 +13,206 @@
 
 #include <cctype>
 
-std::shared_ptr<WormAI> createAi(int controller, Worm& worm, Settings& settings) {
+std::shared_ptr<WormAI> CreateAi(int controller, Worm& worm, Settings& settings) {
   if (controller == 1)
     return std::shared_ptr<WormAI>(new DumbLieroAI());
   else if (controller == 2)
-    return std::shared_ptr<WormAI>(new FollowAI(Weights(), settings.aiParallels, worm.index == 0));
+    return std::shared_ptr<WormAI>(new FollowAI(Weights(), settings.ai_parallels, worm.index == 0));
 
   return std::shared_ptr<WormAI>();
 }
 
 LocalController::LocalController(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings)
-    : game(common, settings, gfx.soundPlayer),
-      state(StateInitial),
-      fadeValue(0),
-      goingToMenu(false) {
+    : game(common, settings, gfx.sound_player),
+      state(kStateInitial),
+      fade_value(0),
+      going_to_menu(false) {
   auto worm1 = std::make_shared<Worm>();
-  worm1->settings = settings->wormSettings[0];
+  worm1->settings = settings->worm_settings[0];
   worm1->health = worm1->settings->health;
   worm1->index = 0;
-  worm1->statsX = 0;
-  worm1->ai = createAi(worm1->settings->controller, *worm1, *settings);
+  worm1->stats_x = 0;
+  worm1->ai = CreateAi(worm1->settings->controller, *worm1, *settings);
 
   auto worm2 = std::make_shared<Worm>();
-  worm2->settings = settings->wormSettings[1];
+  worm2->settings = settings->worm_settings[1];
   worm2->health = worm2->settings->health;
   worm2->index = 1;
-  worm2->statsX = 218;
-  worm2->ai = createAi(worm2->settings->controller, *worm2, *settings);
+  worm2->stats_x = 218;
+  worm2->ai = CreateAi(worm2->settings->controller, *worm2, *settings);
 
-  game.addViewport(new Viewport(Rect(0, 0, 158, 158), worm1->index, 504, 350));
-  game.addViewport(new Viewport(Rect(160, 0, 158 + 160, 158), worm2->index, 504, 350));
+  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), worm1->index, 504, 350));
+  game.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), worm2->index, 504, 350));
 
-  game.addWorm(worm1);
-  game.addWorm(worm2);
+  game.AddWorm(worm1);
+  game.AddWorm(worm2);
 
   // +68 on x to align the viewport in the middle
-  game.addSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
 }
 
-LocalController::~LocalController() { endRecord(); }
+LocalController::~LocalController() { EndRecord(); }
 
-void LocalController::onKey(int key, bool keyState) {
+void LocalController::OnKey(int key, bool key_state) {
   Worm::Control control;
-  Worm* worm = game.findControlForKey(key, control);
+  Worm* worm = game.FindControlForKey(key, control);
   if (worm) {
-    worm->cleanControlStates.set(control, keyState);
+    worm->clean_control_states.Set(control, key_state);
 
-    if (control < Worm::MaxControl) {
+    if (control < Worm::kMaxControl) {
       // Only real controls
-      worm->setControlState(control, keyState);
+      worm->SetControlState(control, key_state);
     }
 
-    if (worm->cleanControlStates[WormSettings::Dig]) {
-      worm->press(Worm::Left);
-      worm->press(Worm::Right);
+    if (worm->clean_control_states[WormSettings::kDig]) {
+      worm->Press(Worm::kLeft);
+      worm->Press(Worm::kRight);
     } else {
-      if (!worm->cleanControlStates[Worm::Left]) worm->release(Worm::Left);
-      if (!worm->cleanControlStates[Worm::Right]) worm->release(Worm::Right);
+      if (!worm->clean_control_states[Worm::kLeft]) worm->Release(Worm::kLeft);
+      if (!worm->clean_control_states[Worm::kRight]) worm->Release(Worm::kRight);
     }
   }
 
-  if (key == DkEscape && !goingToMenu) {
-    fadeValue = 31;
-    goingToMenu = true;
+  if (key == kDkEscape && !going_to_menu) {
+    fade_value = 31;
+    going_to_menu = true;
   }
 }
 
 // Called when the controller loses focus. When not focused, it will not receive key events among
 // other things.
-void LocalController::unfocus() {
-  if (replay.get()) replay->unfocus();
-  if (state == StateWeaponSelection) ws->unfocus();
+void LocalController::Unfocus() {
+  if (replay.get()) replay->Unfocus();
+  if (state == kStateWeaponSelection) ws->Unfocus();
 }
 
 // Called when the controller gets focus.
-void LocalController::focus() {
-  if (state == StateGameEnded) {
-    goingToMenu = true;
-    fadeValue = 0;
+void LocalController::Focus() {
+  if (state == kStateGameEnded) {
+    going_to_menu = true;
+    fade_value = 0;
     return;
   }
-  if (state == StateWeaponSelection) ws->focus();
-  if (replay.get()) replay->focus();
-  if (state == StateInitial) changeState(StateWeaponSelection);
-  game.focus(gfx.playRenderer);
+  if (state == kStateWeaponSelection) ws->Focus();
+  if (replay.get()) replay->Focus();
+  if (state == kStateInitial) ChangeState(kStateWeaponSelection);
+  game.Focus(gfx.play_renderer);
   // FIXME rewrite the focus function to avoid nonsense like this?
-  game.focus(gfx.singleScreenRenderer);
-  goingToMenu = false;
-  fadeValue = 0;
+  game.Focus(gfx.single_screen_renderer);
+  going_to_menu = false;
+  fade_value = 0;
 }
 
-bool LocalController::process() {
-  if (state == StateWeaponSelection) {
+bool LocalController::Process() {
+  if (state == kStateWeaponSelection) {
     // Apply key repeat for held keys during weapon selection.
     // Without SDL repeat events, we need to re-set control bits that
     // were consumed by WeaponSelection (via release/pressedOnce).
     for (std::size_t wi = 0; wi < game.worms.size(); ++wi) {
       Worm& worm = *game.worms[wi];
       for (int bit = 0; bit < 7; ++bit) {
-        bool held = worm.cleanControlStates[bit];
+        bool held = worm.clean_control_states[bit];
         if (held) {
-          if (!worm.controlStates[bit]) {
+          if (!worm.control_states[bit]) {
             // Key is physically held but bit was consumed — apply repeat logic
-            ++wormHeldFrames[wi][bit];
-            if (wormHeldFrames[wi][bit] >= KEY_REPEAT_INITIAL &&
-                (wormHeldFrames[wi][bit] - KEY_REPEAT_INITIAL) % KEY_REPEAT_INTERVAL == 0) {
-              worm.press(static_cast<Worm::Control>(bit));
+            ++worm_held_frames[wi][bit];
+            if (worm_held_frames[wi][bit] >= kKeyRepeatInitial &&
+                (worm_held_frames[wi][bit] - kKeyRepeatInitial) % kKeyRepeatInterval == 0) {
+              worm.Press(static_cast<Worm::Control>(bit));
             }
           } else {
             // Bit is set (initial press frame or just re-set) — reset counter
-            wormHeldFrames[wi][bit] = 0;
+            worm_held_frames[wi][bit] = 0;
           }
         } else {
-          wormHeldFrames[wi][bit] = 0;
+          worm_held_frames[wi][bit] = 0;
         }
       }
     }
 
-    if (ws->processFrame()) changeState(StateGame);
-  } else if (state == StateGame || state == StateGameEnded) {
-    int realFrameSkip = inverseFrameSkip ? !(cycles % frameSkip) : frameSkip;
-    for (int i = 0; i < realFrameSkip && (state == StateGame || state == StateGameEnded); ++i) {
+    if (ws->ProcessFrame()) ChangeState(kStateGame);
+  } else if (state == kStateGame || state == kStateGameEnded) {
+    int real_frame_skip = inverse_frame_skip ? !(cycles % frame_skip) : frame_skip;
+    for (int i = 0; i < real_frame_skip && (state == kStateGame || state == kStateGameEnded); ++i) {
       int phase = game.cycles % 2;
       for (std::size_t i = 0; i < game.worms.size(); ++i) {
         Worm& worm = *game.worms[(i + phase) % game.worms.size()];
         if (worm.ai.get()) {
           auto start_time = std::chrono::steady_clock::now();
-          worm.ai->process(game, worm);
+          worm.ai->Process(game, worm);
           auto time = std::chrono::steady_clock::now() - start_time;
-          game.statsRecorder->aiProcessTime(&worm, time);
+          game.stats_recorder->AiProcessTime(&worm, time);
         }
       }
       if (replay.get()) {
         try {
-          replay->recordFrame();
+          replay->RecordFrame();
         } catch (std::runtime_error& e) {
-          Console::writeWarning(std::string("Error recording replay frame: ") + e.what());
-          Console::writeWarning("Replay recording aborted");
+          console::WriteWarning(std::string("Error recording replay frame: ") + e.what());
+          console::WriteWarning("Replay recording aborted");
           replay.reset();
         }
       }
-      game.processFrame();
+      game.ProcessFrame();
 
-      if (game.isGameOver()) {
-        changeState(StateGameEnded);
+      if (game.IsGameOver()) {
+        ChangeState(kStateGameEnded);
       }
     }
   }
 
   // CommonController::process();
 
-  if (goingToMenu) {
-    if (fadeValue > 0)
-      fadeValue -= 1;
+  if (going_to_menu) {
+    if (fade_value > 0)
+      fade_value -= 1;
     else {
-      if (state == StateGameEnded) {
-        endRecord();
-        game.statsRecorder->finish(game);
+      if (state == kStateGameEnded) {
+        EndRecord();
+        game.stats_recorder->Finish(game);
       }
       return false;
     }
   } else {
-    if (fadeValue < 33) {
-      fadeValue += 1;
+    if (fade_value < 33) {
+      fade_value += 1;
     }
   }
 
   return true;
 }
 
-void LocalController::draw(Renderer& renderer, bool useSpectatorViewports) {
-  if (state == StateWeaponSelection) {
-    ws->draw(renderer, state, useSpectatorViewports);
-  } else if (state == StateGame || state == StateGameEnded || state == StateInitial) {
-    game.draw(renderer, state, useSpectatorViewports);
+void LocalController::Draw(Renderer& renderer, bool use_spectator_viewports) {
+  if (state == kStateWeaponSelection) {
+    ws->Draw(renderer, state, use_spectator_viewports);
+  } else if (state == kStateGame || state == kStateGameEnded || state == kStateInitial) {
+    game.Draw(renderer, state, use_spectator_viewports);
   }
-  renderer.fadeValue = fadeValue;
+  renderer.fade_value = fade_value;
 }
 
-void LocalController::changeState(GameState newState) {
-  if (state == newState) return;
+void LocalController::ChangeState(GameState new_state) {
+  if (state == new_state) return;
 
   // NOTE: We prepare new state before destroying the old.
   // e.g. weapon selection is destroyed first after we successfully
   // started recording.
 
   // NOTE: Must do this here before starting recording!
-  if (state == StateWeaponSelection) {
-    ws->finalize();
+  if (state == kStateWeaponSelection) {
+    ws->Finalize();
   }
 
-  if (newState == StateWeaponSelection) {
+  if (new_state == kStateWeaponSelection) {
     ws.reset(new WeaponSelection(game));
-  } else if (newState == StateGame) {
+  } else if (new_state == kStateGame) {
     // NOTE: This must be done before the replay recording starts below
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm& worm = *game.worms[i];
       worm.lives = game.settings->lives;
     }
 
-    if (game.settings->extensions && game.settings->recordReplays) {
+    if (game.settings->kExtensions && game.settings->record_replays) {
       try {
         std::time_t ticks = std::time(0);
         std::tm* now = std::localtime(&ticks);
@@ -220,58 +220,58 @@ void LocalController::changeState(GameState newState) {
         char buf[512];
         std::strftime(buf, sizeof(buf), "%Y-%m-%d %H.%M.%S", now);
 
-        std::string playerNames = " ";
+        std::string player_names = " ";
         for (std::size_t i = 0; i < 2; ++i) {
           Worm& worm = *game.worms[i];
           std::string const& name = worm.settings->name;
           int chars = 0;
 
-          if (i > 0) playerNames.push_back('-');
+          if (i > 0) player_names.push_back('-');
           for (std::size_t c = 0; c < name.size() && chars < 4; ++c, ++chars) {
             unsigned char ch = (unsigned char)name[c];
-            if (std::isalnum(ch)) playerNames.push_back(ch);
+            if (std::isalnum(ch)) player_names.push_back(ch);
           }
         }
 
-        auto node = gfx.getUserConfigNode() / "Replays" / (buf + playerNames + ".lrp");
+        auto node = gfx.GetUserConfigNode() / "Replays" / (buf + player_names + ".lrp");
 
-        replay.reset(new ReplayWriter(node.toWriter()));
+        replay.reset(new ReplayWriter(node.ToWriter()));
 
-        replay->beginRecord(game);
+        replay->BeginRecord(game);
       } catch (std::runtime_error& e) {
-        gfx.pendingErrorMessage = std::string("Error starting replay recording: ") + e.what();
-        goingToMenu = true;
-        fadeValue = 0;
+        gfx.pending_error_message = std::string("Error starting replay recording: ") + e.what();
+        going_to_menu = true;
+        fade_value = 0;
         return;
       }
     }
 
-    game.startGame();
-  } else if (newState == StateGameEnded) {
-    if (!goingToMenu) {
-      fadeValue = 180;
-      goingToMenu = true;
+    game.StartGame();
+  } else if (new_state == kStateGameEnded) {
+    if (!going_to_menu) {
+      fade_value = 180;
+      going_to_menu = true;
     }
   }
 
-  if (state == StateWeaponSelection) {
-    fadeValue = 33;
+  if (state == kStateWeaponSelection) {
+    fade_value = 33;
     ws.reset();
   }
 
-  state = newState;
+  state = new_state;
 }
 
-void LocalController::endRecord() {
+void LocalController::EndRecord() {
   if (replay.get()) {
     replay.reset();
   }
 }
 
-void LocalController::swapLevel(Level& newLevel) { currentLevel()->swap(newLevel); }
+void LocalController::SwapLevel(Level& new_level) { CurrentLevel()->Swap(new_level); }
 
-Level* LocalController::currentLevel() { return &game.level; }
+Level* LocalController::CurrentLevel() { return &game.level; }
 
-Game* LocalController::currentGame() { return &game; }
+Game* LocalController::CurrentGame() { return &game; }
 
-bool LocalController::running() { return state != StateGameEnded && state != StateInitial; }
+bool LocalController::Running() { return state != kStateGameEnded && state != kStateInitial; }

--- a/src/game/controller/localController.hpp
+++ b/src/game/controller/localController.hpp
@@ -17,31 +17,31 @@ struct ReplayWriter;
 struct LocalController : CommonController {
   LocalController(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings);
   ~LocalController();
-  void onKey(int key, bool keyState);
+  void OnKey(int key, bool key_state);
 
   // Called when the controller loses focus. When not focused, it will not receive key events among
   // other things.
-  void unfocus();
+  void Unfocus();
   // Called when the controller gets focus.
-  void focus();
-  bool process();
-  void draw(Renderer& renderer, bool useSpectatorViewports);
-  void changeState(GameState newState);
-  void endRecord();
-  void swapLevel(Level& newLevel);
-  Level* currentLevel();
-  Game* currentGame();
-  bool running();
+  void Focus();
+  bool Process();
+  void Draw(Renderer& renderer, bool use_spectator_viewports);
+  void ChangeState(GameState new_state);
+  void EndRecord();
+  void SwapLevel(Level& new_level);
+  Level* CurrentLevel();
+  Game* CurrentGame();
+  bool Running();
 
   Game game;
   std::unique_ptr<WeaponSelection> ws;
   GameState state;
-  int fadeValue;
-  bool goingToMenu;
+  int fade_value;
+  bool going_to_menu;
   std::unique_ptr<ReplayWriter> replay;
 
   // Per-worm key repeat counters for weapon selection
-  static constexpr int KEY_REPEAT_INITIAL = 12;
-  static constexpr int KEY_REPEAT_INTERVAL = 3;
-  std::array<std::array<uint16_t, 7>, 2> wormHeldFrames{};
+  static constexpr int kKeyRepeatInitial = 12;
+  static constexpr int kKeyRepeatInterval = 3;
+  std::array<std::array<uint16_t, 7>, 2> worm_held_frames{};
 };

--- a/src/game/controller/replayController.cpp
+++ b/src/game/controller/replayController.cpp
@@ -8,169 +8,169 @@
 
 ReplayController::ReplayController(std::shared_ptr<Common> common,
                                    std::unique_ptr<io::Reader> source)
-    : state(StateInitial),
-      fadeValue(0),
-      goingToMenu(false),
+    : state(kStateInitial),
+      fade_value(0),
+      going_to_menu(false),
       replay(new ReplayReader(std::move(source))),
       common(common) {}
 
-void ReplayController::onKey(int key, bool keyState) {
-  if (key == DkEscape && !goingToMenu) {
-    fadeValue = 31;
-    goingToMenu = true;
+void ReplayController::OnKey(int key, bool key_state) {
+  if (key == kDkEscape && !going_to_menu) {
+    fade_value = 31;
+    going_to_menu = true;
   }
 }
 
 // Called when the controller loses focus. When not focused, it will not receive key events among
 // other things.
-void ReplayController::unfocus() {}
+void ReplayController::Unfocus() {}
 
 // Called when the controller gets focus.
-void ReplayController::focus() {
-  if (state == StateGameEnded) {
-    goingToMenu = true;
-    fadeValue = 0;
+void ReplayController::Focus() {
+  if (state == kStateGameEnded) {
+    going_to_menu = true;
+    fade_value = 0;
     return;
   }
-  if (state == StateInitial) {
+  if (state == kStateInitial) {
     try {
-      game = replay->beginPlayback(common, gfx.soundPlayer);
+      game = replay->BeginPlayback(common, gfx.sound_player);
     } catch (std::runtime_error& e) {
-      gfx.pendingErrorMessage = std::string("Error starting replay playback: ") + e.what();
-      goingToMenu = true;
-      fadeValue = 0;
+      gfx.pending_error_message = std::string("Error starting replay playback: ") + e.what();
+      going_to_menu = true;
+      fade_value = 0;
       return;
     }
     replay->game = game.get();
     // Changing state first when game is available
-    changeState(StateGame);
+    ChangeState(kStateGame);
   }
-  game->focus(gfx.playRenderer);
-  game->focus(gfx.singleScreenRenderer);
-  goingToMenu = false;
-  fadeValue = 0;
+  game->Focus(gfx.play_renderer);
+  game->Focus(gfx.single_screen_renderer);
+  going_to_menu = false;
+  fade_value = 0;
 }
 
-bool ReplayController::process() {
-  if (state == StateGame || state == StateGameEnded) {
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_R)) {
-      *game = *initialGame;
-      game->postClone(*initialGame, true);
-      replay->reader.seekg(initialReaderPos);
+bool ReplayController::Process() {
+  if (state == kStateGame || state == kStateGameEnded) {
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_R)) {
+      *game = *initial_game;
+      game->PostClone(*initial_game, true);
+      replay->reader.Seekg(initial_reader_pos);
     }
 
-    int realFrameSkip = inverseFrameSkip ? !(cycles % frameSkip) : frameSkip;
-    for (int i = 0; i < realFrameSkip && (state == StateGame || state == StateGameEnded); ++i) {
+    int real_frame_skip = inverse_frame_skip ? !(cycles % frame_skip) : frame_skip;
+    for (int i = 0; i < real_frame_skip && (state == kStateGame || state == kStateGameEnded); ++i) {
       if (replay.get()) {
         try {
-          if (!replay->playbackFrame(*gfx.primaryRenderer)) {
+          if (!replay->PlaybackFrame(*gfx.primary_renderer)) {
             // End of replay
             replay.reset();
           }
         } catch (io::StreamError& e) {
-          gfx.pendingErrorMessage = std::string("Stream error in replay: ") + e.what();
-          changeState(StateGameEnded);
+          gfx.pending_error_message = std::string("Stream error in replay: ") + e.what();
+          ChangeState(kStateGameEnded);
           replay.reset();
         } catch (io::ArchiveCheckError& e) {
-          gfx.pendingErrorMessage = std::string("Archive error in replay: ") + e.what();
-          changeState(StateGameEnded);
+          gfx.pending_error_message = std::string("Archive error in replay: ") + e.what();
+          ChangeState(kStateGameEnded);
           replay.reset();
         } catch (io::EndOfStream& e) {
-          gfx.pendingErrorMessage = std::string("EOF in replay: ") + e.what();
-          changeState(StateGameEnded);
+          gfx.pending_error_message = std::string("EOF in replay: ") + e.what();
+          ChangeState(kStateGameEnded);
           replay.reset();
         }
       }
-      game->processFrame();
+      game->ProcessFrame();
 
-      if (goingToMenu) {
-        if (fadeValue > 0)
-          fadeValue -= 1;
+      if (going_to_menu) {
+        if (fade_value > 0)
+          fade_value -= 1;
         else
           break;
-      } else if (fadeValue < 33) {
-        fadeValue += 1;
+      } else if (fade_value < 33) {
+        fade_value += 1;
       }
     }
 
-    if (game->isGameOver()) {
-      changeState(StateGameEnded);
+    if (game->IsGameOver()) {
+      ChangeState(kStateGameEnded);
     }
   }
 
-  CommonController::process();
+  CommonController::Process();
 
-  if (goingToMenu && fadeValue <= 0) {
-    if (state == StateGameEnded) {
-      game->statsRecorder->finish(*game);
+  if (going_to_menu && fade_value <= 0) {
+    if (state == kStateGameEnded) {
+      game->stats_recorder->Finish(*game);
     }
     return false;
   }
 
-  if (!replay.get() && state == StateGame) {
-    game->statsRecorder->finish(*game);
+  if (!replay.get() && state == kStateGame) {
+    game->stats_recorder->Finish(*game);
     return false;
   }
 
   return true;
 }
 
-void ReplayController::draw(Renderer& renderer, bool useSpectatorViewports) {
-  if (state == StateGame || state == StateGameEnded) {
-    game->draw(renderer, state, useSpectatorViewports, true);
+void ReplayController::Draw(Renderer& renderer, bool use_spectator_viewports) {
+  if (state == kStateGame || state == kStateGameEnded) {
+    game->Draw(renderer, state, use_spectator_viewports, true);
   }
-  renderer.fadeValue = fadeValue;
+  renderer.fade_value = fade_value;
 }
 
-void ReplayController::changeState(GameState newState) {
-  if (state == newState) return;
+void ReplayController::ChangeState(GameState new_state) {
+  if (state == new_state) return;
 
-  if (newState == StateGame) {
+  if (new_state == kStateGame) {
     // FIXME: the viewports are changed based on the replay for some
     // reason, so we need to restore them here. Probably makes more sense
     // to not save the viewports at all. But that probably breaks save
     // format compatibility?
-    game->clearViewports();
+    game->ClearViewports();
 
     // for backwards compatibility reasons, this is not stored within the
     // replay. Yet.
-    game->worms[0]->statsX = 0;
-    game->worms[1]->statsX = 218;
+    game->worms[0]->stats_x = 0;
+    game->worms[1]->stats_x = 218;
 
     // spectator viewport is always full size
     // +68 on x to align the viewport in the middle
-    game->addSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
-    if (gfx.settings->singleScreenReplay) {
+    game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+    if (gfx.settings->single_screen_replay) {
       // on single screen replay, use the spectator viewport for the
       // main screen as well
       // we can't use the same object, as the vector's clean function will delete them
-      game->addViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+      game->AddViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
     } else {
-      game->addViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
-      game->addViewport(
+      game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
+      game->AddViewport(
           new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
     }
-    game->startGame();
-    initialGame.reset(new Game(*game));
-    initialGame->postClone(*game, true);
-    initialReaderPos = replay->reader.tellg();
-  } else if (newState == StateGameEnded) {
-    if (!goingToMenu) {
-      fadeValue = 180;
-      goingToMenu = true;
+    game->StartGame();
+    initial_game.reset(new Game(*game));
+    initial_game->PostClone(*game, true);
+    initial_reader_pos = replay->reader.Tellg();
+  } else if (new_state == kStateGameEnded) {
+    if (!going_to_menu) {
+      fade_value = 180;
+      going_to_menu = true;
     }
   }
 
-  state = newState;
+  state = new_state;
 }
 
-void ReplayController::swapLevel(Level& newLevel) { currentLevel()->swap(newLevel); }
+void ReplayController::SwapLevel(Level& new_level) { CurrentLevel()->Swap(new_level); }
 
-Level* ReplayController::currentLevel() {
+Level* ReplayController::CurrentLevel() {
   if (game.get() && replay.get()) return &game->level;
   return nullptr;
 }
 
-Game* ReplayController::currentGame() { return game.get(); }
+Game* ReplayController::CurrentGame() { return game.get(); }
 
-bool ReplayController::running() { return state != StateGameEnded && state != StateInitial; }
+bool ReplayController::Running() { return state != kStateGameEnded && state != kStateInitial; }

--- a/src/game/controller/replayController.hpp
+++ b/src/game/controller/replayController.hpp
@@ -18,29 +18,29 @@ struct Game;
 struct ReplayController : CommonController {
   ReplayController(std::shared_ptr<Common> common, std::unique_ptr<io::Reader> source);
 
-  bool isReplay() { return true; };
-  void onKey(int key, bool keyState);
+  bool IsReplay() { return true; };
+  void OnKey(int key, bool key_state);
   // Called when the controller loses focus. When not focused, it will not receive key events among
   // other things.
-  void unfocus();
+  void Unfocus();
   // Called when the controller gets focus.
-  void focus();
-  bool process();
-  void draw(Renderer& renderer, bool useSpectatorViewports);
-  void changeState(GameState newState);
-  void swapLevel(Level& newLevel);
-  Level* currentLevel();
-  Game* currentGame();
-  bool running();
+  void Focus();
+  bool Process();
+  void Draw(Renderer& renderer, bool use_spectator_viewports);
+  void ChangeState(GameState new_state);
+  void SwapLevel(Level& new_level);
+  Level* CurrentLevel();
+  Game* CurrentGame();
+  bool Running();
 
   std::unique_ptr<Game> game;
 
-  std::unique_ptr<Game> initialGame;
-  std::size_t initialReaderPos = 0;
+  std::unique_ptr<Game> initial_game;
+  std::size_t initial_reader_pos = 0;
 
   GameState state;
-  int fadeValue;
-  bool goingToMenu;
+  int fade_value;
+  bool going_to_menu;
   std::unique_ptr<ReplayReader> replay;
   std::shared_ptr<Common> common;
 };

--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -19,78 +19,78 @@
 // viewports are configured here from a single source of truth. The
 // live ctor also adds a SpectatorViewport; the shadow does not need
 // one.
-static void configureGameSlots(Game& g, std::array<std::shared_ptr<WormSettings>, 2> ws) {
+static void ConfigureGameSlots(Game& g, std::array<std::shared_ptr<WormSettings>, 2> ws) {
   for (int idx = 0; idx < 2; ++idx) {
     auto worm = std::make_shared<Worm>();
     worm->settings = ws[idx];
     worm->health = worm->settings->health;
     worm->index = idx;
-    worm->statsX = idx == 0 ? 0 : 218;
-    g.addWorm(worm);
+    worm->stats_x = idx == 0 ? 0 : 218;
+    g.AddWorm(worm);
   }
-  g.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  g.addViewport(new Viewport(Rect(160, 0, 158 + 160, 158), 1, 504, 350));
+  g.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+  g.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), 1, 504, 350));
 }
 
 RollbackController::RollbackController(std::shared_ptr<Common> common,
-                                       std::shared_ptr<Settings> settings, int localPlayerIdx)
-    : game(common, settings, gfx.soundPlayer),
-      localIdx(localPlayerIdx),
-      remoteIdx(localPlayerIdx ^ 1),
-      state(StateInitial),
-      fadeValue(0),
-      goingToMenu(false),
-      simFrame(0),
-      inputDelay(3),
-      lastSentFrame(0),
-      lastSentFrameValid(false),
+                                       std::shared_ptr<Settings> settings, int local_player_idx)
+    : game(common, settings, gfx.sound_player),
+      localIdx_(local_player_idx),
+      remoteIdx_(local_player_idx ^ 1),
+      state_(kStateInitial),
+      fadeValue_(0),
+      goingToMenu_(false),
+      simFrame_(0),
+      inputDelay_(3),
+      lastSentFrame_(0),
+      lastSentFrameValid_(false),
       rollbackBufferPrepared_(false),
       confirmedSimFrame_(-1),
       lastRemoteInput_(0) {
-  localPrevInput = 0;
-  remotePrevInput = 0;
-  localHeldFrames.fill(0);
-  remoteHeldFrames.fill(0);
-  skipWeaponSelection = false;
-  levelPreloaded = false;
+  localPrevInput_ = 0;
+  remotePrevInput_ = 0;
+  localHeldFrames_.fill(0);
+  remoteHeldFrames_.fill(0);
+  skipWeaponSelection_ = false;
+  levelPreloaded_ = false;
   localPaused_ = false;
   remotePaused_ = false;
 
-  pauseMenu_.init(true);
-  pauseMenu_.addItem(MenuItem(7, 6, "RESUME", 0));
-  pauseMenu_.addItem(MenuItem(7, 6, "END MATCH", 2));
-  pauseMenu_.addItem(MenuItem(7, 6, "DISCONNECT", 1));
+  pauseMenu_.Init(true);
+  pauseMenu_.AddItem(MenuItem(7, 6, "RESUME", 0));
+  pauseMenu_.AddItem(MenuItem(7, 6, "END MATCH", 2));
+  pauseMenu_.AddItem(MenuItem(7, 6, "DISCONNECT", 1));
 
-  localInputs.fill(0);
-  remoteInputs.fill(0);
-  remoteInputReady.fill(false);
+  localInputs_.fill(0);
+  remoteInputs_.fill(0);
+  remoteInputReady_.fill(false);
 
   std::array<std::shared_ptr<WormSettings>, 2> ws;
   for (int idx = 0; idx < 2; ++idx) {
-    ws[idx] = (idx == localIdx) ? settings->wormSettings[Settings::NetworkPlayerIdx]
-                                : settings->wormSettings[idx];
+    ws[idx] = (idx == localIdx_) ? settings->worm_settings[Settings::kNetworkPlayerIdx]
+                                : settings->worm_settings[idx];
   }
-  configureGameSlots(game, ws);
-  game.addSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  ConfigureGameSlots(game, ws);
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
 }
 
 RollbackController::~RollbackController() {}
 
-void RollbackController::loadLevelFromData(const std::vector<uint8_t>& data) {
+void RollbackController::LoadLevelFromData(const std::vector<uint8_t>& data) {
   if (data.size() < 5) return;
 
-  bool isCompressed = (data[0] != 0);
-  uint32_t rawSize;
-  std::memcpy(&rawSize, data.data() + 1, 4);
+  bool is_compressed = (data[0] != 0);
+  uint32_t raw_size;
+  std::memcpy(&raw_size, data.data() + 1, 4);
 
-  static constexpr uint32_t MAX_RAW_SIZE = 10 * 1024 * 1024;
-  if (rawSize > MAX_RAW_SIZE) return;
+  static constexpr uint32_t kMaxRawSize = 10 * 1024 * 1024;
+  if (raw_size > kMaxRawSize) return;
 
   std::vector<uint8_t> raw;
-  if (isCompressed) {
-    raw.resize(rawSize);
-    mz_ulong destLen = rawSize;
-    int status = mz_uncompress(raw.data(), &destLen, data.data() + 5,
+  if (is_compressed) {
+    raw.resize(raw_size);
+    mz_ulong dest_len = raw_size;
+    int status = mz_uncompress(raw.data(), &dest_len, data.data() + 5,
                                static_cast<mz_ulong>(data.size() - 5));
     if (status != MZ_OK) return;
   } else {
@@ -105,77 +105,77 @@ void RollbackController::loadLevelFromData(const std::vector<uint8_t>& data) {
 
   if (w == 0 || h == 0 || w > 4096 || h > 4096) return;
 
-  uint32_t randStateLen;
-  std::memcpy(&randStateLen, raw.data() + 4, 4);
+  uint32_t rand_state_len;
+  std::memcpy(&rand_state_len, raw.data() + 4, 4);
 
-  if (randStateLen > 64 * 1024) return;
-  if (raw.size() < 8 + randStateLen + 4) return;
+  if (rand_state_len > 64 * 1024) return;
+  if (raw.size() < 8 + rand_state_len + 4) return;
 
-  std::string randState(reinterpret_cast<const char*>(raw.data() + 8), randStateLen);
-  uint32_t randLast;
-  std::memcpy(&randLast, raw.data() + 8 + randStateLen, 4);
+  std::string rand_state(reinterpret_cast<const char*>(raw.data() + 8), rand_state_len);
+  uint32_t rand_last;
+  std::memcpy(&rand_last, raw.data() + 8 + rand_state_len, 4);
 
-  size_t pixelsOffset = 8 + randStateLen + 4;
-  size_t pixelDataSize = static_cast<size_t>(w) * h;
-  if (raw.size() < pixelsOffset + pixelDataSize + 768) return;
+  size_t pixels_offset = 8 + rand_state_len + 4;
+  size_t pixel_data_size = static_cast<size_t>(w) * h;
+  if (raw.size() < pixels_offset + pixel_data_size + 768) return;
 
-  game.level.resize(w, h);
+  game.level.Resize(w, h);
   Common& common = *game.common;
 
-  const uint8_t* pixels = raw.data() + pixelsOffset;
-  for (size_t i = 0; i < pixelDataSize; ++i) {
+  const uint8_t* pixels = raw.data() + pixels_offset;
+  for (size_t i = 0; i < pixel_data_size; ++i) {
     game.level.data[i] = pixels[i];
     game.level.materials[i] = common.materials[pixels[i]];
   }
 
-  const uint8_t* palData = raw.data() + pixelsOffset + pixelDataSize;
+  const uint8_t* pal_data = raw.data() + pixels_offset + pixel_data_size;
   for (int i = 0; i < 256; ++i) {
-    game.level.origpal.entries[i].r = palData[i * 3 + 0];
-    game.level.origpal.entries[i].g = palData[i * 3 + 1];
-    game.level.origpal.entries[i].b = palData[i * 3 + 2];
+    game.level.origpal.entries[i].r = pal_data[i * 3 + 0];
+    game.level.origpal.entries[i].g = pal_data[i * 3 + 1];
+    game.level.origpal.entries[i].b = pal_data[i * 3 + 2];
   }
 
-  game.rand.deserialize(randState);
-  game.rand.last = randLast;
+  game.rand.Deserialize(rand_state);
+  game.rand.last = rand_last;
 
-  levelPreloaded = true;
+  levelPreloaded_ = true;
 }
 
-void RollbackController::setInputCallbacks(InputBatchSendCallback send) {
-  sendInputBatch = std::move(send);
+void RollbackController::SetInputCallbacks(InputBatchSendCallback send) {
+  sendInputBatch_ = std::move(send);
 }
 
-void RollbackController::sendInputWindow(uint32_t newestFrame, uint32_t localFrame) {
-  if (!sendInputBatch) return;
-  constexpr uint8_t K = static_cast<uint8_t>(rollback::kMaxRollback + 1);
+void RollbackController::SendInputWindow(uint32_t newest_frame, uint32_t local_frame) {
+  if (!sendInputBatch_) return;
+  constexpr uint8_t kK = static_cast<uint8_t>(rollback::kMaxRollback + 1);
   uint8_t count;
-  uint32_t baseFrame;
-  if (newestFrame + 1u < K) {
-    count = static_cast<uint8_t>(newestFrame + 1u);
-    baseFrame = 0;
+  uint32_t base_frame;
+  if (newest_frame + 1u < kK) {
+    count = static_cast<uint8_t>(newest_frame + 1u);
+    base_frame = 0;
   } else {
-    count = K;
-    baseFrame = newestFrame - (K - 1u);
+    count = kK;
+    base_frame = newest_frame - (kK - 1u);
   }
-  std::array<uint8_t, K> window{};
+  std::array<uint8_t, kK> window{};
   for (uint8_t i = 0; i < count; ++i) {
-    window[i] = localInputs[(baseFrame + i) % INPUT_BUFFER_SIZE];
+    window[i] = localInputs_[(base_frame + i) % kInputBufferSize];
   }
-  sendInputBatch(generation_, baseFrame, count, window.data(), localFrame);
+  sendInputBatch_(generation_, base_frame, count, window.data(), local_frame);
 }
 
-void RollbackController::injectRemoteBatch(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                           uint8_t const* inputs, uint32_t remoteLocalFrame) {
+void RollbackController::InjectRemoteBatch(uint8_t generation, uint32_t base_frame, uint8_t count,
+                                           uint8_t const* inputs, uint32_t remote_local_frame) {
   // Same-generation packets feed the input ring; gen+1 packets are
   // buffered until our own phase transition fires (replayed in
   // resetForGamePhase). Older or further-future packets are unrecoverable.
   if (generation == generation_) {
     for (uint8_t i = 0; i < count; ++i) {
-      injectRemoteInput(baseFrame + i, inputs[i]);
+      InjectRemoteInput(base_frame + i, inputs[i]);
     }
     // Monotonic — an out-of-order stale packet must not pull our
     // knowledge of the remote's progress backwards.
-    int32_t f = static_cast<int32_t>(remoteLocalFrame);
+    int32_t f = static_cast<int32_t>(remote_local_frame);
     if (f > lastKnownRemoteFrame_) lastKnownRemoteFrame_ = f;
     return;
   }
@@ -183,10 +183,10 @@ void RollbackController::injectRemoteBatch(uint8_t generation, uint32_t baseFram
   if (generation == static_cast<uint8_t>(generation_ + 1) && count <= kMaxPendingFutureBatches) {
     if (pendingFutureCount_ < kMaxPendingFutureBatches) {
       auto& slot = pendingFutureBatches_[pendingFutureCount_++];
-      slot.baseFrame = baseFrame;
+      slot.base_frame = base_frame;
       slot.count = count;
       for (uint8_t i = 0; i < count; ++i) slot.inputs[i] = inputs[i];
-      slot.remoteLocalFrame = remoteLocalFrame;
+      slot.remote_local_frame = remote_local_frame;
       return;
     }
   }
@@ -194,27 +194,27 @@ void RollbackController::injectRemoteBatch(uint8_t generation, uint32_t baseFram
   ++droppedOldGenerationBatches_;
 }
 
-void RollbackController::injectRemoteInput(uint32_t frame, uint8_t input) {
+void RollbackController::InjectRemoteInput(uint32_t frame, uint8_t input) {
   // Redundant batch packets routinely overlap the confirmation boundary;
   // re-injecting already-confirmed frames would re-set remoteInputReady
   // on a ring slot that wraps into the live rollback window.
   if (static_cast<int32_t>(frame) <= confirmedSimFrame_) return;
-  uint32_t slot = frame % INPUT_BUFFER_SIZE;
-  remoteInputs[slot] = input;
-  remoteInputReady[slot] = true;
+  uint32_t slot = frame % kInputBufferSize;
+  remoteInputs_[slot] = input;
+  remoteInputReady_[slot] = true;
 }
 
-void RollbackController::onKey(int key, bool keyState) {
+void RollbackController::OnKey(int key, bool key_state) {
   Worm::Control control;
-  Worm* worm = game.worms[localIdx].get();
+  Worm* worm = game.worms[localIdx_].get();
   bool found = false;
 
-  if (worm->settings->inputDevice == WormSettingsExtensions::InputKeyboard) {
+  if (worm->settings->input_device == WormSettingsExtensions::kInputKeyboard) {
     uint32_t* controls =
-        game.settings->extensions ? worm->settings->controlsEx : worm->settings->controls;
-    std::size_t maxControl =
-        game.settings->extensions ? WormSettings::MaxControlEx : WormSettings::MaxControl;
-    for (std::size_t c = 0; c < maxControl; ++c) {
+        game.settings->kExtensions ? worm->settings->controls_ex : worm->settings->controls;
+    std::size_t max_control =
+        game.settings->kExtensions ? WormSettings::kMaxControlEx : WormSettings::kMaxControl;
+    for (std::size_t c = 0; c < max_control; ++c) {
       if (controls[c] == static_cast<uint32_t>(key)) {
         control = static_cast<Worm::Control>(c);
         found = true;
@@ -224,120 +224,120 @@ void RollbackController::onKey(int key, bool keyState) {
   }
 
   if (found) {
-    worm->cleanControlStates.set(control, keyState);
+    worm->clean_control_states.Set(control, key_state);
 
-    if (control < Worm::MaxControl) {
-      localControlState.set(control, keyState);
+    if (control < Worm::kMaxControl) {
+      localControlState_.Set(control, key_state);
     }
 
-    if (worm->cleanControlStates[WormSettings::Dig]) {
-      localControlState.set(Worm::Left, true);
-      localControlState.set(Worm::Right, true);
+    if (worm->clean_control_states[WormSettings::kDig]) {
+      localControlState_.Set(Worm::kLeft, true);
+      localControlState_.Set(Worm::kRight, true);
     } else {
-      if (!worm->cleanControlStates[Worm::Left]) localControlState.set(Worm::Left, false);
-      if (!worm->cleanControlStates[Worm::Right]) localControlState.set(Worm::Right, false);
+      if (!worm->clean_control_states[Worm::kLeft]) localControlState_.Set(Worm::kLeft, false);
+      if (!worm->clean_control_states[Worm::kRight]) localControlState_.Set(Worm::kRight, false);
     }
   }
 
-  if (key == DkEscape && keyState) {
+  if (key == kDkEscape && key_state) {
     if (localPaused_) {
       localPaused_ = false;
-      if (onLocalResume) onLocalResume();
-    } else if (remotePaused_ && !goingToMenu) {
+      if (onLocalResume_) onLocalResume_();
+    } else if (remotePaused_ && !goingToMenu_) {
       // Remote is paused, local Escapes — treat as a disconnect so the
       // peer learns and tears down in lockstep instead of waiting for
       // socket timeout.
-      if (onPeerLeft) onPeerLeft();
-      peerLeft();
-    } else if (!goingToMenu) {
+      if (onPeerLeft_) onPeerLeft_();
+      PeerLeft();
+    } else if (!goingToMenu_) {
       localPaused_ = true;
-      pauseMenu_.moveToFirstVisible();
-      if (onLocalPause) onLocalPause();
+      pauseMenu_.MoveToFirstVisible();
+      if (onLocalPause_) onLocalPause_();
     }
   }
 }
 
-void RollbackController::unfocus() {
-  if (state == StateWeaponSelection && ws) ws->unfocus();
+void RollbackController::Unfocus() {
+  if (state_ == kStateWeaponSelection && ws_) ws_->Unfocus();
   localPaused_ = false;
   remotePaused_ = false;
 }
 
-void RollbackController::focus() {
-  if (state == StateGameEnded) {
-    goingToMenu = true;
-    fadeValue = 0;
+void RollbackController::Focus() {
+  if (state_ == kStateGameEnded) {
+    goingToMenu_ = true;
+    fadeValue_ = 0;
     return;
   }
-  if (state == StateWeaponSelection) ws->focus();
-  if (state == StateInitial) {
-    if (!levelPreloaded) game.level.generateFromSettings(*game.common, *game.settings, game.rand);
+  if (state_ == kStateWeaponSelection) ws_->Focus();
+  if (state_ == kStateInitial) {
+    if (!levelPreloaded_) game.level.GenerateFromSettings(*game.common, *game.settings, game.rand);
 
-    if (skipWeaponSelection) {
-      for (auto const& w : game.worms) w->initWeapons(game);
+    if (skipWeaponSelection_) {
+      for (auto const& w : game.worms) w->InitWeapons(game);
       for (auto const& w : game.worms) w->lives = game.settings->lives;
-      game.startGame();
-      game.resetWorms();
-      state = StateGame;
+      game.StartGame();
+      game.ResetWorms();
+      state_ = kStateGame;
 
-      seedRollbackAndShadow();
+      SeedRollbackAndShadow();
     } else {
-      state = StateWeaponSelection;
+      state_ = kStateWeaponSelection;
 
       for (auto const& w : game.worms) {
         w->settings->controller = 0;
       }
 
-      ws = std::make_unique<WeaponSelection>(game);
+      ws_ = std::make_unique<WeaponSelection>(game);
     }
   }
-  game.focus(gfx.playRenderer);
-  game.focus(gfx.singleScreenRenderer);
-  goingToMenu = false;
-  fadeValue = 0;
+  game.Focus(gfx.play_renderer);
+  game.Focus(gfx.single_screen_renderer);
+  goingToMenu_ = false;
+  fadeValue_ = 0;
 
   // Size the rollback ring buffer once the level (and therefore the
   // GameSnapshot vector sizes) are known.
   if (!rollbackBufferPrepared_) {
-    rollbackBuffer_.prepare(game);
+    rollbackBuffer_.Prepare(game);
     rollbackBufferPrepared_ = true;
   }
 }
 
-bool RollbackController::process() {
-  if (isPaused()) {
-    if (fadeValue < 33) fadeValue += 1;
+bool RollbackController::Process() {
+  if (IsPaused()) {
+    if (fadeValue_ < 33) fadeValue_ += 1;
 
     if (localPaused_) {
-      if (gfx.testSDLKeyOnce(SDL_SCANCODE_UP) || gfx.testControlOnce(WormSettingsExtensions::Up) ||
-          gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
-        g_soundPlayer->play(game.common->soundHook[SoundMenuMoveDown]);
-        pauseMenu_.movement(-1);
+      if (gfx.TestSdlKeyOnce(SDL_SCANCODE_UP) || gfx.TestControlOnce(WormSettingsExtensions::kUp) ||
+          gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+        g_sound_player->Play(game.common->sound_hook[SoundMenuMoveDown]);
+        pauseMenu_.Movement(-1);
       }
 
-      if (gfx.testSDLKeyOnce(SDL_SCANCODE_DOWN) ||
-          gfx.testControlOnce(WormSettingsExtensions::Down) ||
-          gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
-        g_soundPlayer->play(game.common->soundHook[SoundMenuMoveUp]);
-        pauseMenu_.movement(1);
+      if (gfx.TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
+          gfx.TestControlOnce(WormSettingsExtensions::kDown) ||
+          gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+        g_sound_player->Play(game.common->sound_hook[SoundMenuMoveUp]);
+        pauseMenu_.Movement(1);
       }
 
-      if (gfx.testSDLKeyOnce(SDL_SCANCODE_RETURN) || gfx.testSDLKeyOnce(SDL_SCANCODE_KP_ENTER) ||
-          gfx.testControlOnce(WormSettingsExtensions::Fire) ||
-          gfx.testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
-        int sel = pauseMenu_.selectedId();
+      if (gfx.TestSdlKeyOnce(SDL_SCANCODE_RETURN) || gfx.TestSdlKeyOnce(SDL_SCANCODE_KP_ENTER) ||
+          gfx.TestControlOnce(WormSettingsExtensions::kFire) ||
+          gfx.TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
+        int sel = pauseMenu_.SelectedId();
         if (sel == 0) {
           localPaused_ = false;
-          if (onLocalResume) onLocalResume();
+          if (onLocalResume_) onLocalResume_();
         } else if (sel == 2) {
           localPaused_ = false;
-          if (onLocalResume) onLocalResume();
-          if (onEndMatch) onEndMatch();
-          endMatch();
+          if (onLocalResume_) onLocalResume_();
+          if (onEndMatch_) onEndMatch_();
+          EndMatch();
         } else {
-          if (onLocalResume) onLocalResume();
-          if (onPeerLeft) onPeerLeft();
-          peerLeft();
+          if (onLocalResume_) onLocalResume_();
+          if (onPeerLeft_) onPeerLeft_();
+          PeerLeft();
         }
       }
     }
@@ -347,150 +347,150 @@ bool RollbackController::process() {
 
   lastTickResimFrames_ = 0;
 
-  if (state == StateWeaponSelection) {
-    advanceWeaponSelection();
-  } else if (state == StateGame || state == StateGameEnded) {
-    advanceSimulation();
+  if (state_ == kStateWeaponSelection) {
+    AdvanceWeaponSelection();
+  } else if (state_ == kStateGame || state_ == kStateGameEnded) {
+    AdvanceSimulation();
   }
 
-  if (goingToMenu) {
-    if (fadeValue > 0)
-      fadeValue -= 1;
+  if (goingToMenu_) {
+    if (fadeValue_ > 0)
+      fadeValue_ -= 1;
     else {
-      if (state == StateGameEnded) {
+      if (state_ == kStateGameEnded) {
         // Stats live on the shadow (see setupShadowGame); finalize there
         // so gameTime / lifeSpans reflect the confirmed timeline.
-        Game* sg = statsGame();
-        sg->statsRecorder->finish(*sg);
+        Game* sg = StatsGame();
+        sg->stats_recorder->Finish(*sg);
       }
       return false;
     }
   } else {
-    if (fadeValue < 33) fadeValue += 1;
+    if (fadeValue_ < 33) fadeValue_ += 1;
   }
 
   return true;
 }
 
-bool RollbackController::weaponSelectStep(uint8_t curLocal, uint8_t curRemote) {
-  uint8_t risingLocal = curLocal & ~localPrevInput;
-  uint8_t risingRemote = curRemote & ~remotePrevInput;
-  uint8_t releasedLocal = localPrevInput & ~curLocal;
-  uint8_t releasedRemote = remotePrevInput & ~curRemote;
+bool RollbackController::WeaponSelectStep(uint8_t cur_local, uint8_t cur_remote) {
+  uint8_t rising_local = cur_local & ~localPrevInput_;
+  uint8_t rising_remote = cur_remote & ~remotePrevInput_;
+  uint8_t released_local = localPrevInput_ & ~cur_local;
+  uint8_t released_remote = remotePrevInput_ & ~cur_remote;
 
-  game.worms[localIdx]->controlStates.istate |= risingLocal;
-  game.worms[remoteIdx]->controlStates.istate |= risingRemote;
-  game.worms[localIdx]->controlStates.istate &= ~releasedLocal;
-  game.worms[remoteIdx]->controlStates.istate &= ~releasedRemote;
+  game.worms[localIdx_]->control_states.istate |= rising_local;
+  game.worms[remoteIdx_]->control_states.istate |= rising_remote;
+  game.worms[localIdx_]->control_states.istate &= ~released_local;
+  game.worms[remoteIdx_]->control_states.istate &= ~released_remote;
 
   for (int bit = 0; bit < 7; ++bit) {
     uint8_t mask = 1 << bit;
-    if (risingLocal & mask) {
-      localHeldFrames[bit] = 0;
-    } else if (curLocal & mask) {
-      ++localHeldFrames[bit];
-      if (localHeldFrames[bit] >= KEY_REPEAT_INITIAL &&
-          (localHeldFrames[bit] - KEY_REPEAT_INITIAL) % KEY_REPEAT_INTERVAL == 0) {
-        game.worms[localIdx]->controlStates.istate |= mask;
+    if (rising_local & mask) {
+      localHeldFrames_[bit] = 0;
+    } else if (cur_local & mask) {
+      ++localHeldFrames_[bit];
+      if (localHeldFrames_[bit] >= kKeyRepeatInitial &&
+          (localHeldFrames_[bit] - kKeyRepeatInitial) % kKeyRepeatInterval == 0) {
+        game.worms[localIdx_]->control_states.istate |= mask;
       }
     } else {
-      localHeldFrames[bit] = 0;
+      localHeldFrames_[bit] = 0;
     }
-    if (risingRemote & mask) {
-      remoteHeldFrames[bit] = 0;
-    } else if (curRemote & mask) {
-      ++remoteHeldFrames[bit];
-      if (remoteHeldFrames[bit] >= KEY_REPEAT_INITIAL &&
-          (remoteHeldFrames[bit] - KEY_REPEAT_INITIAL) % KEY_REPEAT_INTERVAL == 0) {
-        game.worms[remoteIdx]->controlStates.istate |= mask;
+    if (rising_remote & mask) {
+      remoteHeldFrames_[bit] = 0;
+    } else if (cur_remote & mask) {
+      ++remoteHeldFrames_[bit];
+      if (remoteHeldFrames_[bit] >= kKeyRepeatInitial &&
+          (remoteHeldFrames_[bit] - kKeyRepeatInitial) % kKeyRepeatInterval == 0) {
+        game.worms[remoteIdx_]->control_states.istate |= mask;
       }
     } else {
-      remoteHeldFrames[bit] = 0;
+      remoteHeldFrames_[bit] = 0;
     }
   }
 
-  localPrevInput = curLocal;
-  remotePrevInput = curRemote;
+  localPrevInput_ = cur_local;
+  remotePrevInput_ = cur_remote;
 
-  return ws->processFrame();
+  return ws_->ProcessFrame();
 }
 
-void RollbackController::saveWeaponSelectSnap(WeaponSelectSnap& snap) const {
+void RollbackController::SaveWeaponSelectSnap(WeaponSelectSnap& snap) const {
   snap.valid = true;
   for (int i = 0; i < 2; ++i) {
     Worm const& w = *game.worms[i];
-    WormSettings const& wsCfg = *w.settings;
+    WormSettings const& ws_cfg = *w.settings;
     auto& p = snap.players[i];
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
-      p.weapons[j] = wsCfg.weapons[j];
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
+      p.weapons[j] = ws_cfg.weapons[j];
     }
-    p.isReady = ws->isReady[i];
-    p.menuSelection = ws->menus[i].selection();
-    p.menuTopItem = ws->menus[i].topItem;
-    p.menuBottomItem = ws->menus[i].bottomItem;
-    p.wormControlStates = static_cast<uint16_t>(w.controlStates.istate);
-    p.currentWeapon = w.currentWeapon;
+    p.is_ready = ws_->is_ready[i];
+    p.menu_selection = ws_->menus[i].Selection();
+    p.menu_top_item = ws_->menus[i].top_item;
+    p.menu_bottom_item = ws_->menus[i].bottom_item;
+    p.worm_control_states = static_cast<uint16_t>(w.control_states.istate);
+    p.current_weapon = w.current_weapon;
   }
   snap.rand = game.rand;
-  snap.localPrevInput = localPrevInput;
-  snap.remotePrevInput = remotePrevInput;
-  snap.localHeldFrames = localHeldFrames;
-  snap.remoteHeldFrames = remoteHeldFrames;
+  snap.local_prev_input = localPrevInput_;
+  snap.remote_prev_input = remotePrevInput_;
+  snap.local_held_frames = localHeldFrames_;
+  snap.remote_held_frames = remoteHeldFrames_;
 }
 
-void RollbackController::loadWeaponSelectSnap(WeaponSelectSnap const& snap) {
+void RollbackController::LoadWeaponSelectSnap(WeaponSelectSnap const& snap) {
   Common const& common = *game.common;
   for (int i = 0; i < 2; ++i) {
     Worm& w = *game.worms[i];
-    WormSettings& wsCfg = *w.settings;
+    WormSettings& ws_cfg = *w.settings;
     auto const& p = snap.players[i];
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
-      wsCfg.weapons[j] = p.weapons[j];
-      int weapOrderIdx = static_cast<int>(p.weapons[j]) - 1;
-      if (weapOrderIdx >= 0 && weapOrderIdx < static_cast<int>(common.weapOrder.size())) {
-        int w_idx = common.weapOrder[weapOrderIdx];
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
+      ws_cfg.weapons[j] = p.weapons[j];
+      int weap_order_idx = static_cast<int>(p.weapons[j]) - 1;
+      if (weap_order_idx >= 0 && weap_order_idx < static_cast<int>(common.weap_order.size())) {
+        int w_idx = common.weap_order[weap_order_idx];
         w.weapons[j].type = &common.weapons[w_idx];
         // menus[i].items index 0 is "Randomize", indices [1..N] are the
         // weapon slots, index N+1 is "Done".
-        if (j + 1 < static_cast<int>(ws->menus[i].items.size())) {
-          ws->menus[i].items[j + 1].string = common.weapons[w_idx].name;
+        if (j + 1 < static_cast<int>(ws_->menus[i].items.size())) {
+          ws_->menus[i].items[j + 1].string = common.weapons[w_idx].name;
         }
       }
     }
-    ws->isReady[i] = p.isReady;
-    ws->menus[i].setSelection(p.menuSelection);
-    ws->menus[i].topItem = p.menuTopItem;
-    ws->menus[i].bottomItem = p.menuBottomItem;
-    w.controlStates.istate = p.wormControlStates;
-    w.currentWeapon = p.currentWeapon;
+    ws_->is_ready[i] = p.is_ready;
+    ws_->menus[i].SetSelection(p.menu_selection);
+    ws_->menus[i].top_item = p.menu_top_item;
+    ws_->menus[i].bottom_item = p.menu_bottom_item;
+    w.control_states.istate = p.worm_control_states;
+    w.current_weapon = p.current_weapon;
   }
   game.rand = snap.rand;
-  localPrevInput = snap.localPrevInput;
-  remotePrevInput = snap.remotePrevInput;
-  localHeldFrames = snap.localHeldFrames;
-  remoteHeldFrames = snap.remoteHeldFrames;
+  localPrevInput_ = snap.local_prev_input;
+  remotePrevInput_ = snap.remote_prev_input;
+  localHeldFrames_ = snap.local_held_frames;
+  remoteHeldFrames_ = snap.remote_held_frames;
 }
 
-void RollbackController::resetForGamePhase() {
-  localInputs.fill(0);
-  remoteInputs.fill(0);
-  remoteInputReady.fill(false);
+void RollbackController::ResetForGamePhase() {
+  localInputs_.fill(0);
+  remoteInputs_.fill(0);
+  remoteInputReady_.fill(false);
 
-  simFrame = 0;
+  simFrame_ = 0;
   confirmedSimFrame_ = -1;
-  lastSentFrame = 0;
-  lastSentFrameValid = false;
+  lastSentFrame_ = 0;
+  lastSentFrameValid_ = false;
   lastRemoteInput_ = 0;
   lastKnownRemoteFrame_ = -1;
 
   // Edge-detection state — carrying these across the phase boundary
   // would produce a spurious rising/released edge on the first frame.
-  localPrevInput = 0;
-  remotePrevInput = 0;
-  localHeldFrames.fill(0);
-  remoteHeldFrames.fill(0);
+  localPrevInput_ = 0;
+  remotePrevInput_ = 0;
+  localHeldFrames_.fill(0);
+  remoteHeldFrames_.fill(0);
 
-  rollbackBuffer_.clear();
+  rollbackBuffer_.Clear();
   lastTickResimFrames_ = 0;
 
   // The generation bump is what makes the wire layer drop any
@@ -509,38 +509,38 @@ void RollbackController::resetForGamePhase() {
   pendingFutureCount_ = 0;
   for (uint8_t i = 0; i < pending; ++i) {
     auto const& s = pendingFutureBatches_[i];
-    injectRemoteBatch(generation_, s.baseFrame, s.count, s.inputs.data(), s.remoteLocalFrame);
+    InjectRemoteBatch(generation_, s.base_frame, s.count, s.inputs.data(), s.remote_local_frame);
   }
 }
 
-void RollbackController::finishWeaponSelect() {
-  if (state != StateWeaponSelection) return;
+void RollbackController::FinishWeaponSelect() {
+  if (state_ != kStateWeaponSelection) return;
 
-  ws->finalize();
-  ws.reset();
+  ws_->Finalize();
+  ws_.reset();
 
   for (auto const& w : game.worms) {
     w->lives = game.settings->lives;
   }
-  game.startGame();
-  game.resetWorms();
-  state = StateGame;
+  game.StartGame();
+  game.ResetWorms();
+  state_ = kStateGame;
 
   // The WS phase can leave peers at different simFrame counters
   // (asymmetric stalls + WS-rollback resims). Carrying that skew into
   // game phase would silently diverge every simFrame-keyed comparison
   // downstream (checksums, terrain destruction) and trip the desync
   // detector. Resetting here gives the game phase a symmetric baseline.
-  resetForGamePhase();
+  ResetForGamePhase();
 
-  seedRollbackAndShadow();
+  SeedRollbackAndShadow();
 }
 
-void RollbackController::seedRollbackAndShadow() {
+void RollbackController::SeedRollbackAndShadow() {
   // Game state vectors are fully sized only after startGame; prepare
   // here so the slot-0 snapshot below captures the right widths.
   if (!rollbackBufferPrepared_) {
-    rollbackBuffer_.prepare(game);
+    rollbackBuffer_.Prepare(game);
     rollbackBufferPrepared_ = true;
   }
 
@@ -548,25 +548,25 @@ void RollbackController::seedRollbackAndShadow() {
   // game-phase frame has a valid rollback target, and so setupShadowGame
   // has a frame-0 snapshot to clone into the shadow. The first
   // process() tick will overwrite this with the post-frame-0 snapshot.
-  rollback::Slot& seed = rollbackBuffer_.write(0);
-  seed.localInput = 0;
-  seed.remoteInput = 0;
-  seed.remoteState = rollback::RemoteState::Confirmed;
-  seed.wsSnap.valid = false;
-  game.saveSnapshotFast(seed.snapshot);
-  seed.checksum = wideRollbackChecksum(game);
+  rollback::Slot& seed = rollbackBuffer_.Write(0);
+  seed.local_input = 0;
+  seed.remote_input = 0;
+  seed.remote_state = rollback::RemoteState::kConfirmed;
+  seed.ws_snap.valid = false;
+  game.SaveSnapshotFast(seed.snapshot);
+  seed.checksum = WideRollbackChecksum(game);
 
-  setupShadowGame();
+  SetupShadowGame();
 }
 
-void RollbackController::setupShadowGame() {
+void RollbackController::SetupShadowGame() {
   // Mirror the live game's construction: same Common/Settings, silent
   // sound player, identical worm+viewport configuration so the
   // snapshot we load below produces an identical processFrame path.
   shadowGame_ =
       std::make_unique<Game>(game.common, game.settings, std::make_shared<NullSoundPlayer>());
 
-  configureGameSlots(*shadowGame_, {game.worms[0]->settings, game.worms[1]->settings});
+  ConfigureGameSlots(*shadowGame_, {game.worms[0]->settings, game.worms[1]->settings});
 
   // loadSnapshotFast assumes level buffers are already sized; the
   // snapshot itself carries pixel data but not dimensions.
@@ -588,14 +588,14 @@ void RollbackController::setupShadowGame() {
   // simulation-visible side effects (rand, holdazone, worm pos), but
   // we still need startGame() to resize bobjects to bloodParticleMax
   // since the snapshot only carries `count`, not capacity.
-  for (auto const& w : shadowGame_->worms) w->initWeapons(*shadowGame_);
+  for (auto const& w : shadowGame_->worms) w->InitWeapons(*shadowGame_);
   shadowGame_->paused = false;
-  shadowGame_->startGame();
-  shadowGame_->resetWorms();
+  shadowGame_->StartGame();
+  shadowGame_->ResetWorms();
 
   // Frame-0 seed: live game's post-startGame state.
-  if (auto* seedSlot = rollbackBuffer_.find(0)) {
-    shadowGame_->loadSnapshotFast(seedSlot->snapshot);
+  if (auto* seed_slot = rollbackBuffer_.Find(0)) {
+    shadowGame_->LoadSnapshotFast(seed_slot->snapshot);
   }
 
   shadowFrame_ = -1;
@@ -610,12 +610,12 @@ void RollbackController::setupShadowGame() {
   // shadow, which advances once per confirmed frame. Replace the live
   // recorder with the base no-op so the in-sim hooks (damageDealt, hit,
   // afterSpawn, …) become silent on the live side.
-  game.statsRecorder.reset(new StatsRecorder);
+  game.stats_recorder.reset(new StatsRecorder);
 
-  startReplayRecording();
+  StartReplayRecording();
 }
 
-void RollbackController::startReplayRecording() {
+void RollbackController::StartReplayRecording() {
   if (!shadowGame_) return;
 
   // Test path: caller provided a writer directly; skip the gfx-driven
@@ -623,7 +623,7 @@ void RollbackController::startReplayRecording() {
   if (replayWriterOverride_) {
     try {
       shadowReplay_ = std::make_unique<ReplayWriter>(std::move(replayWriterOverride_));
-      shadowReplay_->beginRecord(*shadowGame_);
+      shadowReplay_->BeginRecord(*shadowGame_);
     } catch (std::runtime_error& e) {
       std::fprintf(stderr, "[replay] failed to start recording: %s\n", e.what());
       shadowReplay_.reset();
@@ -631,29 +631,29 @@ void RollbackController::startReplayRecording() {
     return;
   }
 
-  if (!Settings::extensions || !game.settings->recordReplays) return;
+  if (!Settings::kExtensions || !game.settings->record_replays) return;
 
   // Tests construct RollbackControllers without first wiring up gfx,
   // so getUserConfigNode() returns a default-constructed FsNode with
   // a null impl pointer. Operator/ would dereference that and segv.
-  FsNode configRoot = gfx.getUserConfigNode();
-  if (!configRoot.imp) return;
+  FsNode config_root = gfx.GetUserConfigNode();
+  if (!config_root.imp) return;
 
   try {
     std::time_t ticks = std::time(nullptr);
     std::tm* now = std::localtime(&ticks);
-    char timeBuf[64];
-    std::strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%d %H.%M.%S", now);
+    char time_buf[64];
+    std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H.%M.%S", now);
 
-    std::string playerNames = " ";
+    std::string player_names = " ";
     for (std::size_t i = 0; i < shadowGame_->worms.size() && i < 2; ++i) {
       Worm& worm = *shadowGame_->worms[i];
       std::string const& name = worm.settings->name;
-      if (i > 0) playerNames.push_back('-');
+      if (i > 0) player_names.push_back('-');
       int chars = 0;
       for (std::size_t c = 0; c < name.size() && chars < 4; ++c, ++chars) {
         unsigned char ch = static_cast<unsigned char>(name[c]);
-        if (std::isalnum(ch)) playerNames.push_back(static_cast<char>(ch));
+        if (std::isalnum(ch)) player_names.push_back(static_cast<char>(ch));
       }
     }
 
@@ -661,29 +661,29 @@ void RollbackController::startReplayRecording() {
     // they share a config directory and prevents the host's and
     // client's files from colliding.
     char suffix[8];
-    std::snprintf(suffix, sizeof(suffix), " mp%d", localIdx);
+    std::snprintf(suffix, sizeof(suffix), " mp%d", localIdx_);
 
-    auto node = configRoot / "Replays" / (std::string(timeBuf) + playerNames + suffix + ".lrp");
+    auto node = config_root / "Replays" / (std::string(time_buf) + player_names + suffix + ".lrp");
 
-    shadowReplay_ = std::make_unique<ReplayWriter>(node.toWriter());
-    shadowReplay_->beginRecord(*shadowGame_);
+    shadowReplay_ = std::make_unique<ReplayWriter>(node.ToWriter());
+    shadowReplay_->BeginRecord(*shadowGame_);
   } catch (std::runtime_error& e) {
     std::fprintf(stderr, "[replay] failed to start recording: %s\n", e.what());
     shadowReplay_.reset();
   }
 }
 
-void RollbackController::stopReplayRecording() {
+void RollbackController::StopReplayRecording() {
   // ReplayWriter destructor writes the 0x83 terminator.
   shadowReplay_.reset();
 }
 
-void RollbackController::driveShadow() {
+void RollbackController::DriveShadow() {
   if (!shadowGame_) return;
 
   while (shadowFrame_ < confirmedSimFrame_) {
-    int32_t F = shadowFrame_ + 1;
-    rollback::Slot const* slot = rollbackBuffer_.find(F);
+    int32_t f = shadowFrame_ + 1;
+    rollback::Slot const* slot = rollbackBuffer_.Find(f);
     if (!slot) {
       // The ring only holds kMaxRollback+1 slots; if the shadow ever
       // falls more than that behind, we can't reconstruct the missing
@@ -692,46 +692,46 @@ void RollbackController::driveShadow() {
       return;
     }
 
-    uint8_t curLocal = (localIdx == 0) ? slot->localInput : slot->remoteInput;
-    uint8_t curRemote = (localIdx == 0) ? slot->remoteInput : slot->localInput;
+    uint8_t cur_local = (localIdx_ == 0) ? slot->local_input : slot->remote_input;
+    uint8_t cur_remote = (localIdx_ == 0) ? slot->remote_input : slot->local_input;
 
-    uint8_t risingLocal = curLocal & ~shadowLocalPrevInput_;
-    uint8_t risingRemote = curRemote & ~shadowRemotePrevInput_;
-    uint8_t releasedLocal = shadowLocalPrevInput_ & ~curLocal;
-    uint8_t releasedRemote = shadowRemotePrevInput_ & ~curRemote;
-    shadowGame_->worms[localIdx]->controlStates.istate |= risingLocal;
-    shadowGame_->worms[remoteIdx]->controlStates.istate |= risingRemote;
-    shadowGame_->worms[localIdx]->controlStates.istate &= ~releasedLocal;
-    shadowGame_->worms[remoteIdx]->controlStates.istate &= ~releasedRemote;
-    shadowLocalPrevInput_ = curLocal;
-    shadowRemotePrevInput_ = curRemote;
+    uint8_t rising_local = cur_local & ~shadowLocalPrevInput_;
+    uint8_t rising_remote = cur_remote & ~shadowRemotePrevInput_;
+    uint8_t released_local = shadowLocalPrevInput_ & ~cur_local;
+    uint8_t released_remote = shadowRemotePrevInput_ & ~cur_remote;
+    shadowGame_->worms[localIdx_]->control_states.istate |= rising_local;
+    shadowGame_->worms[remoteIdx_]->control_states.istate |= rising_remote;
+    shadowGame_->worms[localIdx_]->control_states.istate &= ~released_local;
+    shadowGame_->worms[remoteIdx_]->control_states.istate &= ~released_remote;
+    shadowLocalPrevInput_ = cur_local;
+    shadowRemotePrevInput_ = cur_remote;
 
     // recordFrame() reads worm.controlStates ^ prevControlStates, so it
     // must run after edge detection but before processFrame() (which
     // sets prev = current at end of tick, wiping the delta).
     if (shadowReplay_) {
       try {
-        shadowReplay_->recordFrame();
+        shadowReplay_->RecordFrame();
       } catch (std::runtime_error& e) {
-        std::fprintf(stderr, "[replay] aborting recording at frame %d: %s\n", F, e.what());
+        std::fprintf(stderr, "[replay] aborting recording at frame %d: %s\n", f, e.what());
         shadowReplay_.reset();
       }
     }
 
-    shadowGame_->processFrame();
-    shadowFrame_ = F;
+    shadowGame_->ProcessFrame();
+    shadowFrame_ = f;
 
     // Sanity check: the shadow must match the live game's confirmed
     // state for the same frame. Log once on divergence so the breakage
     // surfaces without spamming stderr.
-    uint32_t shadowChk = wideRollbackChecksum(*shadowGame_);
-    if (shadowChk != slot->checksum && !shadowMismatchLogged_) {
+    uint32_t shadow_chk = WideRollbackChecksum(*shadowGame_);
+    if (shadow_chk != slot->checksum && !shadowMismatchLogged_) {
       std::fprintf(stderr,
                    "[replay shadow] mismatch at frame %d: shadow=%08x live=%08x"
                    " curLocal=%02x curRemote=%02x slot.localInput=%02x slot.remoteInput=%02x"
                    " shadowRand=%08x\n",
-                   F, shadowChk, slot->checksum, curLocal, curRemote, slot->localInput,
-                   slot->remoteInput, shadowGame_->rand.last);
+                   f, shadow_chk, slot->checksum, cur_local, cur_remote, slot->local_input,
+                   slot->remote_input, shadowGame_->rand.last);
       shadowMismatchLogged_ = true;
     }
   }
@@ -742,149 +742,149 @@ void RollbackController::driveShadow() {
 // save-snapshot shape, but stepping weaponSelectStep instead of
 // processFrame and saving into wsSnap instead of snapshot. Keep the two
 // in sync — a fix here likely needs to land in the sibling too.
-void RollbackController::advanceWeaponSelection() {
-  uint32_t inputFrame = simFrame + inputDelay;
-  if (!lastSentFrameValid || inputFrame != lastSentFrame) {
-    uint32_t slot = inputFrame % INPUT_BUFFER_SIZE;
+void RollbackController::AdvanceWeaponSelection() {
+  uint32_t input_frame = simFrame_ + inputDelay_;
+  if (!lastSentFrameValid_ || input_frame != lastSentFrame_) {
+    uint32_t slot = input_frame % kInputBufferSize;
     // Mask to the 7 ControlState bits (Up/Down/Left/Right/Fire/Change/
     // Jump); bit 7 is reserved and must not leak onto the wire.
-    localInputs[slot] = localControlState.pack() & 0x7f;
-    lastSentFrame = inputFrame;
-    lastSentFrameValid = true;
+    localInputs_[slot] = localControlState_.Pack() & 0x7f;
+    lastSentFrame_ = input_frame;
+    lastSentFrameValid_ = true;
   }
-  sendInputWindow(inputFrame, simFrame);
+  SendInputWindow(input_frame, simFrame_);
 
   // Promote previously-predicted WS frames whose real remote input has
   // now arrived and matches the prediction.
-  int32_t rollbackTo = -1;
-  while (confirmedSimFrame_ + 1 < static_cast<int32_t>(simFrame)) {
-    int32_t F = confirmedSimFrame_ + 1;
-    uint32_t s = static_cast<uint32_t>(F) % INPUT_BUFFER_SIZE;
-    if (!remoteInputReady[s]) break;
-    uint8_t real = remoteInputs[s];
+  int32_t rollback_to = -1;
+  while (confirmedSimFrame_ + 1 < static_cast<int32_t>(simFrame_)) {
+    int32_t f = confirmedSimFrame_ + 1;
+    uint32_t s = static_cast<uint32_t>(f) % kInputBufferSize;
+    if (!remoteInputReady_[s]) break;
+    uint8_t real = remoteInputs_[s];
 
-    auto* slot = rollbackBuffer_.find(F);
+    auto* slot = rollbackBuffer_.Find(f);
     bool match = true;
-    bool wasPredicted = slot && slot->remoteState == rollback::RemoteState::Predicted;
-    if (wasPredicted) {
-      uint8_t storedOther = (localIdx == 0) ? slot->remoteInput : slot->localInput;
-      match = (storedOther == real);
+    bool was_predicted = slot && slot->remote_state == rollback::RemoteState::kPredicted;
+    if (was_predicted) {
+      uint8_t stored_other = (localIdx_ == 0) ? slot->remote_input : slot->local_input;
+      match = (stored_other == real);
     }
 
     if (!match) {
-      rollbackTo = F - 1;
+      rollback_to = f - 1;
       break;
     }
 
-    if (slot) slot->remoteState = rollback::RemoteState::Confirmed;
+    if (slot) slot->remote_state = rollback::RemoteState::kConfirmed;
     lastRemoteInput_ = real;
-    remoteInputReady[s] = false;
-    confirmedSimFrame_ = F;
+    remoteInputReady_[s] = false;
+    confirmedSimFrame_ = f;
   }
 
   // Rollback resim for the weapon-select phase. Identical structure to
   // advanceSimulation's resim, but with weaponSelectStep / wsSnap in
   // place of processFrame / GameSnapshot.
-  if (rollbackTo >= 0) {
+  if (rollback_to >= 0) {
     ++rollbackCount_;
-    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame) - rollbackTo - 1);
-    auto* lastGood = rollbackBuffer_.find(rollbackTo);
-    if (lastGood && lastGood->wsSnap.valid) {
-      loadWeaponSelectSnap(lastGood->wsSnap);
+    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
+    auto* last_good = rollbackBuffer_.Find(rollback_to);
+    if (last_good && last_good->ws_snap.valid) {
+      LoadWeaponSelectSnap(last_good->ws_snap);
     }
 
-    uint8_t lastGoodWorm0 = lastGood ? lastGood->localInput : 0;
-    uint8_t lastGoodWorm1 = lastGood ? lastGood->remoteInput : 0;
-    localPrevInput = (localIdx == 0) ? lastGoodWorm0 : lastGoodWorm1;
-    remotePrevInput = (localIdx == 0) ? lastGoodWorm1 : lastGoodWorm0;
+    uint8_t last_good_worm0 = last_good ? last_good->local_input : 0;
+    uint8_t last_good_worm1 = last_good ? last_good->remote_input : 0;
+    localPrevInput_ = (localIdx_ == 0) ? last_good_worm0 : last_good_worm1;
+    remotePrevInput_ = (localIdx_ == 0) ? last_good_worm1 : last_good_worm0;
 
-    game.setSpeculative(true);
-    for (int32_t F = rollbackTo + 1; F < static_cast<int32_t>(simFrame); ++F) {
-      uint32_t s = static_cast<uint32_t>(F) % INPUT_BUFFER_SIZE;
-      uint8_t curLocal = localInputs[s];
-      uint8_t curRemote;
-      bool framePredicted;
-      bool resimContiguous = (confirmedSimFrame_ + 1 == F);
-      if (remoteInputReady[s] && resimContiguous) {
-        curRemote = remoteInputs[s];
-        remoteInputReady[s] = false;
-        lastRemoteInput_ = curRemote;
-        framePredicted = false;
-        confirmedSimFrame_ = F;
+    game.SetSpeculative(true);
+    for (int32_t f = rollback_to + 1; f < static_cast<int32_t>(simFrame_); ++f) {
+      uint32_t s = static_cast<uint32_t>(f) % kInputBufferSize;
+      uint8_t cur_local = localInputs_[s];
+      uint8_t cur_remote;
+      bool frame_predicted;
+      bool resim_contiguous = (confirmedSimFrame_ + 1 == f);
+      if (remoteInputReady_[s] && resim_contiguous) {
+        cur_remote = remoteInputs_[s];
+        remoteInputReady_[s] = false;
+        lastRemoteInput_ = cur_remote;
+        frame_predicted = false;
+        confirmedSimFrame_ = f;
       } else {
-        curRemote = lastRemoteInput_;
-        framePredicted = true;
+        cur_remote = lastRemoteInput_;
+        frame_predicted = true;
       }
 
-      bool wsDoneResim = weaponSelectStep(curLocal, curRemote);
+      bool ws_done_resim = WeaponSelectStep(cur_local, cur_remote);
 
-      auto& outSlot = rollbackBuffer_.write(static_cast<int>(F));
-      outSlot.localInput = (localIdx == 0) ? curLocal : curRemote;
-      outSlot.remoteInput = (localIdx == 0) ? curRemote : curLocal;
-      outSlot.remoteState =
-          framePredicted ? rollback::RemoteState::Predicted : rollback::RemoteState::Confirmed;
-      saveWeaponSelectSnap(outSlot.wsSnap);
-      outSlot.wsSnap.wsDone = wsDoneResim;
+      auto& out_slot = rollbackBuffer_.Write(static_cast<int>(f));
+      out_slot.local_input = (localIdx_ == 0) ? cur_local : cur_remote;
+      out_slot.remote_input = (localIdx_ == 0) ? cur_remote : cur_local;
+      out_slot.remote_state =
+          frame_predicted ? rollback::RemoteState::kPredicted : rollback::RemoteState::kConfirmed;
+      SaveWeaponSelectSnap(out_slot.ws_snap);
+      out_slot.ws_snap.ws_done = ws_done_resim;
     }
-    game.setSpeculative(false);
+    game.SetSpeculative(false);
 
     // Resim may have just confirmed the wsDone frame. Re-check here so
     // both peers transition on the same simFrame regardless of whether
     // wsDone was first observed forward or via a resim correcting a
     // mispredicted Fire press.
-    if (rollback::Slot const* confSlot = rollbackBuffer_.find(confirmedSimFrame_)) {
-      if (confSlot->wsSnap.valid && confSlot->wsSnap.wsDone) {
-        finishWeaponSelect();
+    if (rollback::Slot const* conf_slot = rollbackBuffer_.Find(confirmedSimFrame_)) {
+      if (conf_slot->ws_snap.valid && conf_slot->ws_snap.ws_done) {
+        FinishWeaponSelect();
         return;
       }
     }
   }
 
   // Stall guards — same thresholds as advanceSimulation.
-  if (static_cast<int32_t>(simFrame) - confirmedSimFrame_ > rollback::kMaxRollback) {
+  if (static_cast<int32_t>(simFrame_) - confirmedSimFrame_ > rollback::kMaxRollback) {
     return;
   }
   if (lastKnownRemoteFrame_ >= 0 &&
-      static_cast<int32_t>(simFrame) - lastKnownRemoteFrame_ >= frameAdvantageThreshold_) {
+      static_cast<int32_t>(simFrame_) - lastKnownRemoteFrame_ >= frameAdvantageThreshold_) {
     ++frameAdvantageStalls_;
     return;
   }
 
   // Predict if remote input not yet ready, run ws tick, snapshot.
-  uint32_t currentSlot = simFrame % INPUT_BUFFER_SIZE;
-  uint8_t curLocal = localInputs[currentSlot];
-  uint8_t curRemote;
+  uint32_t current_slot = simFrame_ % kInputBufferSize;
+  uint8_t cur_local = localInputs_[current_slot];
+  uint8_t cur_remote;
   bool predicted;
-  bool chainContiguous = confirmedSimFrame_ + 1 == static_cast<int32_t>(simFrame);
-  if (remoteInputReady[currentSlot] && chainContiguous) {
-    curRemote = remoteInputs[currentSlot];
-    remoteInputReady[currentSlot] = false;
-    lastRemoteInput_ = curRemote;
+  bool chain_contiguous = confirmedSimFrame_ + 1 == static_cast<int32_t>(simFrame_);
+  if (remoteInputReady_[current_slot] && chain_contiguous) {
+    cur_remote = remoteInputs_[current_slot];
+    remoteInputReady_[current_slot] = false;
+    lastRemoteInput_ = cur_remote;
     predicted = false;
   } else {
-    curRemote = lastRemoteInput_;
+    cur_remote = lastRemoteInput_;
     predicted = true;
   }
 
-  game.setSpeculative(predicted);
-  bool wsDone = weaponSelectStep(curLocal, curRemote);
-  game.setSpeculative(false);
-  ++simFrame;
+  game.SetSpeculative(predicted);
+  bool ws_done = WeaponSelectStep(cur_local, cur_remote);
+  game.SetSpeculative(false);
+  ++simFrame_;
 
   if (!predicted) {
-    confirmedSimFrame_ = static_cast<int32_t>(simFrame) - 1;
+    confirmedSimFrame_ = static_cast<int32_t>(simFrame_) - 1;
   }
 
   // Snapshot post-frame weapon-select state.
   {
-    int snapFrame = static_cast<int>(simFrame) - 1;
-    rollback::Slot& slot = rollbackBuffer_.write(snapFrame);
-    slot.localInput = (localIdx == 0) ? curLocal : curRemote;
-    slot.remoteInput = (localIdx == 0) ? curRemote : curLocal;
-    slot.remoteState =
-        predicted ? rollback::RemoteState::Predicted : rollback::RemoteState::Confirmed;
-    saveWeaponSelectSnap(slot.wsSnap);
-    slot.wsSnap.wsDone = wsDone;
+    int snap_frame = static_cast<int>(simFrame_) - 1;
+    rollback::Slot& slot = rollbackBuffer_.Write(snap_frame);
+    slot.local_input = (localIdx_ == 0) ? cur_local : cur_remote;
+    slot.remote_input = (localIdx_ == 0) ? cur_remote : cur_local;
+    slot.remote_state =
+        predicted ? rollback::RemoteState::kPredicted : rollback::RemoteState::kConfirmed;
+    SaveWeaponSelectSnap(slot.ws_snap);
+    slot.ws_snap.ws_done = ws_done;
   }
 
   // Transition into game phase as soon as the highest confirmed frame's
@@ -893,141 +893,141 @@ void RollbackController::advanceWeaponSelection() {
   // confirm, a promote-loop confirm, or a resim-confirm all fire the
   // transition on the same simFrame on both peers. Predicted wsDone
   // snapshots never fire it.
-  if (rollback::Slot const* confSlot = rollbackBuffer_.find(confirmedSimFrame_)) {
-    if (confSlot->wsSnap.valid && confSlot->wsSnap.wsDone) {
-      finishWeaponSelect();
+  if (rollback::Slot const* conf_slot = rollbackBuffer_.Find(confirmedSimFrame_)) {
+    if (conf_slot->ws_snap.valid && conf_slot->ws_snap.ws_done) {
+      FinishWeaponSelect();
     }
   }
 }
 
 // Mirror of advanceWeaponSelection() for the game phase. Keep the two
 // in sync — a fix here likely needs to land in the sibling too.
-void RollbackController::advanceSimulation() {
-  uint32_t inputFrame = simFrame + inputDelay;
-  if (!lastSentFrameValid || inputFrame != lastSentFrame) {
-    uint32_t slot = inputFrame % INPUT_BUFFER_SIZE;
+void RollbackController::AdvanceSimulation() {
+  uint32_t input_frame = simFrame_ + inputDelay_;
+  if (!lastSentFrameValid_ || input_frame != lastSentFrame_) {
+    uint32_t slot = input_frame % kInputBufferSize;
     // Mask to the 7 ControlState bits (Up/Down/Left/Right/Fire/Change/
     // Jump); bit 7 is reserved and must not leak onto the wire.
-    localInputs[slot] = localControlState.pack() & 0x7f;
-    lastSentFrame = inputFrame;
-    lastSentFrameValid = true;
+    localInputs_[slot] = localControlState_.Pack() & 0x7f;
+    lastSentFrame_ = input_frame;
+    lastSentFrameValid_ = true;
   }
 
   // Emit the last K = kMaxRollback + 1 local inputs as a redundant
   // batch every tick. The redundancy covers single dropped packets
   // without a retransmit RTT. Send continues even when stalled below so
   // the remote peer can promote out of its own stall.
-  sendInputWindow(inputFrame, simFrame);
+  SendInputWindow(input_frame, simFrame_);
 
   // Walk confirmedSimFrame_+1 .. simFrame-1 in order: promote slots whose
   // prediction matched, stop at the first mismatch and let the resim
   // below reload its predecessor's snapshot.
-  int32_t rollbackTo = -1;
-  while (confirmedSimFrame_ + 1 < static_cast<int32_t>(simFrame)) {
-    int32_t F = confirmedSimFrame_ + 1;
-    uint32_t s = static_cast<uint32_t>(F) % INPUT_BUFFER_SIZE;
-    if (!remoteInputReady[s]) break;
-    uint8_t real = remoteInputs[s];
+  int32_t rollback_to = -1;
+  while (confirmedSimFrame_ + 1 < static_cast<int32_t>(simFrame_)) {
+    int32_t f = confirmedSimFrame_ + 1;
+    uint32_t s = static_cast<uint32_t>(f) % kInputBufferSize;
+    if (!remoteInputReady_[s]) break;
+    uint8_t real = remoteInputs_[s];
 
-    auto* slot = rollbackBuffer_.find(F);
+    auto* slot = rollbackBuffer_.Find(f);
     bool match = true;
-    bool wasPredicted = slot && slot->remoteState == rollback::RemoteState::Predicted;
-    if (wasPredicted) {
+    bool was_predicted = slot && slot->remote_state == rollback::RemoteState::kPredicted;
+    if (was_predicted) {
       // slot stores inputs by worm index: localInput=worm0, remoteInput=worm1.
       // The misprediction question is about the *other* peer's input.
-      uint8_t storedOther = (localIdx == 0) ? slot->remoteInput : slot->localInput;
-      match = (storedOther == real);
+      uint8_t stored_other = (localIdx_ == 0) ? slot->remote_input : slot->local_input;
+      match = (stored_other == real);
     }
 
     if (!match) {
-      rollbackTo = F - 1;
+      rollback_to = f - 1;
       break;
     }
 
-    if (slot) slot->remoteState = rollback::RemoteState::Confirmed;
+    if (slot) slot->remote_state = rollback::RemoteState::kConfirmed;
     lastRemoteInput_ = real;
-    remoteInputReady[s] = false;
-    confirmedSimFrame_ = F;
+    remoteInputReady_[s] = false;
+    confirmedSimFrame_ = f;
 
     // The forward path skipped sending a checksum when the frame was
     // first run as predicted; emit the cached value now that we've
     // confirmed it.
-    if (wasPredicted && sendChecksum) {
-      sendChecksum(generation_, static_cast<uint32_t>(F), slot->checksum);
+    if (was_predicted && sendChecksum_) {
+      sendChecksum_(generation_, static_cast<uint32_t>(f), slot->checksum);
     }
   }
 
   // Load the last known-good snapshot, then replay every frame after it
   // with the freshest input available. Speculative across the window so
   // previously-emitted sounds/stats don't duplicate.
-  if (rollbackTo >= 0) {
+  if (rollback_to >= 0) {
     ++rollbackCount_;
-    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame) - rollbackTo - 1);
-    auto* lastGood = rollbackBuffer_.find(rollbackTo);
+    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
+    auto* last_good = rollbackBuffer_.Find(rollback_to);
     // Resident by construction: the stall guard caps simFrame - confirmedSimFrame_
     // at kMaxRollback, and the ring holds kMaxRollback+1 slots.
-    game.loadSnapshotFast(lastGood->snapshot);
+    game.LoadSnapshotFast(last_good->snapshot);
 
-    uint8_t lastGoodWorm0 = lastGood->localInput;
-    uint8_t lastGoodWorm1 = lastGood->remoteInput;
-    localPrevInput = (localIdx == 0) ? lastGoodWorm0 : lastGoodWorm1;
-    remotePrevInput = (localIdx == 0) ? lastGoodWorm1 : lastGoodWorm0;
+    uint8_t last_good_worm0 = last_good->local_input;
+    uint8_t last_good_worm1 = last_good->remote_input;
+    localPrevInput_ = (localIdx_ == 0) ? last_good_worm0 : last_good_worm1;
+    remotePrevInput_ = (localIdx_ == 0) ? last_good_worm1 : last_good_worm0;
 
-    game.setSpeculative(true);
-    for (int32_t F = rollbackTo + 1; F < static_cast<int32_t>(simFrame); ++F) {
-      uint32_t s = static_cast<uint32_t>(F) % INPUT_BUFFER_SIZE;
-      uint8_t curLocal = localInputs[s];
-      uint8_t curRemote;
-      bool framePredicted;
+    game.SetSpeculative(true);
+    for (int32_t f = rollback_to + 1; f < static_cast<int32_t>(simFrame_); ++f) {
+      uint32_t s = static_cast<uint32_t>(f) % kInputBufferSize;
+      uint8_t cur_local = localInputs_[s];
+      uint8_t cur_remote;
+      bool frame_predicted;
       // Same contiguity rule as the new-frame block — only consume real
       // input (and clear the ring entry) when the chain reaches F-1.
       // Out-of-order real inputs stay in the ring for a later promote.
-      bool resimContiguous = (confirmedSimFrame_ + 1 == F);
-      if (remoteInputReady[s] && resimContiguous) {
-        curRemote = remoteInputs[s];
-        remoteInputReady[s] = false;
-        lastRemoteInput_ = curRemote;
-        framePredicted = false;
-        confirmedSimFrame_ = F;
+      bool resim_contiguous = (confirmedSimFrame_ + 1 == f);
+      if (remoteInputReady_[s] && resim_contiguous) {
+        cur_remote = remoteInputs_[s];
+        remoteInputReady_[s] = false;
+        lastRemoteInput_ = cur_remote;
+        frame_predicted = false;
+        confirmedSimFrame_ = f;
       } else {
-        curRemote = lastRemoteInput_;
-        framePredicted = true;
+        cur_remote = lastRemoteInput_;
+        frame_predicted = true;
       }
 
-      uint8_t risingLocal = curLocal & ~localPrevInput;
-      uint8_t risingRemote = curRemote & ~remotePrevInput;
-      uint8_t releasedLocal = localPrevInput & ~curLocal;
-      uint8_t releasedRemote = remotePrevInput & ~curRemote;
-      game.worms[localIdx]->controlStates.istate |= risingLocal;
-      game.worms[remoteIdx]->controlStates.istate |= risingRemote;
-      game.worms[localIdx]->controlStates.istate &= ~releasedLocal;
-      game.worms[remoteIdx]->controlStates.istate &= ~releasedRemote;
-      localPrevInput = curLocal;
-      remotePrevInput = curRemote;
+      uint8_t rising_local = cur_local & ~localPrevInput_;
+      uint8_t rising_remote = cur_remote & ~remotePrevInput_;
+      uint8_t released_local = localPrevInput_ & ~cur_local;
+      uint8_t released_remote = remotePrevInput_ & ~cur_remote;
+      game.worms[localIdx_]->control_states.istate |= rising_local;
+      game.worms[remoteIdx_]->control_states.istate |= rising_remote;
+      game.worms[localIdx_]->control_states.istate &= ~released_local;
+      game.worms[remoteIdx_]->control_states.istate &= ~released_remote;
+      localPrevInput_ = cur_local;
+      remotePrevInput_ = cur_remote;
 
-      game.processFrame();
+      game.ProcessFrame();
 
-      auto& outSlot = rollbackBuffer_.write(static_cast<int>(F));
-      outSlot.localInput = (localIdx == 0) ? curLocal : curRemote;
-      outSlot.remoteInput = (localIdx == 0) ? curRemote : curLocal;
-      outSlot.remoteState =
-          framePredicted ? rollback::RemoteState::Predicted : rollback::RemoteState::Confirmed;
-      game.saveSnapshotFast(outSlot.snapshot);
-      outSlot.checksum = wideRollbackChecksum(game);
+      auto& out_slot = rollbackBuffer_.Write(static_cast<int>(f));
+      out_slot.local_input = (localIdx_ == 0) ? cur_local : cur_remote;
+      out_slot.remote_input = (localIdx_ == 0) ? cur_remote : cur_local;
+      out_slot.remote_state =
+          frame_predicted ? rollback::RemoteState::kPredicted : rollback::RemoteState::kConfirmed;
+      game.SaveSnapshotFast(out_slot.snapshot);
+      out_slot.checksum = WideRollbackChecksum(game);
 
       // Predicted resim frames stay silent — their checksum is cached
       // for a later promote/resim pass.
-      if (!framePredicted && sendChecksum) {
-        sendChecksum(generation_, static_cast<uint32_t>(F), outSlot.checksum);
+      if (!frame_predicted && sendChecksum_) {
+        sendChecksum_(generation_, static_cast<uint32_t>(f), out_slot.checksum);
       }
     }
-    game.setSpeculative(false);
+    game.SetSpeculative(false);
   }
 
   // Stall guard: cap in-flight predicted frames at kMaxRollback so the
   // ring buffer (kMaxRollback+1 slots) can still cover the post-tick
   // window.
-  if (static_cast<int32_t>(simFrame) - confirmedSimFrame_ > rollback::kMaxRollback) {
+  if (static_cast<int32_t>(simFrame_) - confirmedSimFrame_ > rollback::kMaxRollback) {
     return;
   }
 
@@ -1036,160 +1036,160 @@ void RollbackController::advanceSimulation() {
   // remote still hears from us this tick. -1 keeps this disarmed before
   // any packet has arrived.
   if (lastKnownRemoteFrame_ >= 0 &&
-      static_cast<int32_t>(simFrame) - lastKnownRemoteFrame_ >= frameAdvantageThreshold_) {
+      static_cast<int32_t>(simFrame_) - lastKnownRemoteFrame_ >= frameAdvantageThreshold_) {
     ++frameAdvantageStalls_;
     return;
   }
 
-  uint32_t currentSlot = simFrame % INPUT_BUFFER_SIZE;
+  uint32_t current_slot = simFrame_ % kInputBufferSize;
 
-  uint8_t curLocal = localInputs[currentSlot];
-  uint8_t curRemote;
+  uint8_t cur_local = localInputs_[current_slot];
+  uint8_t cur_remote;
   bool predicted;
   // Only consume real remote input when the confirmed chain reaches
   // simFrame-1. Out-of-order arrival (real input for a future frame
   // while an earlier one is still missing) must stay in the ring so a
   // later promote can fold it into a contiguous chain.
-  bool chainContiguous = confirmedSimFrame_ + 1 == static_cast<int32_t>(simFrame);
-  if (remoteInputReady[currentSlot] && chainContiguous) {
-    curRemote = remoteInputs[currentSlot];
-    remoteInputReady[currentSlot] = false;
-    lastRemoteInput_ = curRemote;
+  bool chain_contiguous = confirmedSimFrame_ + 1 == static_cast<int32_t>(simFrame_);
+  if (remoteInputReady_[current_slot] && chain_contiguous) {
+    cur_remote = remoteInputs_[current_slot];
+    remoteInputReady_[current_slot] = false;
+    lastRemoteInput_ = cur_remote;
     predicted = false;
   } else {
-    curRemote = lastRemoteInput_;
+    cur_remote = lastRemoteInput_;
     predicted = true;
   }
 
-  uint8_t risingLocal = curLocal & ~localPrevInput;
-  uint8_t risingRemote = curRemote & ~remotePrevInput;
-  uint8_t releasedLocal = localPrevInput & ~curLocal;
-  uint8_t releasedRemote = remotePrevInput & ~curRemote;
+  uint8_t rising_local = cur_local & ~localPrevInput_;
+  uint8_t rising_remote = cur_remote & ~remotePrevInput_;
+  uint8_t released_local = localPrevInput_ & ~cur_local;
+  uint8_t released_remote = remotePrevInput_ & ~cur_remote;
 
-  game.worms[localIdx]->controlStates.istate |= risingLocal;
-  game.worms[remoteIdx]->controlStates.istate |= risingRemote;
-  game.worms[localIdx]->controlStates.istate &= ~releasedLocal;
-  game.worms[remoteIdx]->controlStates.istate &= ~releasedRemote;
+  game.worms[localIdx_]->control_states.istate |= rising_local;
+  game.worms[remoteIdx_]->control_states.istate |= rising_remote;
+  game.worms[localIdx_]->control_states.istate &= ~released_local;
+  game.worms[remoteIdx_]->control_states.istate &= ~released_remote;
 
-  localPrevInput = curLocal;
-  remotePrevInput = curRemote;
+  localPrevInput_ = cur_local;
+  remotePrevInput_ = cur_remote;
 
-  game.setSpeculative(predicted);
-  game.processFrame();
-  game.setSpeculative(false);
-  ++simFrame;
+  game.SetSpeculative(predicted);
+  game.ProcessFrame();
+  game.SetSpeculative(false);
+  ++simFrame_;
 
   if (!predicted) {
-    confirmedSimFrame_ = static_cast<int32_t>(simFrame) - 1;
+    confirmedSimFrame_ = static_cast<int32_t>(simFrame_) - 1;
   }
 
   // Snapshot the post-frame state and cache the checksum (used by a
   // later promote/resim if the frame was predicted).
   {
-    int snapFrame = static_cast<int>(simFrame) - 1;
-    rollback::Slot& slot = rollbackBuffer_.write(snapFrame);
-    slot.localInput = (localIdx == 0) ? curLocal : curRemote;
-    slot.remoteInput = (localIdx == 0) ? curRemote : curLocal;
-    slot.remoteState =
-        predicted ? rollback::RemoteState::Predicted : rollback::RemoteState::Confirmed;
-    game.saveSnapshotFast(slot.snapshot);
-    slot.checksum = wideRollbackChecksum(game);
+    int snap_frame = static_cast<int>(simFrame_) - 1;
+    rollback::Slot& slot = rollbackBuffer_.Write(snap_frame);
+    slot.local_input = (localIdx_ == 0) ? cur_local : cur_remote;
+    slot.remote_input = (localIdx_ == 0) ? cur_remote : cur_local;
+    slot.remote_state =
+        predicted ? rollback::RemoteState::kPredicted : rollback::RemoteState::kConfirmed;
+    game.SaveSnapshotFast(slot.snapshot);
+    slot.checksum = WideRollbackChecksum(game);
 
-    if (!predicted && sendChecksum) {
-      sendChecksum(generation_, simFrame - 1, slot.checksum);
+    if (!predicted && sendChecksum_) {
+      sendChecksum_(generation_, simFrame_ - 1, slot.checksum);
     }
   }
 
-  if (game.isGameOver()) {
-    state = StateGameEnded;
-    if (!goingToMenu) enterGoingToMenu(180);
+  if (game.IsGameOver()) {
+    state_ = kStateGameEnded;
+    if (!goingToMenu_) EnterGoingToMenu(180);
   }
 
-  driveShadow();
+  DriveShadow();
 }
 
-void RollbackController::draw(Renderer& renderer, bool useSpectatorViewports) {
-  if (state == StateWeaponSelection) {
-    ws->draw(renderer, state, useSpectatorViewports);
-  } else if (state == StateGame || state == StateGameEnded) {
-    game.draw(renderer, state, useSpectatorViewports);
+void RollbackController::Draw(Renderer& renderer, bool use_spectator_viewports) {
+  if (state_ == kStateWeaponSelection) {
+    ws_->Draw(renderer, state_, use_spectator_viewports);
+  } else if (state_ == kStateGame || state_ == kStateGameEnded) {
+    game.Draw(renderer, state_, use_spectator_viewports);
   }
-  renderer.fadeValue = fadeValue;
+  renderer.fade_value = fadeValue_;
 
   // Dev HUD: bottom-left `RB:n` resim indicator, always shown so the
   // value doesn't blink as resim windows come and go.
-  if (state == StateGame) {
+  if (state_ == kStateGame) {
     Font& font = game.common->font;
     char buf[16];
     std::snprintf(buf, sizeof(buf), "RB:%u", lastTickResimFrames_);
-    font.drawText(renderer.bmp, buf, 2, renderer.renderResY - 9, 50);
+    font.DrawText(renderer.bmp, buf, 2, renderer.render_res_y - 9, 50);
   }
 
-  if (isPaused()) {
-    fill(renderer.bmp, 0);
+  if (IsPaused()) {
+    Fill(renderer.bmp, 0);
     Common& common = *game.common;
     Font& font = common.font;
-    int cx = renderer.renderResX / 2;
-    int cy = renderer.renderResY / 2 - 20;
+    int cx = renderer.render_res_x / 2;
+    int cy = renderer.render_res_y / 2 - 20;
 
     renderer.pal = game.common->exepal;
-    renderer.pal.rotateFrom(game.common->exepal, 168, 174, gfx.menuCycles);
-    renderer.pal.fade(fadeValue);
+    renderer.pal.RotateFrom(game.common->exepal, 168, 174, gfx.menu_cycles);
+    renderer.pal.Fade(fadeValue_);
 
     if (localPaused_) {
       std::string title = "GAME PAUSED";
-      int tw = font.getDims(title);
-      font.drawText(renderer.bmp, title, cx - tw / 2, cy, 50);
+      int tw = font.GetDims(title);
+      font.DrawText(renderer.bmp, title, cx - tw / 2, cy, 50);
 
-      pauseMenu_.place(cx, cy + 16);
-      pauseMenu_.draw(common, renderer, false);
+      pauseMenu_.Place(cx, cy + 16);
+      pauseMenu_.Draw(common, renderer, false);
     } else {
       std::string title = "PAUSED BY PEER";
-      int tw = font.getDims(title);
-      font.drawText(renderer.bmp, title, cx - tw / 2, cy, 50);
+      int tw = font.GetDims(title);
+      font.DrawText(renderer.bmp, title, cx - tw / 2, cy, 50);
 
       std::string hint = "PRESS ESC TO DISCONNECT";
-      int hw = font.getDims(hint);
-      font.drawText(renderer.bmp, hint, cx - hw / 2, cy + 16, 6);
+      int hw = font.GetDims(hint);
+      font.DrawText(renderer.bmp, hint, cx - hw / 2, cy + 16, 6);
     }
   }
 }
 
-void RollbackController::swapLevel(Level& newLevel) { currentLevel()->swap(newLevel); }
+void RollbackController::SwapLevel(Level& new_level) { CurrentLevel()->Swap(new_level); }
 
-Level* RollbackController::currentLevel() { return &game.level; }
+Level* RollbackController::CurrentLevel() { return &game.level; }
 
-Game* RollbackController::currentGame() { return &game; }
+Game* RollbackController::CurrentGame() { return &game; }
 
-Game* RollbackController::statsGame() { return shadowGame_ ? shadowGame_.get() : &game; }
+Game* RollbackController::StatsGame() { return shadowGame_ ? shadowGame_.get() : &game; }
 
-bool RollbackController::running() {
-  return state != StateGameEnded && state != StateInitial && resumable_;
+bool RollbackController::Running() {
+  return state_ != kStateGameEnded && state_ != kStateInitial && resumable_;
 }
 
-void RollbackController::enterGoingToMenu(int fade) {
-  goingToMenu = true;
-  fadeValue = fade;
+void RollbackController::EnterGoingToMenu(int fade) {
+  goingToMenu_ = true;
+  fadeValue_ = fade;
   // Without this, process()'s isPaused() early return would skip the
   // fade decrement and the menu transition would stall.
   localPaused_ = false;
   remotePaused_ = false;
 }
 
-void RollbackController::endMatch() {
-  if (state == StateGame || state == StateWeaponSelection) {
-    state = StateGameEnded;
-    enterGoingToMenu(33);
-    stopReplayRecording();
+void RollbackController::EndMatch() {
+  if (state_ == kStateGame || state_ == kStateWeaponSelection) {
+    state_ = kStateGameEnded;
+    EnterGoingToMenu(33);
+    StopReplayRecording();
   }
 }
 
-void RollbackController::peerLeft() {
+void RollbackController::PeerLeft() {
   // Mirrors the local Disconnect pause-menu branch: skip the fade and
   // do NOT transition to StateGameEnded — that keeps statsRecorder
   // unfinalized so the host loop routes us back to the menu rather
   // than to the stats screen.
-  enterGoingToMenu(0);
+  EnterGoingToMenu(0);
   resumable_ = false;
-  stopReplayRecording();
+  StopReplayRecording();
 }

--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -1124,7 +1124,7 @@ void RollbackController::Draw(Renderer& renderer, bool use_spectator_viewports) 
     Font& font = game.common->font;
     char buf[16];
     std::snprintf(buf, sizeof(buf), "RB:%u", lastTickResimFrames_);
-    font.DrawText(renderer.bmp, buf, 2, renderer.render_res_y - 9, 50);
+    font.DrawString(renderer.bmp, buf, 2, renderer.render_res_y - 9, 50);
   }
 
   if (IsPaused()) {
@@ -1141,18 +1141,18 @@ void RollbackController::Draw(Renderer& renderer, bool use_spectator_viewports) 
     if (localPaused_) {
       std::string title = "GAME PAUSED";
       int tw = font.GetDims(title);
-      font.DrawText(renderer.bmp, title, cx - tw / 2, cy, 50);
+      font.DrawString(renderer.bmp, title, cx - tw / 2, cy, 50);
 
       pauseMenu_.Place(cx, cy + 16);
       pauseMenu_.Draw(common, renderer, false);
     } else {
       std::string title = "PAUSED BY PEER";
       int tw = font.GetDims(title);
-      font.DrawText(renderer.bmp, title, cx - tw / 2, cy, 50);
+      font.DrawString(renderer.bmp, title, cx - tw / 2, cy, 50);
 
       std::string hint = "PRESS ESC TO DISCONNECT";
       int hw = font.GetDims(hint);
-      font.DrawText(renderer.bmp, hint, cx - hw / 2, cy + 16, 6);
+      font.DrawString(renderer.bmp, hint, cx - hw / 2, cy + 16, 6);
     }
   }
 }

--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -68,7 +68,7 @@ RollbackController::RollbackController(std::shared_ptr<Common> common,
   std::array<std::shared_ptr<WormSettings>, 2> ws;
   for (int idx = 0; idx < 2; ++idx) {
     ws[idx] = (idx == localIdx_) ? settings->worm_settings[Settings::kNetworkPlayerIdx]
-                                : settings->worm_settings[idx];
+                                 : settings->worm_settings[idx];
   }
   ConfigureGameSlots(game, ws);
   game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
@@ -787,7 +787,8 @@ void RollbackController::AdvanceWeaponSelection() {
   // place of processFrame / GameSnapshot.
   if (rollback_to >= 0) {
     ++rollbackCount_;
-    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
+    lastTickResimFrames_ +=
+        static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
     auto* last_good = rollbackBuffer_.Find(rollback_to);
     if (last_good && last_good->ws_snap.valid) {
       LoadWeaponSelectSnap(last_good->ws_snap);
@@ -962,7 +963,8 @@ void RollbackController::AdvanceSimulation() {
   // previously-emitted sounds/stats don't duplicate.
   if (rollback_to >= 0) {
     ++rollbackCount_;
-    lastTickResimFrames_ += static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
+    lastTickResimFrames_ +=
+        static_cast<uint32_t>(static_cast<int32_t>(simFrame_) - rollback_to - 1);
     auto* last_good = rollbackBuffer_.Find(rollback_to);
     // Resident by construction: the stall guard caps simFrame - confirmedSimFrame_
     // at kMaxRollback, and the ring holds kMaxRollback+1 slots.

--- a/src/game/controller/rollbackController.hpp
+++ b/src/game/controller/rollbackController.hpp
@@ -100,7 +100,7 @@ struct RollbackController : CommonController {
   // underlying NetSession has gone away (clean PeerLeft or socket
   // close); makes `running()` return false so the main menu hides
   // "RESUME GAME".
-  void MarkUnresumable() { resumable_ = false; }
+  void MarkUnresumable() override { resumable_ = false; }
 
   void SetSkipWeaponSelection(bool skip) { skipWeaponSelection_ = skip; }
 

--- a/src/game/controller/rollbackController.hpp
+++ b/src/game/controller/rollbackController.hpp
@@ -23,8 +23,8 @@ struct ReplayWriter;
 // tracking); `generation` = sender's phase generation (receivers drop
 // stale ones).
 using InputBatchSendCallback =
-    std::function<void(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t const* inputs,
-                       uint32_t local_frame)>;
+    std::function<void(uint8_t generation, uint32_t base_frame, uint8_t count,
+                       uint8_t const* inputs, uint32_t local_frame)>;
 
 // Checksum emission for desync detection. `generation` = sender's
 // phase generation.

--- a/src/game/controller/rollbackController.hpp
+++ b/src/game/controller/rollbackController.hpp
@@ -23,8 +23,8 @@ struct ReplayWriter;
 // tracking); `generation` = sender's phase generation (receivers drop
 // stale ones).
 using InputBatchSendCallback =
-    std::function<void(uint8_t generation, uint32_t baseFrame, uint8_t count, uint8_t const* inputs,
-                       uint32_t localFrame)>;
+    std::function<void(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t const* inputs,
+                       uint32_t local_frame)>;
 
 // Checksum emission for desync detection. `generation` = sender's
 // phase generation.
@@ -33,116 +33,116 @@ using ChecksumSendCallback =
 
 struct RollbackController : CommonController {
   RollbackController(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings,
-                     int localPlayerIdx);
+                     int local_player_idx);
   ~RollbackController();
 
-  void onKey(int key, bool keyState) override;
-  void unfocus() override;
-  void focus() override;
-  bool process() override;
-  void draw(Renderer& renderer, bool useSpectatorViewports) override;
-  void swapLevel(Level& newLevel) override;
-  Level* currentLevel() override;
-  Game* currentGame() override;
-  Game* statsGame() override;
-  bool running() override;
+  void OnKey(int key, bool key_state) override;
+  void Unfocus() override;
+  void Focus() override;
+  bool Process() override;
+  void Draw(Renderer& renderer, bool use_spectator_viewports) override;
+  void SwapLevel(Level& new_level) override;
+  Level* CurrentLevel() override;
+  Game* CurrentGame() override;
+  Game* StatsGame() override;
+  bool Running() override;
 
-  void setInputCallbacks(InputBatchSendCallback send);
-  void setChecksumCallback(ChecksumSendCallback cb) { sendChecksum = std::move(cb); }
+  void SetInputCallbacks(InputBatchSendCallback send);
+  void SetChecksumCallback(ChecksumSendCallback cb) { sendChecksum_ = std::move(cb); }
 
-  void injectRemoteInput(uint32_t frame, uint8_t input);
+  void InjectRemoteInput(uint32_t frame, uint8_t input);
 
   // `generation` is the sender's phase generation. Batches from an older
   // generation are dropped (their simFrame numbering describes a phase
   // the local controller has already abandoned, and slots are reused
   // across the phase boundary). Batches from generation_+1 are buffered
   // until the local phase transition fires; anything further is dropped.
-  void injectRemoteBatch(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                         uint8_t const* inputs, uint32_t remoteLocalFrame);
+  void InjectRemoteBatch(uint8_t generation, uint32_t base_frame, uint8_t count,
+                         uint8_t const* inputs, uint32_t remote_local_frame);
   // Same-generation overload for tests that aren't exercising the
   // wire-level generation filter.
-  void injectRemoteBatch(uint32_t baseFrame, uint8_t count, uint8_t const* inputs,
-                         uint32_t remoteLocalFrame) {
-    injectRemoteBatch(generation_, baseFrame, count, inputs, remoteLocalFrame);
+  void InjectRemoteBatch(uint32_t base_frame, uint8_t count, uint8_t const* inputs,
+                         uint32_t remote_local_frame) {
+    InjectRemoteBatch(generation_, base_frame, count, inputs, remote_local_frame);
   }
 
-  void setRemotePaused(bool paused) { remotePaused_ = paused; }
-  bool isPaused() const { return localPaused_ || remotePaused_; }
+  void SetRemotePaused(bool paused) { remotePaused_ = paused; }
+  bool IsPaused() const { return localPaused_ || remotePaused_; }
 
-  void setPauseCallbacks(std::function<void()> pauseCb, std::function<void()> resumeCb) {
-    onLocalPause = std::move(pauseCb);
-    onLocalResume = std::move(resumeCb);
+  void SetPauseCallbacks(std::function<void()> pause_cb, std::function<void()> resume_cb) {
+    onLocalPause_ = std::move(pause_cb);
+    onLocalResume_ = std::move(resume_cb);
   }
 
-  void setEndMatchCallback(std::function<void()> cb) { onEndMatch = std::move(cb); }
-  void setPeerLeftCallback(std::function<void()> cb) { onPeerLeft = std::move(cb); }
+  void SetEndMatchCallback(std::function<void()> cb) { onEndMatch_ = std::move(cb); }
+  void SetPeerLeftCallback(std::function<void()> cb) { onPeerLeft_ = std::move(cb); }
 
   // Test/embedding hook: redirect the multiplayer replay writer to a
   // user-supplied io::Writer instead of the gfx-configured Replays/
   // directory. Must be called before focus() so it's in place when
   // setupShadowGame runs. Overrides the recordReplays/gfx gates.
-  void setReplayWriterOverride(std::unique_ptr<io::Writer> sink) {
+  void SetReplayWriterOverride(std::unique_ptr<io::Writer> sink) {
     replayWriterOverride_ = std::move(sink);
   }
 
   // Test accessor: the shadow Game tracking confirmed frames. Used by
   // the replay round-trip test to compare the shadow's final state
   // against the replayed file's playback state.
-  Game* shadowGameForTest() { return shadowGame_.get(); }
+  Game* ShadowGameForTest() { return shadowGame_.get(); }
   // Single entry into the goingToMenu fade. Clears pause flags so
   // process()'s paused-branch early-return can't strand fadeValue.
-  void enterGoingToMenu(int fade);
-  void endMatch();
+  void EnterGoingToMenu(int fade);
+  void EndMatch();
   // Used by both the local "Disconnect" pause menu option and the wire
   // PeerLeft handler: drop to the menu without finalizing stats.
-  void peerLeft();
+  void PeerLeft();
   // Mark the controller as no longer resumable. Called when the
   // underlying NetSession has gone away (clean PeerLeft or socket
   // close); makes `running()` return false so the main menu hides
   // "RESUME GAME".
-  void markUnresumable() { resumable_ = false; }
+  void MarkUnresumable() { resumable_ = false; }
 
-  void setSkipWeaponSelection(bool skip) { skipWeaponSelection = skip; }
+  void SetSkipWeaponSelection(bool skip) { skipWeaponSelection_ = skip; }
 
-  void loadLevelFromData(const std::vector<uint8_t>& data);
-  void setLevelPreloaded() { levelPreloaded = true; }
+  void LoadLevelFromData(const std::vector<uint8_t>& data);
+  void SetLevelPreloaded() { levelPreloaded_ = true; }
 
-  uint32_t currentFrame() const { return simFrame; }
-  GameState gameState() const { return state; }
-  void setLocalControlState(uint8_t packed) { localControlState.unpack(packed); }
+  uint32_t CurrentFrame() const { return simFrame_; }
+  GameState State() const { return state_; }
+  void SetLocalControlState(uint8_t packed) { localControlState_.Unpack(packed); }
   // Must be called before the first sim tick. Clamped to kMaxRollback:
   // the send path encodes (localFrame - baseFrame) as a uint8_t equal to
   // (K-1) - inputDelay, which underflows once inputDelay exceeds K-1.
-  void setInputDelay(uint32_t frames) {
-    inputDelay =
+  void SetInputDelay(uint32_t frames) {
+    inputDelay_ =
         frames > rollback::kMaxRollback ? static_cast<uint32_t>(rollback::kMaxRollback) : frames;
   }
 
-  rollback::RollbackBuffer const& rollbackBuffer() const { return rollbackBuffer_; }
+  rollback::RollbackBuffer const& RollbackBuffer() const { return rollbackBuffer_; }
 
   // Highest simFrame run with real (received) remote input; anything
   // past this is currently a prediction. -1 before the first frame.
-  int32_t confirmedFrame() const { return confirmedSimFrame_; }
+  int32_t ConfirmedFrame() const { return confirmedSimFrame_; }
 
-  uint64_t rollbackCount() const { return rollbackCount_; }
+  uint64_t RollbackCount() const { return rollbackCount_; }
 
   // Frames the resim loop replayed during the most recent process() tick.
   // Reset each tick. Used by the dev HUD overlay (`RB:n`).
-  uint32_t lastTickResimFrames() const { return lastTickResimFrames_; }
+  uint32_t LastTickResimFrames() const { return lastTickResimFrames_; }
 
   // Sender-side simFrame from the most recent batched packet accepted.
   // -1 before any packet arrives, so the frame-advantage stall stays
   // disarmed during warm-up.
-  int32_t lastKnownRemoteFrame() const { return lastKnownRemoteFrame_; }
-  uint64_t frameAdvantageStallCount() const { return frameAdvantageStalls_; }
+  int32_t LastKnownRemoteFrame() const { return lastKnownRemoteFrame_; }
+  uint64_t FrameAdvantageStallCount() const { return frameAdvantageStalls_; }
 
   // Phase generation. 0 = weapon select, 1 = game, etc. Bumped at every
   // WS→game transition so the wire layer can drop pre-transition packets.
-  uint8_t generation() const { return generation_; }
-  void setGenerationForTest(uint8_t g) { generation_ = g; }
-  void resetForGamePhaseForTest() { resetForGamePhase(); }
-  uint64_t droppedOldGenerationBatches() const { return droppedOldGenerationBatches_; }
-  uint8_t pendingFutureBatchCount() const { return pendingFutureCount_; }
+  uint8_t Generation() const { return generation_; }
+  void SetGenerationForTest(uint8_t g) { generation_ = g; }
+  void ResetForGamePhaseForTest() { ResetForGamePhase(); }
+  uint64_t DroppedOldGenerationBatches() const { return droppedOldGenerationBatches_; }
+  uint8_t PendingFutureBatchCount() const { return pendingFutureCount_; }
 
   // Stall a tick when simFrame is at least this far ahead of the remote's
   // last reported simFrame. 5 absorbs natural ±1-2 frame jitter between
@@ -153,7 +153,7 @@ struct RollbackController : CommonController {
 
   // Test hook: raises the threshold high enough that the stall never
   // fires, so tests exercising loss/reorder can freely run ahead.
-  void setFrameAdvantageEnabled(bool enabled) {
+  void SetFrameAdvantageEnabled(bool enabled) {
     frameAdvantageThreshold_ = enabled ? kFrameAdvantage : INT32_MAX;
   }
 
@@ -164,55 +164,55 @@ struct RollbackController : CommonController {
   // so tests can drive a round-trip. worm.weapons[].type and menu item
   // display strings are re-derived on restore from the snapshotted
   // weapon IDs via Common.
-  void saveWeaponSelectSnap(WeaponSelectSnap& snap) const;
-  void loadWeaponSelectSnap(WeaponSelectSnap const& snap);
+  void SaveWeaponSelectSnap(WeaponSelectSnap& snap) const;
+  void LoadWeaponSelectSnap(WeaponSelectSnap const& snap);
 
  private:
-  void advanceSimulation();
-  void advanceWeaponSelection();
+  void AdvanceSimulation();
+  void AdvanceWeaponSelection();
   // Apply (curLocal, curRemote) to worm control states, run one ws tick,
   // and return whether weapon selection is now complete. Shared between
   // the forward path and the rollback resim.
-  bool weaponSelectStep(uint8_t curLocal, uint8_t curRemote);
+  bool WeaponSelectStep(uint8_t cur_local, uint8_t cur_remote);
   // Idempotent via the state check.
-  void finishWeaponSelect();
-  void sendInputWindow(uint32_t newestFrame, uint32_t localFrame);
+  void FinishWeaponSelect();
+  void SendInputWindow(uint32_t newest_frame, uint32_t local_frame);
   // Full controller state reset for a phase transition. Clears the
   // input ring, snapshot ring, frame counters, and edge-detection state;
   // bumps generation_.
-  void resetForGamePhase();
+  void ResetForGamePhase();
 
-  int localIdx;
-  int remoteIdx;
+  int localIdx_;
+  int remoteIdx_;
 
-  GameState state;
-  int fadeValue;
-  bool goingToMenu;
+  ::GameState state_;
+  int fadeValue_;
+  bool goingToMenu_;
 
-  uint32_t simFrame;
-  uint32_t inputDelay;
+  uint32_t simFrame_;
+  uint32_t inputDelay_;
   // simFrame + inputDelay of the most recent local input we packed into
   // localInputs[]. Empty (no input packed yet this phase) when false.
-  uint32_t lastSentFrame;
-  bool lastSentFrameValid;
+  uint32_t lastSentFrame_;
+  bool lastSentFrameValid_;
 
-  static constexpr uint32_t INPUT_BUFFER_SIZE = 256;
-  std::array<uint8_t, INPUT_BUFFER_SIZE> localInputs;
-  std::array<uint8_t, INPUT_BUFFER_SIZE> remoteInputs;
-  std::array<bool, INPUT_BUFFER_SIZE> remoteInputReady;
+  static constexpr uint32_t kInputBufferSize = 256;
+  std::array<uint8_t, kInputBufferSize> localInputs_;
+  std::array<uint8_t, kInputBufferSize> remoteInputs_;
+  std::array<bool, kInputBufferSize> remoteInputReady_;
 
-  Worm::ControlState localControlState;
+  Worm::ControlState localControlState_;
 
-  uint8_t localPrevInput;
-  uint8_t remotePrevInput;
+  uint8_t localPrevInput_;
+  uint8_t remotePrevInput_;
 
-  static constexpr int KEY_REPEAT_INITIAL = 12;
-  static constexpr int KEY_REPEAT_INTERVAL = 3;
-  std::array<uint16_t, 8> localHeldFrames;
-  std::array<uint16_t, 8> remoteHeldFrames;
+  static constexpr int kKeyRepeatInitial = 12;
+  static constexpr int kKeyRepeatInterval = 3;
+  std::array<uint16_t, 8> localHeldFrames_;
+  std::array<uint16_t, 8> remoteHeldFrames_;
 
-  bool skipWeaponSelection;
-  bool levelPreloaded;
+  bool skipWeaponSelection_;
+  bool levelPreloaded_;
 
   bool localPaused_;
   bool remotePaused_;
@@ -235,26 +235,26 @@ struct RollbackController : CommonController {
   uint8_t shadowRemotePrevInput_ = 0;
   bool shadowMismatchLogged_ = false;
 
-  void setupShadowGame();
-  void startReplayRecording();
-  void stopReplayRecording();
-  void driveShadow();
+  void SetupShadowGame();
+  void StartReplayRecording();
+  void StopReplayRecording();
+  void DriveShadow();
 
   // Prepare the rollback ring (idempotent), seed slot 0 with the
   // post-startGame state, then construct the shadow Game. Shared by
   // the WS->Game transition (finishWeaponSelect) and the skip-WS path
   // (focus's StateInitial branch).
-  void seedRollbackAndShadow();
+  void SeedRollbackAndShadow();
 
-  InputBatchSendCallback sendInputBatch;
-  ChecksumSendCallback sendChecksum;
+  InputBatchSendCallback sendInputBatch_;
+  ChecksumSendCallback sendChecksum_;
 
-  std::function<void()> onLocalPause;
-  std::function<void()> onLocalResume;
-  std::function<void()> onEndMatch;
-  std::function<void()> onPeerLeft;
+  std::function<void()> onLocalPause_;
+  std::function<void()> onLocalResume_;
+  std::function<void()> onEndMatch_;
+  std::function<void()> onPeerLeft_;
 
-  std::unique_ptr<WeaponSelection> ws;
+  std::unique_ptr<WeaponSelection> ws_;
 
   // Snapshots after each confirmed frame, plus the local/remote input
   // bytes that produced them. Pre-sized in focus() once the level is
@@ -295,10 +295,10 @@ struct RollbackController : CommonController {
   static constexpr uint8_t kMaxPendingFutureBatches =
       static_cast<uint8_t>(rollback::kMaxRollback + 1);
   struct PendingFutureBatch {
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
-    uint32_t remoteLocalFrame;
+    uint32_t remote_local_frame;
   };
   std::array<PendingFutureBatch, kMaxPendingFutureBatches> pendingFutureBatches_{};
   uint8_t pendingFutureCount_ = 0;

--- a/src/game/cp437.cpp
+++ b/src/game/cp437.cpp
@@ -147,7 +147,7 @@ constexpr char32_t kHighHalf[128] = {
     0x00A0,
 };
 
-void appendUtf8(std::string& out, char32_t cp) {
+void AppendUtf8(std::string& out, char32_t cp) {
   if (cp < 0x80) {
     out.push_back(static_cast<char>(cp));
   } else if (cp < 0x800) {
@@ -167,12 +167,12 @@ void appendUtf8(std::string& out, char32_t cp) {
 
 }  // namespace
 
-char32_t byteToUnicode(uint8_t b) {
+char32_t ByteToUnicode(uint8_t b) {
   if (b < 0x80) return b;
   return kHighHalf[b - 0x80];
 }
 
-int unicodeToByte(char32_t cp) {
+int UnicodeToByte(char32_t cp) {
   if (cp < 0x80) return static_cast<int>(cp);
   for (int i = 0; i < 128; ++i) {
     if (kHighHalf[i] == cp) return i + 0x80;
@@ -180,7 +180,7 @@ int unicodeToByte(char32_t cp) {
   return -1;
 }
 
-char32_t utf8DecodeNext(char const* str, std::size_t len, std::size_t& i) {
+char32_t Utf8DecodeNext(char const* str, std::size_t len, std::size_t& i) {
   if (i >= len) return 0xFFFD;
   unsigned char c = static_cast<unsigned char>(str[i]);
   if (c < 0x80) {
@@ -227,10 +227,10 @@ char32_t utf8DecodeNext(char const* str, std::size_t len, std::size_t& i) {
   return 0xFFFD;
 }
 
-std::string cp437BytesToUtf8(std::string_view in) {
+std::string Cp437BytesToUtf8(std::string_view in) {
   std::string out;
   out.reserve(in.size());
-  for (unsigned char c : in) appendUtf8(out, byteToUnicode(c));
+  for (unsigned char c : in) AppendUtf8(out, ByteToUnicode(c));
   return out;
 }
 

--- a/src/game/cp437.hpp
+++ b/src/game/cp437.hpp
@@ -22,16 +22,16 @@ namespace cp437 {
 // Map a CP437 byte (0x00–0xFF) to its Unicode codepoint. Bytes 0x00–0x1F map
 // to themselves (control codes used in-band by the font); 0x20–0x7E are ASCII;
 // 0x7F maps to U+007F; 0x80–0xFF use the standard CP437 → Unicode table.
-char32_t byteToUnicode(uint8_t b);
+char32_t ByteToUnicode(uint8_t b);
 
 // Reverse mapping. Returns -1 if cp has no CP437 representation.
-int unicodeToByte(char32_t cp);
+int UnicodeToByte(char32_t cp);
 
 // Decode one UTF-8 codepoint at str[i], advance i past it, and return the
 // codepoint. On malformed input, returns U+FFFD and advances by one byte.
-char32_t utf8DecodeNext(char const* str, std::size_t len, std::size_t& i);
+char32_t Utf8DecodeNext(char const* str, std::size_t len, std::size_t& i);
 
 // Convert a string of CP437 bytes into UTF-8.
-std::string cp437BytesToUtf8(std::string_view in);
+std::string Cp437BytesToUtf8(std::string_view in);
 
 }  // namespace cp437

--- a/src/game/exactObjectList.hpp
+++ b/src/game/exactObjectList.hpp
@@ -12,10 +12,10 @@ struct ExactObjectListBase {
 
 template <typename T, int Limit>
 struct ExactObjectList {
-  struct range {
-    range(T* cur, T* end) : cur(cur), end(end) {}
+  struct Range {
+    Range(T* cur, T* end) : cur(cur), end(end) {}
 
-    T* next() {
+    T* Next() {
       while (!cur->used) ++cur;
 
       T* ret = cur;
@@ -28,19 +28,19 @@ struct ExactObjectList {
     T* end;
   };
 
-  ExactObjectList() { clear(); }
+  ExactObjectList() { Clear(); }
 
-  T* getFreeObject() {
+  T* GetFreeObject() {
     assert(count < Limit);
     ++count;
 
     T* ptr = 0;
-    for (uint32_t i = 0; i < FreeListSize; ++i) {
-      if (freeList[i] != 0) {
-        int bit = std::countr_zero(freeList[i]);
+    for (uint32_t i = 0; i < kFreeListSize; ++i) {
+      if (free_list[i] != 0) {
+        int bit = std::countr_zero(free_list[i]);
         uint32_t index = (i << 5) + bit;
         ptr = arr + index;
-        freeList[i] &= ~(uint32_t(1) << bit);
+        free_list[i] &= ~(uint32_t(1) << bit);
         break;
       }
     }
@@ -51,32 +51,32 @@ struct ExactObjectList {
     return ptr;
   }
 
-  T* newObjectReuse() {
+  T* NewObjectReuse() {
     T* ret;
     if (count >= Limit)
       ret = &arr[Limit - 1];
     else
-      ret = getFreeObject();
+      ret = GetFreeObject();
 
     assert(ret->used && ret >= arr && ret < arr + Limit);
     return ret;
   }
 
-  T* newObject() {
+  T* NewObject() {
     if (count >= Limit) return 0;
 
-    T* ret = getFreeObject();
+    T* ret = GetFreeObject();
     assert(ret->used && ret >= arr && ret < arr + Limit);
     return ret;
   }
 
-  range all() { return range(&arr[0], &arr[Limit]); }
+  Range All() { return Range(&arr[0], &arr[Limit]); }
 
-  void free(T* ptr) {
+  void Free(T* ptr) {
     assert(ptr->used);
     if (ptr->used) {
       uint32_t index = uint32_t(ptr - arr);
-      freeList[index >> 5] |= (uint32_t(1) << (index & 31));
+      free_list[index >> 5] |= (uint32_t(1) << (index & 31));
 
       ptr->used = false;
 
@@ -85,10 +85,10 @@ struct ExactObjectList {
     }
   }
 
-  void free(range& r) { free(r.cur - 1); }
+  void Free(Range& r) { Free(r.cur - 1); }
 
-  void clear() {
-    std::memset(freeList, 0xff, FreeListSize * sizeof(uint32_t));
+  void Clear() {
+    std::memset(free_list, 0xff, kFreeListSize * sizeof(uint32_t));
     count = 0;
 
     for (std::size_t i = 0; i < Limit; ++i) arr[i].used = false;
@@ -96,16 +96,16 @@ struct ExactObjectList {
     arr[Limit].used = true;
 
     // Mark padding as used
-    for (uint32_t index = Limit; index < FreeListSize * 32; ++index)
-      freeList[index >> 5] &= ~(uint32_t(1) << (index & 31));
+    for (uint32_t index = Limit; index < kFreeListSize * 32; ++index)
+      free_list[index >> 5] &= ~(uint32_t(1) << (index & 31));
   }
 
-  std::size_t size() const { return count; }
+  std::size_t Size() const { return count; }
 
   T arr[Limit + 1];  // Sentinel
 
-  static uint32_t const FreeListSize = (Limit + 31) / 32;
-  uint32_t freeList[FreeListSize];
+  static uint32_t const kFreeListSize = (Limit + 31) / 32;
+  uint32_t free_list[kFreeListSize];
 
   std::size_t count;
 };

--- a/src/game/fastObjectList.hpp
+++ b/src/game/fastObjectList.hpp
@@ -7,10 +7,10 @@
 
 template <typename T>
 struct FastObjectList {
-  struct iterator {
-    iterator(T* cur_) : cur(cur_) {}
+  struct Iterator {
+    Iterator(T* cur) : cur(cur) {}
 
-    iterator& operator++() {
+    Iterator& operator++() {
       ++cur;
       return *this;
     }
@@ -19,56 +19,56 @@ struct FastObjectList {
 
     T* operator->() { return cur; }
 
-    bool operator!=(iterator b) { return cur != b.cur; }
+    bool operator!=(Iterator b) { return cur != b.cur; }
 
     T* cur;
   };
 
-  FastObjectList(std::size_t limit = 1) : limit(limit), arr(limit) { clear(); }
+  FastObjectList(std::size_t limit = 1) : limit(limit), arr(limit) { Clear(); }
 
-  T* getFreeObject() {
+  T* GetFreeObject() {
     assert(count < limit);
     T* ptr = &arr[count++];
     return ptr;
   }
 
-  T* newObjectReuse() {
+  T* NewObjectReuse() {
     T* ret;
     if (count == limit)
       ret = &arr[limit - 1];
     else
-      ret = getFreeObject();
+      ret = GetFreeObject();
 
     return ret;
   }
 
-  T* newObject() {
+  T* NewObject() {
     if (count == limit) return 0;
 
-    T* ret = getFreeObject();
+    T* ret = GetFreeObject();
     return ret;
   }
 
-  iterator begin() { return iterator(&arr[0]); }
+  Iterator Begin() { return Iterator(&arr[0]); }
 
-  iterator end() { return iterator(&arr[0] + count); }
+  Iterator End() { return Iterator(&arr[0] + count); }
 
-  void free(T* ptr) {
+  void Free(T* ptr) {
     assert(ptr < &arr[0] + count && ptr >= &arr[0]);
     *ptr = arr[--count];
   }
 
-  void free(iterator i) { free(&*i); }
+  void Free(Iterator i) { Free(&*i); }
 
-  void clear() { count = 0; }
+  void Clear() { count = 0; }
 
-  void resize(std::size_t newLimit) {
-    limit = newLimit;
-    count = std::min(count, newLimit);
-    arr.resize(newLimit);
+  void Resize(std::size_t new_limit) {
+    limit = new_limit;
+    count = std::min(count, new_limit);
+    arr.resize(new_limit);
   }
 
-  std::size_t size() const { return count; }
+  std::size_t Size() const { return count; }
 
   std::size_t limit;
   std::vector<T> arr;

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -18,24 +18,24 @@ using std::string;
 
 FileSelectorState::FileSelectorState(std::string title) : title_(std::move(title)) {}
 
-void FileSelectorState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void FileSelectorState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool FileSelectorState::update() {
+bool FileSelectorState::Update() {
   if (done_) return false;
 
-  if (!selector_->process()) {
+  if (!selector_->Process()) {
     done_ = true;
     return false;
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN) || gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER) ||
-      gfx->testControlOnce(WormSettingsExtensions::Fire) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
-    g_soundPlayer->play(gfx->common->soundHook[SoundMenuSelect]);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RETURN) || gfx->TestSdlKeyOnce(SDL_SCANCODE_KP_ENTER) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kFire) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
+    g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
 
-    auto* sel = selector_->enter();
+    auto* sel = selector_->Enter();
     if (sel) {
-      if (onSelected(sel)) {
+      if (OnSelected(sel)) {
         done_ = true;
         return false;
       }
@@ -45,72 +45,72 @@ bool FileSelectorState::update() {
   return true;
 }
 
-void FileSelectorState::draw() {
-  gfx->playRenderer.bmp.copy(gfx->frozenScreen);
+void FileSelectorState::Draw() {
+  gfx->play_renderer.bmp.Copy(gfx->frozen_screen);
 
   if (!title_.empty()) {
-    string displayTitle = title_;
-    if (!selector_->currentNode->fullPath.empty()) {
-      displayTitle += ' ';
-      displayTitle += selector_->currentNode->fullPath;
+    string display_title = title_;
+    if (!selector_->current_node->full_path.empty()) {
+      display_title += ' ';
+      display_title += selector_->current_node->full_path;
     }
 
-    gfx->common->font.drawFramedText(gfx->playRenderer.bmp, displayTitle, 178, 20, 50);
+    gfx->common->font.DrawFramedText(gfx->play_renderer.bmp, display_title, 178, 20, 50);
   }
 
-  drawExtra();
-  selector_->draw();
+  DrawExtra();
+  selector_->Draw();
 }
 
 // --- LevelSelectorState ---
 
 LevelSelectorState::LevelSelectorState() : FileSelectorState("") {}
 
-void LevelSelectorState::enter() {
+void LevelSelectorState::Enter() {
   Common& common = *gfx->common;
   // title_ left empty — LevelSelectorState draws its own title in drawExtra()
   selector_ = std::make_unique<FileSelector>(common);
 
-  randomNode_ = std::make_shared<FileNode>(LS(Random), "", "", false, &selector_->rootNode);
+  randomNode_ = std::make_shared<FileNode>(LS(Random), "", "", false, &selector_->root_node);
 
-  selector_->fill(gfx->getConfigNode(),
-                  [](string const& name, string const& ext) { return ciCompare(ext, "LEV"); });
+  selector_->Fill(gfx->GetConfigNode(),
+                  [](string const& name, string const& ext) { return CiCompare(ext, "LEV"); });
 
   randomNode_->id = 1;
-  selector_->rootNode.children.insert(selector_->rootNode.children.begin(), randomNode_);
-  selector_->setFolder(selector_->rootNode);
-  selector_->select(gfx->settings->levelFile);
+  selector_->root_node.children.insert(selector_->root_node.children.begin(), randomNode_);
+  selector_->SetFolder(selector_->root_node);
+  selector_->Select(gfx->settings->level_file);
 
   previewNode_ = nullptr;
 }
 
-bool LevelSelectorState::onSelected(FileNode* node) {
+bool LevelSelectorState::OnSelected(FileNode* node) {
   if (node == randomNode_.get()) {
-    gfx->settings->randomLevel = true;
-    gfx->settings->levelFile.clear();
+    gfx->settings->random_level = true;
+    gfx->settings->level_file.clear();
   } else {
-    gfx->settings->randomLevel = false;
-    gfx->settings->levelFile = node->fullPath;
+    gfx->settings->random_level = false;
+    gfx->settings->level_file = node->full_path;
   }
   return true;
 }
 
-void LevelSelectorState::drawExtra() {
+void LevelSelectorState::DrawExtra() {
   Common& common = *gfx->common;
-  FileNode* sel = selector_->curSel();
+  FileNode* sel = selector_->CurSel();
 
   if (previewNode_ != sel && sel && sel != randomNode_.get() && !sel->folder) {
     Level level(common);
 
     try {
-      auto r_ptr = sel->getFsNode().toReader();
+      auto r_ptr = sel->GetFsNode().ToReader();
       io::Reader& r = *r_ptr;
       if (level.load(common, *gfx->settings, r)) {
-        int centerX = gfx->singleScreenRenderer.renderResX / 2;
+        int center_x = gfx->single_screen_renderer.render_res_x / 2;
 
-        level.drawMiniature(gfx->frozenScreen, 134, 162, 10);
-        level.drawMiniature(gfx->frozenSpectatorScreen, centerX - 126,
-                            gfx->singleScreenRenderer.renderResY - 208, 2);
+        level.DrawMiniature(gfx->frozen_screen, 134, 162, 10);
+        level.DrawMiniature(gfx->frozen_spectator_screen, center_x - 126,
+                            gfx->single_screen_renderer.render_res_y - 208, 2);
       }
     } catch (std::runtime_error&) {
       // Ignore
@@ -121,40 +121,40 @@ void LevelSelectorState::drawExtra() {
 
   // Draw title with width for rounded box (level selector uses different title rendering)
   string title = LS(SelLevel);
-  if (!selector_->currentNode->fullPath.empty()) {
+  if (!selector_->current_node->full_path.empty()) {
     title += ' ';
-    title += selector_->currentNode->fullPath;
+    title += selector_->current_node->full_path;
   }
 
-  int wid = common.font.getDims(title);
-  drawRoundedBox(gfx->playRenderer.bmp, 178, 20, 0, 7, wid);
-  common.font.drawText(gfx->playRenderer.bmp, title, 180, 21, 50);
+  int wid = common.font.GetDims(title);
+  DrawRoundedBox(gfx->play_renderer.bmp, 178, 20, 0, 7, wid);
+  common.font.DrawText(gfx->play_renderer.bmp, title, 180, 21, 50);
 }
 
 // --- ReplaySelectorState ---
 
 ReplaySelectorState::ReplaySelectorState() : FileSelectorState("Select replay:") {}
 
-void ReplaySelectorState::enter() {
+void ReplaySelectorState::Enter() {
   selector_ = std::make_unique<FileSelector>(*gfx->common, 28);
 
-  selector_->fill(gfx->getConfigNode(),
-                  [](string const& name, string const& ext) { return ciCompare(ext, "LRP"); });
+  selector_->Fill(gfx->GetConfigNode(),
+                  [](string const& name, string const& ext) { return CiCompare(ext, "LRP"); });
 
-  selector_->setFolder(selector_->rootNode);
-  if (gfx->prevSelectedReplayPath.empty() || !selector_->select(gfx->prevSelectedReplayPath)) {
-    selector_->select(joinPath(gfx->getConfigNode().fullPath(), "Replays"));
+  selector_->SetFolder(selector_->root_node);
+  if (gfx->prev_selected_replay_path.empty() || !selector_->Select(gfx->prev_selected_replay_path)) {
+    selector_->Select(JoinPath(gfx->GetConfigNode().FullPath(), "Replays"));
   }
 }
 
-bool ReplaySelectorState::onSelected(FileNode* node) {
-  gfx->prevSelectedReplayPath = node->fullPath;
+bool ReplaySelectorState::OnSelected(FileNode* node) {
+  gfx->prev_selected_replay_path = node->full_path;
 
   // Reset controller before opening the replay, since we may be recording it
   gfx->controller.reset();
-  gfx->controller.reset(new ReplayController(gfx->common, node->getFsNode().toReader()));
+  gfx->controller.reset(new ReplayController(gfx->common, node->GetFsNode().ToReader()));
 
-  gfx->pendingMenuSelection = MainMenu::MaReplay;
+  gfx->pending_menu_selection = MainMenu::kMaReplay;
   return true;
 }
 
@@ -163,20 +163,20 @@ bool ReplaySelectorState::onSelected(FileNode* node) {
 ProfileSelectorState::ProfileSelectorState(WormSettings& ws)
     : FileSelectorState("Select profile:"), ws_(ws) {}
 
-void ProfileSelectorState::enter() {
+void ProfileSelectorState::Enter() {
   selector_ = std::make_unique<FileSelector>(*gfx->common, 28);
 
-  selector_->fill(gfx->getConfigNode(),
-                  [](string const& name, string const& ext) { return ciCompare(ext, "TOML"); });
+  selector_->Fill(gfx->GetConfigNode(),
+                  [](string const& name, string const& ext) { return CiCompare(ext, "TOML"); });
 
-  selector_->setFolder(selector_->rootNode);
-  selector_->select(joinPath(gfx->getConfigNode().fullPath(), "Profiles"));
+  selector_->SetFolder(selector_->root_node);
+  selector_->Select(JoinPath(gfx->GetConfigNode().FullPath(), "Profiles"));
 }
 
-bool ProfileSelectorState::onSelected(FileNode* node) {
-  ws_.loadProfile(node->getFsNode());
+bool ProfileSelectorState::OnSelected(FileNode* node) {
+  ws_.LoadProfile(node->GetFsNode());
   // Refresh the player menu so it reflects the newly loaded profile
-  gfx->playerMenu.updateItems(*gfx->common);
+  gfx->player_menu.UpdateItems(*gfx->common);
   return true;
 }
 
@@ -184,19 +184,19 @@ bool ProfileSelectorState::onSelected(FileNode* node) {
 
 OptionsSelectorState::OptionsSelectorState() : FileSelectorState("Select options:") {}
 
-void OptionsSelectorState::enter() {
+void OptionsSelectorState::Enter() {
   selector_ = std::make_unique<FileSelector>(*gfx->common, 28);
 
-  selector_->fill(gfx->getConfigNode(),
-                  [](string const& name, string const& ext) { return ciCompare(ext, "CFG"); });
+  selector_->Fill(gfx->GetConfigNode(),
+                  [](string const& name, string const& ext) { return CiCompare(ext, "CFG"); });
 
-  selector_->setFolder(selector_->rootNode);
-  selector_->select(joinPath(gfx->getConfigNode().fullPath(), "Setups"));
+  selector_->SetFolder(selector_->root_node);
+  selector_->Select(JoinPath(gfx->GetConfigNode().FullPath(), "Setups"));
 }
 
-bool OptionsSelectorState::onSelected(FileNode* node) {
-  gfx->loadSettings(node->getFsNode());
-  gfx->settingsMenu.updateItems(*gfx->common);
+bool OptionsSelectorState::OnSelected(FileNode* node) {
+  gfx->LoadSettings(node->GetFsNode());
+  gfx->settings_menu.UpdateItems(*gfx->common);
   return true;
 }
 
@@ -204,32 +204,32 @@ bool OptionsSelectorState::onSelected(FileNode* node) {
 
 TcSelectorState::TcSelectorState() : FileSelectorState("Select TC:") {}
 
-void TcSelectorState::enter() {
+void TcSelectorState::Enter() {
   selector_ = std::make_unique<FileSelector>(*gfx->common, 28);
 
-  selector_->fill(gfx->getConfigNode() / "TC", 0);
-  selector_->setFolder(selector_->rootNode);
+  selector_->Fill(gfx->GetConfigNode() / "TC", 0);
+  selector_->SetFolder(selector_->root_node);
 
-  auto end = std::remove_if(selector_->rootNode.children.begin(),
-                            selector_->rootNode.children.end(), [](shared_ptr<FileNode> const& n) {
-                              auto tc = n->getFsNode() / "tc.cfg";
-                              return !tc.exists();
+  auto end = std::remove_if(selector_->root_node.children.begin(),
+                            selector_->root_node.children.end(), [](shared_ptr<FileNode> const& n) {
+                              auto tc = n->GetFsNode() / "tc.cfg";
+                              return !tc.Exists();
                             });
 
-  selector_->rootNode.children.erase(end, selector_->rootNode.children.end());
+  selector_->root_node.children.erase(end, selector_->root_node.children.end());
 
-  for (auto& c : selector_->rootNode.children) {
+  for (auto& c : selector_->root_node.children) {
     c->folder = false;
   }
 }
 
-bool TcSelectorState::onSelected(FileNode* node) {
-  std::unique_ptr<Common> newCommon(new Common());
-  newCommon->load(node->getFsNode());
+bool TcSelectorState::OnSelected(FileNode* node) {
+  std::unique_ptr<Common> new_common(new Common());
+  new_common->load(node->GetFsNode());
   gfx->settings->tc = node->name;
-  gfx->common.reset(newCommon.release());
-  if (auto* dp = dynamic_cast<DefaultSoundPlayer*>(gfx->soundPlayer.get()))
-    dp->setCommon(*gfx->common);
-  gfx->pendingMenuSelection = MainMenu::MaTc;
+  gfx->common.reset(new_common.release());
+  if (auto* dp = dynamic_cast<DefaultSoundPlayer*>(gfx->sound_player.get()))
+    dp->SetCommon(*gfx->common);
+  gfx->pending_menu_selection = MainMenu::kMaTc;
   return true;
 }

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -142,7 +142,8 @@ void ReplaySelectorState::Enter() {
                   [](string const& name, string const& ext) { return CiCompare(ext, "LRP"); });
 
   selector_->SetFolder(selector_->root_node);
-  if (gfx->prev_selected_replay_path.empty() || !selector_->Select(gfx->prev_selected_replay_path)) {
+  if (gfx->prev_selected_replay_path.empty() ||
+      !selector_->Select(gfx->prev_selected_replay_path)) {
     selector_->Select(JoinPath(gfx->GetConfigNode().FullPath(), "Replays"));
   }
 }

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -128,7 +128,7 @@ void LevelSelectorState::DrawExtra() {
 
   int wid = common.font.GetDims(title);
   DrawRoundedBox(gfx->play_renderer.bmp, 178, 20, 0, 7, wid);
-  common.font.DrawText(gfx->play_renderer.bmp, title, 180, 21, 50);
+  common.font.DrawString(gfx->play_renderer.bmp, title, 180, 21, 50);
 }
 
 // --- ReplaySelectorState ---

--- a/src/game/fileSelectorState.hpp
+++ b/src/game/fileSelectorState.hpp
@@ -14,18 +14,18 @@
 struct FileSelectorState : AppState {
   FileSelectorState(std::string title);
 
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
   // Called when the user selects a file. Return true to accept and pop.
-  virtual bool onSelected(FileNode* node) = 0;
+  virtual bool OnSelected(FileNode* node) = 0;
 
   // Override to do per-frame drawing before the selector (e.g. level preview)
-  virtual void drawExtra() {}
+  virtual void DrawExtra() {}
 
  protected:
-  FileSelector& selector() { return *selector_; }
+  FileSelector& Selector() { return *selector_; }
   std::unique_ptr<FileSelector> selector_;
   std::string title_;
   bool done_ = false;
@@ -34,9 +34,9 @@ struct FileSelectorState : AppState {
 // Level selector
 struct LevelSelectorState : FileSelectorState {
   LevelSelectorState();
-  void enter() override;
-  bool onSelected(FileNode* node) override;
-  void drawExtra() override;
+  void Enter() override;
+  bool OnSelected(FileNode* node) override;
+  void DrawExtra() override;
 
  private:
   std::shared_ptr<FileNode> randomNode_;
@@ -46,15 +46,15 @@ struct LevelSelectorState : FileSelectorState {
 // Replay selector
 struct ReplaySelectorState : FileSelectorState {
   ReplaySelectorState();
-  void enter() override;
-  bool onSelected(FileNode* node) override;
+  void Enter() override;
+  bool OnSelected(FileNode* node) override;
 };
 
 // Profile selector
 struct ProfileSelectorState : FileSelectorState {
   ProfileSelectorState(WormSettings& ws);
-  void enter() override;
-  bool onSelected(FileNode* node) override;
+  void Enter() override;
+  bool OnSelected(FileNode* node) override;
 
  private:
   WormSettings& ws_;
@@ -63,13 +63,13 @@ struct ProfileSelectorState : FileSelectorState {
 // Options (settings file) selector
 struct OptionsSelectorState : FileSelectorState {
   OptionsSelectorState();
-  void enter() override;
-  bool onSelected(FileNode* node) override;
+  void Enter() override;
+  bool OnSelected(FileNode* node) override;
 };
 
 // TC selector
 struct TcSelectorState : FileSelectorState {
   TcSelectorState();
-  void enter() override;
-  bool onSelected(FileNode* node) override;
+  void Enter() override;
+  bool OnSelected(FileNode* node) override;
 };

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -130,7 +130,7 @@ struct FilenameResult {
 #define BOOST_SYSTEM_DIRECTORY_TYPE struct dirent*
 
 inline FilenameResult FindFirstFile(const char* dir, BOOST_HANDLE& handle,
-                                       BOOST_SYSTEM_DIRECTORY_TYPE&)
+                                    BOOST_SYSTEM_DIRECTORY_TYPE&)
 // Returns: 0 if error, otherwise name
 {
   const char* dummy_first_name = ".";

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -14,42 +14,42 @@
 #include <unistd.h>
 #endif
 
-std::string changeLeaf(std::string const& path, std::string const& newLeaf) {
-  std::size_t lastSep = path.find_last_of("\\/");
+std::string ChangeLeaf(std::string const& path, std::string const& new_leaf) {
+  std::size_t last_sep = path.find_last_of("\\/");
 
-  if (lastSep == std::string::npos) return newLeaf;  // We assume there's only a leaf in the path
-  return path.substr(0, lastSep + 1) + newLeaf;
+  if (last_sep == std::string::npos) return new_leaf;  // We assume there's only a leaf in the path
+  return path.substr(0, last_sep + 1) + new_leaf;
 }
 
-std::string getRoot(std::string const& path) {
-  std::size_t lastSep = path.find_last_of("\\/");
+std::string GetRoot(std::string const& path) {
+  std::size_t last_sep = path.find_last_of("\\/");
 
-  if (lastSep == std::string::npos) return "";
-  return path.substr(0, lastSep);
+  if (last_sep == std::string::npos) return "";
+  return path.substr(0, last_sep);
 }
 
-std::string getLeaf(std::string const& path) {
-  std::size_t lastSep = path.find_last_of("\\/");
+std::string GetLeaf(std::string const& path) {
+  std::size_t last_sep = path.find_last_of("\\/");
 
-  if (lastSep == std::string::npos) return path;
-  return path.substr(lastSep + 1);
+  if (last_sep == std::string::npos) return path;
+  return path.substr(last_sep + 1);
 }
 
-std::string getBasename(std::string const& path) {
-  std::size_t lastSep = path.find_last_of(".");
+std::string GetBasename(std::string const& path) {
+  std::size_t last_sep = path.find_last_of(".");
 
-  if (lastSep == std::string::npos) return path;
-  return path.substr(0, lastSep);
+  if (last_sep == std::string::npos) return path;
+  return path.substr(0, last_sep);
 }
 
-std::string getExtension(std::string const& path) {
-  std::size_t lastSep = path.find_last_of(".");
+std::string GetExtension(std::string const& path) {
+  std::size_t last_sep = path.find_last_of(".");
 
-  if (lastSep == std::string::npos) return "";
-  return path.substr(lastSep + 1);
+  if (last_sep == std::string::npos) return "";
+  return path.substr(last_sep + 1);
 }
 
-std::string toUpperCase(std::string str) {
+std::string ToUpperCase(std::string str) {
   for (std::size_t i = 0; i < str.size(); ++i) {
     str[i] = std::toupper(static_cast<unsigned char>(
         str[i]));  // TODO: Uppercase conversion that works for the DOS charset
@@ -57,7 +57,7 @@ std::string toUpperCase(std::string str) {
   return str;
 }
 
-std::string toLowerCase(std::string str) {
+std::string ToLowerCase(std::string str) {
   for (std::size_t i = 0; i < str.size(); ++i) {
     str[i] = std::tolower(static_cast<unsigned char>(
         str[i]));  // TODO: Lowercase conversion that works for the DOS charset
@@ -65,18 +65,18 @@ std::string toLowerCase(std::string str) {
   return str;
 }
 
-FILE* tolerantFOpen(std::string const& name, char const* mode) {
+FILE* TolerantFOpen(std::string const& name, char const* mode) {
   FILE* f = std::fopen(name.c_str(), mode);
   if (f) return f;
 
-  f = std::fopen(toUpperCase(name).c_str(), mode);
+  f = std::fopen(ToUpperCase(name).c_str(), mode);
   if (f) return f;
 
-  f = std::fopen(toLowerCase(name).c_str(), mode);
+  f = std::fopen(ToLowerCase(name).c_str(), mode);
   if (f) return f;
 
   // Try with first letter capital
-  std::string ch(toLowerCase(name));
+  std::string ch(ToLowerCase(name));
   ch[0] = std::toupper(static_cast<unsigned char>(ch[0]));
   f = std::fopen(ch.c_str(), mode);
   if (f) return f;
@@ -84,7 +84,7 @@ FILE* tolerantFOpen(std::string const& name, char const* mode) {
   return 0;
 }
 
-std::size_t fileLength(FILE* f) {
+std::size_t FileLength(FILE* f) {
   long old = ftell(f);
   fseek(f, 0, SEEK_END);
   long len = ftell(f);
@@ -113,10 +113,10 @@ using std::time_t;
 
 namespace {
 
-struct filename_result {
-  filename_result() : name(0) {}
+struct FilenameResult {
+  FilenameResult() : name(0) {}
 
-  filename_result(char const* name) : name(name) {}
+  FilenameResult(char const* name) : name(name) {}
 
   operator void const*() { return name; }
 
@@ -129,22 +129,22 @@ struct filename_result {
 #define BOOST_INVALID_HANDLE_VALUE 0
 #define BOOST_SYSTEM_DIRECTORY_TYPE struct dirent*
 
-inline filename_result find_first_file(const char* dir, BOOST_HANDLE& handle,
+inline FilenameResult FindFirstFile(const char* dir, BOOST_HANDLE& handle,
                                        BOOST_SYSTEM_DIRECTORY_TYPE&)
 // Returns: 0 if error, otherwise name
 {
   const char* dummy_first_name = ".";
   return ((handle = ::opendir(dir)) == BOOST_INVALID_HANDLE_VALUE)
-             ? filename_result()
-             : filename_result(dummy_first_name);
+             ? FilenameResult()
+             : FilenameResult(dummy_first_name);
 }
 
-inline void find_close(BOOST_HANDLE handle) {
+inline void FindClose(BOOST_HANDLE handle) {
   assert(handle != BOOST_INVALID_HANDLE_VALUE);
   ::closedir(handle);
 }
 
-inline filename_result find_next_file(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE&)
+inline FilenameResult FindNextFile(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE&)
 // Returns: if EOF 0, otherwise name
 // Throws: if system reports error
 {
@@ -157,10 +157,10 @@ inline filename_result find_next_file(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTOR
     if (errno != 0) {
       throw std::runtime_error("Error iterating directory");
     } else {
-      return filename_result();
+      return FilenameResult();
     }  // end reached
   }
-  return filename_result(dp->d_name);
+  return FilenameResult(dp->d_name);
 }
 #elif _WIN32
 
@@ -234,16 +234,16 @@ bool create_directories(std::string const& dir) {
 
 #else
 
-static char const dirSep = '/';
+static char const kDirSep = '/';
 
-inline char isDirSep(char c) { return c == dirSep; }
+inline char IsDirSep(char c) { return c == kDirSep; }
 
 #include <sys/stat.h>
 #include <sys/types.h>
 
-bool create_directories(std::string const& dir) {
+bool CreateDirectories(std::string const& dir) {
   for (std::size_t i = 1; i < dir.size(); ++i) {
-    if (isDirSep(dir[i])) {
+    if (IsDirSep(dir[i])) {
       std::string path = dir.substr(0, i);
       struct stat s;
       if (stat(path.c_str(), &s) < 0) {
@@ -259,7 +259,7 @@ bool create_directories(std::string const& dir) {
 
 #endif
 
-std::string joinPath(std::string const& root, std::string const& leaf) {
+std::string JoinPath(std::string const& root, std::string const& leaf) {
   if (!root.empty() && root[root.size() - 1] != '\\' && root[root.size() - 1] != '/') {
     return root + '/' + leaf;
   } else {
@@ -267,7 +267,7 @@ std::string joinPath(std::string const& root, std::string const& leaf) {
   }
 }
 
-inline bool dot_or_dot_dot(char const* name) {
+inline bool DotOrDotDot(char const* name) {
   return name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'));
 }
 
@@ -276,42 +276,42 @@ DirectoryListing::DirectoryListing(std::string const& dir) {
 
   BOOST_HANDLE handle;
   BOOST_SYSTEM_DIRECTORY_TYPE scratch;
-  filename_result name;  // initialization quiets compiler warnings
+  FilenameResult name;  // initialization quiets compiler warnings
 
   if (!dir_path[0])
     handle = BOOST_INVALID_HANDLE_VALUE;
   else
-    name = find_first_file(dir_path, handle, scratch);  // sets handle
+    name = FindFirstFile(dir_path, handle, scratch);  // sets handle
 
   if (handle != BOOST_INVALID_HANDLE_VALUE) {
     do {
-      if (!dot_or_dot_dot(name.name)) {
+      if (!DotOrDotDot(name.name)) {
         struct stat st;
-        if (stat(joinPath(dir, name.name).c_str(), &st) == 0) {
+        if (stat(JoinPath(dir, name.name).c_str(), &st) == 0) {
           subs.push_back(NodeName(name.name, (st.st_mode & S_IFMT) == S_IFDIR));
 
-          if (endsWith(subs.back().name, ".zip")) {
+          if (EndsWith(subs.back().name, ".zip")) {
             auto& back = subs.back();
             back.name.erase(subs.back().name.size() - 4);
-            back.isDir = true;
+            back.is_dir = true;
           }
         }
       }
-    } while ((name = find_next_file(handle, scratch)));
+    } while ((name = FindNextFile(handle, scratch)));
 
-    find_close(handle);
+    FindClose(handle);
   }
 
-  sort();
+  Sort();
 }
 
-DirectoryListing::DirectoryListing(std::vector<NodeName>&& subsInit) : subs(std::move(subsInit)) {
-  sort();
+DirectoryListing::DirectoryListing(std::vector<NodeName>&& subs_init) : subs(std::move(subs_init)) {
+  Sort();
 }
 
 DirectoryListing::~DirectoryListing() {}
 
-void DirectoryListing::sort() {
+void DirectoryListing::Sort() {
   std::sort(subs.begin(), subs.end(),
             [](NodeName const& a, NodeName const& b) { return a.name < b.name; });
   auto i = std::unique(subs.begin(), subs.end(),
@@ -331,36 +331,36 @@ struct FsNodeZipArchive {
   FsNodeZipFile* root;
 };
 
-std::shared_ptr<FsNodeImp> join(std::shared_ptr<FsNodeImp> a, std::shared_ptr<FsNodeImp> b);
+std::shared_ptr<FsNodeImp> Join(std::shared_ptr<FsNodeImp> a, std::shared_ptr<FsNodeImp> b);
 
 struct FsNodeJoin : FsNodeImp {
   std::shared_ptr<FsNodeImp> a, b;
 
-  FsNodeJoin(std::shared_ptr<FsNodeImp> aInit, std::shared_ptr<FsNodeImp> bInit)
-      : a(std::move(aInit)), b(std::move(bInit)) {}
+  FsNodeJoin(std::shared_ptr<FsNodeImp> a_init, std::shared_ptr<FsNodeImp> b_init)
+      : a(std::move(a_init)), b(std::move(b_init)) {}
 
-  std::string const& fullPath() { return a->fullPath(); }
+  std::string const& FullPath() { return a->FullPath(); }
 
-  DirectoryListing iter() { return a->iter() | b->iter(); }
+  DirectoryListing Iter() { return a->Iter() | b->Iter(); }
 
-  std::shared_ptr<FsNodeImp> go(std::string const& name) { return join(a->go(name), b->go(name)); }
+  std::shared_ptr<FsNodeImp> Go(std::string const& name) { return Join(a->Go(name), b->Go(name)); }
 
-  bool exists() const { return a->exists() || b->exists(); }
+  bool Exists() const { return a->Exists() || b->Exists(); }
 
-  std::unique_ptr<io::Reader> tryToReader() {
-    auto s = a->tryToReader();
+  std::unique_ptr<io::Reader> TryToReader() {
+    auto s = a->TryToReader();
     if (s) return s;
-    return b->tryToReader();
+    return b->TryToReader();
   }
 
-  std::unique_ptr<io::Writer> tryToWriter() {
-    auto s = a->tryToWriter();
+  std::unique_ptr<io::Writer> TryToWriter() {
+    auto s = a->TryToWriter();
     if (s) return s;
-    return b->tryToWriter();
+    return b->TryToWriter();
   }
 };
 
-std::shared_ptr<FsNodeImp> join(std::shared_ptr<FsNodeImp> a, std::shared_ptr<FsNodeImp> b) {
+std::shared_ptr<FsNodeImp> Join(std::shared_ptr<FsNodeImp> a, std::shared_ptr<FsNodeImp> b) {
   if (!b) return a;
   if (!a) return b;
   return std::shared_ptr<FsNodeImp>(new FsNodeJoin(std::move(a), std::move(b)));
@@ -369,21 +369,21 @@ std::shared_ptr<FsNodeImp> join(std::shared_ptr<FsNodeImp> a, std::shared_ptr<Fs
 struct FsNodeZipFile : FsNodeImp {
   std::shared_ptr<FsNodeZipArchive> archive;
   std::string path;
-  std::string relPath;
-  int fileIndex;
-  bool isDir;
+  std::string rel_path;
+  int file_index;
+  bool is_dir;
 
-  FsNodeZipFile(std::string const& path, bool isDir)
-      : archive(new FsNodeZipArchive(path)), path(path), fileIndex(-1), isDir(isDir) {
+  FsNodeZipFile(std::string const& path, bool is_dir)
+      : archive(new FsNodeZipArchive(path)), path(path), file_index(-1), is_dir(is_dir) {
     archive->root = this;
 
-    auto fileCount = mz_zip_reader_get_num_files(&archive->archive);
+    auto file_count = mz_zip_reader_get_num_files(&archive->archive);
 
-    for (mz_uint fileIndex = 0; fileIndex < fileCount; ++fileIndex) {
+    for (mz_uint file_index = 0; file_index < file_count; ++file_index) {
       char buf[260];
-      mz_zip_reader_get_filename(&archive->archive, fileIndex, buf, 260);
+      mz_zip_reader_get_filename(&archive->archive, file_index, buf, 260);
 
-      bool isDir = mz_zip_reader_is_file_a_directory(&archive->archive, fileIndex);
+      bool is_dir = mz_zip_reader_is_file_a_directory(&archive->archive, file_index);
 
       std::string filepath(buf);
 
@@ -392,13 +392,13 @@ struct FsNodeZipFile : FsNodeImp {
       std::size_t beg = 0, i = 0;
 
       for (; i < filepath.size(); ++i) {
-        if (isDirSep(filepath[i])) {
+        if (IsDirSep(filepath[i])) {
           std::string const& part = filepath.substr(beg, i - beg);
 
           auto& c = cur->children[part];
           if (!c)
-            c.reset(new FsNodeZipFile(archive, joinPath(cur->path, part),
-                                      joinPath(cur->relPath, part), -1, true));
+            c.reset(new FsNodeZipFile(archive, JoinPath(cur->path, part),
+                                      JoinPath(cur->rel_path, part), -1, true));
           cur = c.get();
 
           beg = i + 1;
@@ -410,48 +410,48 @@ struct FsNodeZipFile : FsNodeImp {
 
         auto& c = cur->children[part];
         if (!c)
-          c.reset(new FsNodeZipFile(archive, joinPath(cur->path, part),
-                                    joinPath(cur->relPath, part), (int)fileIndex, isDir));
+          c.reset(new FsNodeZipFile(archive, JoinPath(cur->path, part),
+                                    JoinPath(cur->rel_path, part), (int)file_index, is_dir));
         cur = c.get();
       }
     }
   }
 
-  FsNodeZipFile(std::shared_ptr<FsNodeZipArchive> archive, std::string const& fullPath,
-                std::string const& relPath, int fileIndex, bool isDir)
+  FsNodeZipFile(std::shared_ptr<FsNodeZipArchive> archive, std::string const& full_path,
+                std::string const& rel_path, int file_index, bool is_dir)
       : archive(std::move(archive)),
-        path(fullPath),
-        relPath(relPath),
-        fileIndex(fileIndex),
-        isDir(isDir) {}
+        path(full_path),
+        rel_path(rel_path),
+        file_index(file_index),
+        is_dir(is_dir) {}
 
   std::map<std::string, std::shared_ptr<FsNodeZipFile>> children;
 
-  std::string const& fullPath() { return path; }
+  std::string const& FullPath() { return path; }
 
-  DirectoryListing iter() {
+  DirectoryListing Iter() {
     std::vector<NodeName> subs;
 
     for (auto& i : children) {
-      subs.push_back(NodeName(i.first, i.second->isDir));
+      subs.push_back(NodeName(i.first, i.second->is_dir));
     }
 
     return DirectoryListing(std::move(subs));
   }
 
-  std::shared_ptr<FsNodeImp> go(std::string const& name) {
+  std::shared_ptr<FsNodeImp> Go(std::string const& name) {
     auto i = children.find(name);
     if (i != children.end()) return i->second;
     return std::shared_ptr<FsNodeImp>();
   }
 
-  bool exists() const { return true; }
+  bool Exists() const { return true; }
 
-  std::unique_ptr<io::Reader> tryToReader() {
-    if (fileIndex < 0) return nullptr;
+  std::unique_ptr<io::Reader> TryToReader() {
+    if (file_index < 0) return nullptr;
 
     std::size_t size;
-    auto* ptr = mz_zip_reader_extract_to_heap(&archive->archive, (mz_uint)fileIndex, &size, 0);
+    auto* ptr = mz_zip_reader_extract_to_heap(&archive->archive, (mz_uint)file_index, &size, 0);
 
     if (!ptr) return nullptr;
 
@@ -466,28 +466,28 @@ struct FsNodeZipFile : FsNodeImp {
       io::MemReader inner;
       explicit OwnedMemReader(std::vector<uint8_t>&& d)
           : data(std::move(d)), inner(data.data(), data.size()) {}
-      uint8_t get() override { return inner.get(); }
-      std::size_t try_get(uint8_t* dst, std::size_t n) override { return inner.try_get(dst, n); }
+      uint8_t Get() override { return inner.Get(); }
+      std::size_t TryGet(uint8_t* dst, std::size_t n) override { return inner.TryGet(dst, n); }
     };
     return std::make_unique<OwnedMemReader>(std::move(data));
   }
 
-  std::unique_ptr<io::Writer> tryToWriter() {
+  std::unique_ptr<io::Writer> TryToWriter() {
     return nullptr;  // We don't want to write to .zip files
   }
 };
 
 struct FsNodeFilesystem : FsNodeImp {
-  FsNodeFilesystem(std::string const& pathInit) : path(pathInit) {
+  FsNodeFilesystem(std::string const& path_init) : path(path_init) {
     if (path.empty()) path.assign(".");
   }
 
-  std::string const& fullPath() { return path; }
+  std::string const& FullPath() { return path; }
 
-  DirectoryListing iter() { return DirectoryListing(path); }
+  DirectoryListing Iter() { return DirectoryListing(path); }
 
-  std::shared_ptr<FsNodeImp> go(std::string const& name) {
-    std::string fullPath(joinPath(path, name));
+  std::shared_ptr<FsNodeImp> Go(std::string const& name) {
+    std::string full_path(JoinPath(path, name));
     std::shared_ptr<FsNodeImp> imp;
 
     // struct stat st;
@@ -496,35 +496,35 @@ struct FsNodeFilesystem : FsNodeImp {
       // if ((st.st_mode & S_IFMT) == S_IFDIR)
       //	dir = true;
 
-      imp.reset(new FsNodeFilesystem(fullPath));
+      imp.reset(new FsNodeFilesystem(full_path));
     }
 
-    std::string zipPath(fullPath + ".zip");
+    std::string zip_path(full_path + ".zip");
 
-    if (access(zipPath.c_str(), 0) != -1) {
+    if (access(zip_path.c_str(), 0) != -1) {
       // We have a zip file, merge nodes
-      imp = join(std::move(imp), std::shared_ptr<FsNodeImp>(new FsNodeZipFile(zipPath, true)));
-    } else if (access(fullPath.c_str(), 0) != -1 && endsWith(fullPath, ".zip")) {
-      imp = join(std::move(imp), std::shared_ptr<FsNodeImp>(new FsNodeZipFile(fullPath, true)));
+      imp = Join(std::move(imp), std::shared_ptr<FsNodeImp>(new FsNodeZipFile(zip_path, true)));
+    } else if (access(full_path.c_str(), 0) != -1 && EndsWith(full_path, ".zip")) {
+      imp = Join(std::move(imp), std::shared_ptr<FsNodeImp>(new FsNodeZipFile(full_path, true)));
     }
 
     return imp;
   }
 
-  bool exists() const { return access(path.c_str(), 0) != -1; }
+  bool Exists() const { return access(path.c_str(), 0) != -1; }
 
-  std::unique_ptr<io::Reader> tryToReader() {
-    FILE* f = tolerantFOpen(path.c_str(), "rb");
+  std::unique_ptr<io::Reader> TryToReader() {
+    FILE* f = TolerantFOpen(path.c_str(), "rb");
     if (!f) return nullptr;
 
     return std::make_unique<io::FileReader>(f, io::FileReader::OwnFile{});
   }
 
-  std::unique_ptr<io::Writer> tryToWriter() {
+  std::unique_ptr<io::Writer> TryToWriter() {
     FILE* f = fopen(path.c_str(), "wb");
     if (!f) {
       // Try to create directories
-      create_directories(path);
+      CreateDirectories(path);
       f = fopen(path.c_str(), "wb");
       if (!f) return nullptr;
     }
@@ -551,7 +551,7 @@ FsNode::FsNode(std::string const& path) {
   std::size_t beg = 0, i = 0;
 
   for (; i < path.size(); ++i) {
-    if (isDirSep(path[i])) {
+    if (IsDirSep(path[i])) {
       std::string const& part = path.substr(beg, i - beg);
       if (!imp) {
 #if _WIN32
@@ -566,11 +566,11 @@ FsNode::FsNode(std::string const& path) {
           imp.reset(new FsNodeFilesystem("/"));
         else {
           imp.reset(new FsNodeFilesystem("."));
-          imp = imp->go(part);
+          imp = imp->Go(part);
         }
 #endif
       } else {
-        imp = imp->go(part);
+        imp = imp->Go(part);
       }
 
       beg = i + 1;
@@ -593,23 +593,23 @@ FsNode::FsNode(std::string const& path) {
         imp.reset(new FsNodeFilesystem(part));
       else {
         imp.reset(new FsNodeFilesystem("."));
-        imp = imp->go(part);
+        imp = imp->Go(part);
       }
 #endif
     } else {
-      imp = imp->go(part);
+      imp = imp->Go(part);
     }
   }
 }
 
 namespace paths {
 
-FsNode userDataRoot() {
+FsNode UserDataRoot() {
   // Test-only override. Not documented for end users — production paths
   // should go through --config-root or portable.txt instead.
   if (const char* env = std::getenv("OPENLIERO_TEST_USER_DIR")) {
     if (env[0] != '\0') {
-      create_directories(env);
+      CreateDirectories(env);
       return FsNode(std::string(env));
     }
   }
@@ -619,32 +619,32 @@ FsNode userDataRoot() {
   std::string path(p);
   SDL_free(p);
 
-  create_directories(path);
+  CreateDirectories(path);
 
   return FsNode(path);
 }
 
-FsNode systemDataRoot() {
+FsNode SystemDataRoot() {
   // Runtime override: respected by Flatpak builds, packagers who can't
   // recompile, and the test suite.
   if (const char* env = std::getenv("OPENLIERO_DATADIR")) {
     if (env[0] != '\0') {
       FsNode candidate{std::string(env)};
-      if (candidate.exists()) return candidate;
+      if (candidate.Exists()) return candidate;
     }
   }
 
 #ifdef OPENLIERO_DATADIR
   {
     FsNode candidate{std::string(OPENLIERO_DATADIR)};
-    if (candidate.exists()) return candidate;
+    if (candidate.Exists()) return candidate;
   }
 #endif
 
   // SDL3: SDL_GetBasePath returns a const char* owned by SDL; do NOT free.
   if (const char* base = SDL_GetBasePath()) {
     FsNode candidate{std::string(base)};
-    if (candidate.exists()) return candidate;
+    if (candidate.Exists()) return candidate;
   }
 
   return FsNode();
@@ -655,7 +655,7 @@ FsNode systemDataRoot() {
 // reports cloud-sync placeholders as present even after the user has
 // deleted the file in Explorer — leaving anyone with a sync-backed
 // extraction folder permanently stuck in portable mode.
-static bool portableMarkerPresent(std::string const& path) {
+static bool PortableMarkerPresent(std::string const& path) {
 #if _WIN32
   DWORD attr = GetFileAttributesA(path.c_str());
   if (attr == INVALID_FILE_ATTRIBUTES) return false;
@@ -671,7 +671,7 @@ static bool portableMarkerPresent(std::string const& path) {
 #endif
 }
 
-bool shadowsSystem(FsNode const& userRoot, std::string const& subdir, std::string const& leaf) {
+bool ShadowsSystem(FsNode const& user_root, std::string const& subdir, std::string const& leaf) {
   // Auto-managed filenames the game writes itself. Picking these in a
   // Save As dialog would clobber the game's own auto-write target or
   // shadow the shipped default unreachably.
@@ -679,34 +679,34 @@ bool shadowsSystem(FsNode const& userRoot, std::string const& subdir, std::strin
       {"Setups", "liero.cfg"},
   };
   for (auto const& r : kReserved) {
-    if (subdir == r[0] && ciCompare(leaf, r[1])) return true;
+    if (subdir == r[0] && CiCompare(leaf, r[1])) return true;
   }
 
-  FsNode sys = systemDataRoot();
+  FsNode sys = SystemDataRoot();
   if (!sys.imp) return false;
 
   // Single-dir layouts (portable.txt / --config-root pointing at the
   // install dir): user writes go to the same directory the system
   // data is read from. There's no separate layer to shadow, and the
   // user must be able to overwrite their own files.
-  if (userRoot.imp && userRoot.imp->fullPath() == sys.imp->fullPath()) return false;
+  if (user_root.imp && user_root.imp->FullPath() == sys.imp->FullPath()) return false;
 
-  return (sys / subdir / leaf).exists();
+  return (sys / subdir / leaf).Exists();
 }
 
 // Safe to call before SDL_Init: SDL3's SDL_GetPrefPath/SDL_GetBasePath
 // do not require subsystem initialization.
-ResolvedPaths resolve(int argc, char* argv[], std::string const& basePath) {
+ResolvedPaths Resolve(int argc, char* argv[], std::string const& base_path) {
   ResolvedPaths r;
   r.port = 0;
 
-  std::string configRoot;
+  std::string config_root;
 
   // Matches "--<name>" or "--<name>=value". Returns the value (after '=' or
   // the next argv) and advances `i` past it. Refuses to consume the next
   // argv as a value if it looks like another flag, so a typo like
   // "--config-root --port 1234" doesn't silently set configRoot="--port".
-  auto matchOpt = [&](int& i, char const* name, std::string* out) -> bool {
+  auto match_opt = [&](int& i, char const* name, std::string* out) -> bool {
     char const* arg = argv[i] + 2;
     std::size_t nlen = std::strlen(name);
     if (std::strncmp(arg, name, nlen) != 0) return false;
@@ -724,44 +724,44 @@ ResolvedPaths resolve(int argc, char* argv[], std::string const& basePath) {
   for (int i = 1; i < argc; ++i) {
     if (argv[i][0] == '-' && argv[i][1] == '-') {
       std::string value;
-      if (matchOpt(i, "config-root", &value))
-        configRoot = std::move(value);
-      else if (matchOpt(i, "port", &value))
+      if (match_opt(i, "config-root", &value))
+        config_root = std::move(value);
+      else if (match_opt(i, "port", &value))
         r.port = static_cast<uint16_t>(std::atoi(value.c_str()));
     } else if (argv[i][0] != '-') {
-      r.positionalArgs.emplace_back(argv[i]);
+      r.positional_args.emplace_back(argv[i]);
     }
   }
 
-  if (!configRoot.empty()) {
+  if (!config_root.empty()) {
     // Explicit single-directory override (Emscripten, CI, power users).
-    r.configNode = FsNode(configRoot);
-    r.userConfigNode = FsNode(configRoot);
+    r.config_node = FsNode(config_root);
+    r.user_config_node = FsNode(config_root);
     return r;
   }
 
   // Determine basePath: caller-supplied (tests) or SDL_GetBasePath().
-  std::string base = basePath;
+  std::string base = base_path;
   if (base.empty()) {
     if (const char* p = SDL_GetBasePath()) base = p;
   }
 
   // portable.txt next to the binary selects single-directory mode.
-  if (!base.empty() && portableMarkerPresent((FsNode(base) / "portable.txt").fullPath())) {
-    r.configNode = FsNode(base);
-    r.userConfigNode = FsNode(base);
+  if (!base.empty() && PortableMarkerPresent((FsNode(base) / "portable.txt").FullPath())) {
+    r.config_node = FsNode(base);
+    r.user_config_node = FsNode(base);
     return r;
   }
 
   // XDG split: user dir for writes; merged (user + system) for reads.
-  FsNode user = userDataRoot();
-  FsNode system = systemDataRoot();
+  FsNode user = UserDataRoot();
+  FsNode system = SystemDataRoot();
 
-  r.userConfigNode = user;
+  r.user_config_node = user;
   if (system.imp)
-    r.configNode = FsNode(join(user.imp, system.imp));
+    r.config_node = FsNode(Join(user.imp, system.imp));
   else
-    r.configNode = user;
+    r.config_node = user;
 
   return r;
 }

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -129,8 +129,13 @@ struct FilenameResult {
 #define BOOST_INVALID_HANDLE_VALUE 0
 #define BOOST_SYSTEM_DIRECTORY_TYPE struct dirent*
 
-inline FilenameResult FindFirstFile(const char* dir, BOOST_HANDLE& handle,
-                                    BOOST_SYSTEM_DIRECTORY_TYPE&)
+// DirIter{Open,Close,Next} wrap the POSIX/Win32 directory iteration APIs
+// behind a uniform interface. Local names are deliberately distinct from
+// the Windows FindFirstFile/FindNextFile/FindClose macros (which the
+// Windows headers #define to the A/W variants) to avoid preprocessor
+// substitution inside our own definitions.
+inline FilenameResult DirIterOpen(const char* dir, BOOST_HANDLE& handle,
+                                  BOOST_SYSTEM_DIRECTORY_TYPE&)
 // Returns: 0 if error, otherwise name
 {
   const char* dummy_first_name = ".";
@@ -139,12 +144,12 @@ inline FilenameResult FindFirstFile(const char* dir, BOOST_HANDLE& handle,
              : FilenameResult(dummy_first_name);
 }
 
-inline void FindClose(BOOST_HANDLE handle) {
+inline void DirIterClose(BOOST_HANDLE handle) {
   assert(handle != BOOST_INVALID_HANDLE_VALUE);
   ::closedir(handle);
 }
 
-inline FilenameResult FindNextFile(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE&)
+inline FilenameResult DirIterNext(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE&)
 // Returns: if EOF 0, otherwise name
 // Throws: if system reports error
 {
@@ -168,38 +173,31 @@ inline FilenameResult FindNextFile(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_T
 #define BOOST_INVALID_HANDLE_VALUE INVALID_HANDLE_VALUE
 #define BOOST_SYSTEM_DIRECTORY_TYPE WIN32_FIND_DATAA
 
-inline filename_result find_first_file(const char* dir, BOOST_HANDLE& handle,
-                                       BOOST_SYSTEM_DIRECTORY_TYPE& data)
-// Returns: 0 if error, otherwise name
-{
-  //    std::cout << "find_first_file " << dir << std::endl;
+inline FilenameResult DirIterOpen(const char* dir, BOOST_HANDLE& handle,
+                                  BOOST_SYSTEM_DIRECTORY_TYPE& data) {
   std::string dirpath(std::string(dir) + "/*");
   bool fail = ((handle = ::FindFirstFileA(dirpath.c_str(), &data)) == BOOST_INVALID_HANDLE_VALUE);
 
-  if (fail) return filename_result();
+  if (fail) return FilenameResult();
 
-  return filename_result(data.cFileName);
+  return FilenameResult(data.cFileName);
 }
 
-inline void find_close(BOOST_HANDLE handle) {
-  //    std::cout << "find_close" << std::endl;
+inline void DirIterClose(BOOST_HANDLE handle) {
   assert(handle != BOOST_INVALID_HANDLE_VALUE);
   ::FindClose(handle);
 }
 
-inline filename_result find_next_file(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE& data)
-// Returns: 0 if EOF, otherwise name
-// Throws: if system reports error
-{
+inline FilenameResult DirIterNext(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTORY_TYPE& data) {
   if (::FindNextFileA(handle, &data) == 0) {
     if (::GetLastError() != ERROR_NO_MORE_FILES) {
       throw std::runtime_error("Error iterating directory");
     } else {
-      return filename_result();
-    }  // end reached
+      return FilenameResult();
+    }
   }
 
-  return filename_result(data.cFileName);
+  return FilenameResult(data.cFileName);
 }
 
 #else
@@ -211,13 +209,13 @@ inline filename_result find_next_file(BOOST_HANDLE handle, BOOST_SYSTEM_DIRECTOR
 
 #if _WIN32
 
-inline char isDirSep(char c) { return c == '\\' || c == '/'; }
+inline char IsDirSep(char c) { return c == '\\' || c == '/'; }
 
-static char const dirSep = '\\';
+static char const kDirSep = '\\';
 
-bool create_directories(std::string const& dir) {
+bool CreateDirectories(std::string const& dir) {
   for (std::size_t i = 0; i < dir.size(); ++i) {
-    if (isDirSep(dir[i])) {
+    if (IsDirSep(dir[i])) {
       std::string path = dir.substr(0, i);
       DWORD attr = GetFileAttributesA(path.c_str());
 
@@ -281,7 +279,7 @@ DirectoryListing::DirectoryListing(std::string const& dir) {
   if (!dir_path[0])
     handle = BOOST_INVALID_HANDLE_VALUE;
   else
-    name = FindFirstFile(dir_path, handle, scratch);  // sets handle
+    name = DirIterOpen(dir_path, handle, scratch);  // sets handle
 
   if (handle != BOOST_INVALID_HANDLE_VALUE) {
     do {
@@ -297,9 +295,9 @@ DirectoryListing::DirectoryListing(std::string const& dir) {
           }
         }
       }
-    } while ((name = FindNextFile(handle, scratch)));
+    } while ((name = DirIterNext(handle, scratch)));
 
-    FindClose(handle);
+    DirIterClose(handle);
   }
 
   Sort();
@@ -559,7 +557,7 @@ FsNode::FsNode(std::string const& path) {
           imp.reset(new FsNodeFilesystem(part));
         else {
           imp.reset(new FsNodeFilesystem("."));
-          imp = imp->go(part);
+          imp = imp->Go(part);
         }
 #else
         if (part.empty())
@@ -586,7 +584,7 @@ FsNode::FsNode(std::string const& path) {
         imp.reset(new FsNodeFilesystem(part));
       else {
         imp.reset(new FsNodeFilesystem("."));
-        imp = imp->go(part);
+        imp = imp->Go(part);
       }
 #else
       if (path.empty())

--- a/src/game/filesystem.hpp
+++ b/src/game/filesystem.hpp
@@ -23,7 +23,8 @@ std::size_t FileLength(FILE* f);
 bool CreateDirectories(std::string const& dir);
 
 struct NodeName {
-  NodeName(std::string name_init, bool is_dir_init) : name(std::move(name_init)), is_dir(is_dir_init) {}
+  NodeName(std::string name_init, bool is_dir_init)
+      : name(std::move(name_init)), is_dir(is_dir_init) {}
 
   std::string name;
   bool is_dir;
@@ -139,8 +140,8 @@ bool ShadowsSystem(FsNode const& user_root, std::string const& subdir, std::stri
 
 struct ResolvedPaths {
   FsNode config_node;                        // merged (user + system) for reads
-  FsNode user_config_node;                    // user dir only, for writes
-  uint16_t port;                            // from --port, 0 if not given
+  FsNode user_config_node;                   // user dir only, for writes
+  uint16_t port;                             // from --port, 0 if not given
   std::vector<std::string> positional_args;  // non-flag argv entries
 };
 

--- a/src/game/filesystem.hpp
+++ b/src/game/filesystem.hpp
@@ -9,24 +9,24 @@
 
 #include "io/stream.hpp"
 
-std::string changeLeaf(std::string const& path, std::string const& newLeaf);
-std::string getRoot(std::string const& path);
-std::string getLeaf(std::string const& path);
-std::string getBasename(std::string const& path);
-std::string getExtension(std::string const& path);
-std::string toUpperCase(std::string str);
-std::string joinPath(std::string const& root, std::string const& leaf);
+std::string ChangeLeaf(std::string const& path, std::string const& new_leaf);
+std::string GetRoot(std::string const& path);
+std::string GetLeaf(std::string const& path);
+std::string GetBasename(std::string const& path);
+std::string GetExtension(std::string const& path);
+std::string ToUpperCase(std::string str);
+std::string JoinPath(std::string const& root, std::string const& leaf);
 
-FILE* tolerantFOpen(std::string const& name, char const* mode);
+FILE* TolerantFOpen(std::string const& name, char const* mode);
 
-std::size_t fileLength(FILE* f);
-bool create_directories(std::string const& dir);
+std::size_t FileLength(FILE* f);
+bool CreateDirectories(std::string const& dir);
 
 struct NodeName {
-  NodeName(std::string nameInit, bool isDirInit) : name(std::move(nameInit)), isDir(isDirInit) {}
+  NodeName(std::string name_init, bool is_dir_init) : name(std::move(name_init)), is_dir(is_dir_init) {}
 
   std::string name;
-  bool isDir;
+  bool is_dir;
 };
 
 struct DirectoryListing {
@@ -40,32 +40,37 @@ struct DirectoryListing {
   }
 
   DirectoryListing(std::string const& dir);
-  DirectoryListing(std::vector<NodeName>&& subsInit);
+  DirectoryListing(std::vector<NodeName>&& subs_init);
   ~DirectoryListing();
 
   DirectoryListing operator|(DirectoryListing const& other) {
     DirectoryListing ret(std::move(subs));
 
     ret.subs.insert(ret.subs.end(), other.subs.begin(), other.subs.end());
-    ret.sort();
+    ret.Sort();
     return ret;
   }
 
+  // Range-for support: range-for looks up `begin`/`end` via ADL or as
+  // members, so these must stay lower_case. NOLINT keeps the
+  // identifier-naming check from renaming them on future tidy passes.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   std::vector<NodeName>::iterator begin() { return subs.begin(); }
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   std::vector<NodeName>::iterator end() { return subs.end(); }
 
-  void sort();
+  void Sort();
 };
 
 struct FsNodeImp {
   virtual ~FsNodeImp() = default;
-  virtual std::string const& fullPath() = 0;
-  virtual DirectoryListing iter() = 0;
-  virtual std::shared_ptr<FsNodeImp> go(std::string const& name) = 0;
-  virtual std::unique_ptr<io::Reader> tryToReader() = 0;
-  virtual std::unique_ptr<io::Writer> tryToWriter() = 0;
-  virtual bool exists() const = 0;
+  virtual std::string const& FullPath() = 0;
+  virtual DirectoryListing Iter() = 0;
+  virtual std::shared_ptr<FsNodeImp> Go(std::string const& name) = 0;
+  virtual std::unique_ptr<io::Reader> TryToReader() = 0;
+  virtual std::unique_ptr<io::Writer> TryToWriter() = 0;
+  virtual bool Exists() const = 0;
 };
 
 struct FsNode {
@@ -89,23 +94,23 @@ struct FsNode {
 
   operator void*() const { return imp.get(); }
 
-  std::string const& fullPath() const { return imp->fullPath(); }
+  std::string const& FullPath() const { return imp->FullPath(); }
 
-  DirectoryListing iter() const { return imp->iter(); }
+  DirectoryListing Iter() const { return imp->Iter(); }
 
-  FsNode operator/(std::string const& name) const { return FsNode(imp->go(name)); }
+  FsNode operator/(std::string const& name) const { return FsNode(imp->Go(name)); }
 
-  bool exists() const { return imp && imp->exists(); }
+  bool Exists() const { return imp && imp->Exists(); }
 
-  std::unique_ptr<io::Reader> toReader() const {
-    auto r = imp->tryToReader();
-    if (!r) throw std::runtime_error("Could not read " + fullPath());
+  std::unique_ptr<io::Reader> ToReader() const {
+    auto r = imp->TryToReader();
+    if (!r) throw std::runtime_error("Could not read " + FullPath());
     return r;
   }
 
-  std::unique_ptr<io::Writer> toWriter() const {
-    auto w = imp->tryToWriter();
-    if (!w) throw std::runtime_error("Could not write " + fullPath());
+  std::unique_ptr<io::Writer> ToWriter() const {
+    auto w = imp->TryToWriter();
+    if (!w) throw std::runtime_error("Could not write " + FullPath());
     return w;
   }
 };
@@ -113,13 +118,13 @@ struct FsNode {
 namespace paths {
 // Writable user data root. Always returns a non-empty node whose
 // directory has been created on disk. Backed by SDL_GetPrefPath.
-FsNode userDataRoot();
+FsNode UserDataRoot();
 
 // Read-only stock data root. Resolution order:
 //   1. OPENLIERO_DATADIR compile-time macro, if defined and existing.
 //   2. SDL_GetBasePath() (binary-adjacent), if it has stock content.
 // Returns an empty FsNode (!exists()) if neither resolves.
-FsNode systemDataRoot();
+FsNode SystemDataRoot();
 
 // True if Save As of `leaf` into `subdir` of the user dir would
 // shadow either a shipped file or one of the auto-managed names
@@ -129,14 +134,14 @@ FsNode systemDataRoot();
 // mode, `--config-root` aimed at the install dir) there is no
 // separate read-only layer to shadow and the user can freely
 // overwrite their own files, so the on-disk check is skipped.
-bool shadowsSystem(FsNode const& userRoot, std::string const& subdir, std::string const& leaf);
+bool ShadowsSystem(FsNode const& user_root, std::string const& subdir, std::string const& leaf);
 }  // namespace paths
 
 struct ResolvedPaths {
-  FsNode configNode;                        // merged (user + system) for reads
-  FsNode userConfigNode;                    // user dir only, for writes
+  FsNode config_node;                        // merged (user + system) for reads
+  FsNode user_config_node;                    // user dir only, for writes
   uint16_t port;                            // from --port, 0 if not given
-  std::vector<std::string> positionalArgs;  // non-flag argv entries
+  std::vector<std::string> positional_args;  // non-flag argv entries
 };
 
 namespace paths {
@@ -147,5 +152,5 @@ namespace paths {
 //   otherwise          -> configNode = join(user, system); userConfigNode = user
 //
 // basePath overrides SDL_GetBasePath() and is used by tests.
-ResolvedPaths resolve(int argc, char* argv[], std::string const& basePath = std::string());
+ResolvedPaths Resolve(int argc, char* argv[], std::string const& base_path = std::string());
 }  // namespace paths

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -18,56 +18,56 @@
 #include <cereal/archives/portable_binary.hpp>
 #include <sstream>
 
-Game::Game(std::shared_ptr<Common> common, std::shared_ptr<Settings> settingsInit,
-           std::shared_ptr<SoundPlayer> soundPlayer)
+Game::Game(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings_init,
+           std::shared_ptr<SoundPlayer> sound_player)
     : common(common),
-      soundPlayer(soundPlayer),
-      prevSoundPlayer(g_soundPlayer),
-      soundPlayerInstalled(true),
-      settings(settingsInit),
-      statsRecorder(new NormalStatsRecorder),
+      sound_player(sound_player),
+      prev_sound_player(g_sound_player),
+      sound_player_installed(true),
+      settings(settings_init),
+      stats_recorder(new NormalStatsRecorder),
       level(*common),
-      screenFlash(0),
-      gotChanged(false),
-      lastKilledIdx(-1),
+      screen_flash(0),
+      got_changed(false),
+      last_killed_idx(-1),
       paused(true),
-      quickSim(false) {
-  g_soundPlayer = soundPlayer.get();
+      quick_sim(false) {
+  g_sound_player = sound_player.get();
 
-  rand.seed(uint32_t(std::time(0)));
+  rand.Seed(uint32_t(std::time(0)));
 
   cycles = 0;
 }
 
 Game::~Game() {
-  clearViewports();
-  clearWorms();
-  if (soundPlayerInstalled && g_soundPlayer == soundPlayer.get()) g_soundPlayer = prevSoundPlayer;
+  ClearViewports();
+  ClearWorms();
+  if (sound_player_installed && g_sound_player == sound_player.get()) g_sound_player = prev_sound_player;
 }
 
-void Game::onKey(uint32_t key, bool state) {
+void Game::OnKey(uint32_t key, bool state) {
   for (std::size_t i = 0; i < worms.size(); ++i) {
     Worm& w = *worms[i];
 
     // Only check keyboard controls for players using keyboard input
-    if (w.settings->inputDevice != WormSettingsExtensions::InputKeyboard) continue;
+    if (w.settings->input_device != WormSettingsExtensions::kInputKeyboard) continue;
 
-    for (std::size_t control = 0; control < WormSettings::MaxControl; ++control) {
+    for (std::size_t control = 0; control < WormSettings::kMaxControl; ++control) {
       if (w.settings->controls[control] == key) {
-        w.setControlState(static_cast<Worm::Control>(control), state);
+        w.SetControlState(static_cast<Worm::Control>(control), state);
       }
     }
   }
 }
 
-Worm* Game::findControlForKey(uint32_t key, Worm::Control& control) {
+Worm* Game::FindControlForKey(uint32_t key, Worm::Control& control) {
   // Gamepad control keys encode the player index and control directly
-  if (isGamepadControlKey(key)) {
-    int playerIdx = (key - GamepadControlKeysStart) / 8;
-    int c = (key - GamepadControlKeysStart) % 8;
-    if (playerIdx >= 0 && playerIdx < (int)worms.size()) {
+  if (IsGamepadControlKey(key)) {
+    int player_idx = (key - kGamepadControlKeysStart) / 8;
+    int c = (key - kGamepadControlKeysStart) % 8;
+    if (player_idx >= 0 && player_idx < (int)worms.size()) {
       control = static_cast<Worm::Control>(c);
-      return worms[playerIdx].get();
+      return worms[player_idx].get();
     }
     return 0;
   }
@@ -76,12 +76,12 @@ Worm* Game::findControlForKey(uint32_t key, Worm::Control& control) {
     Worm& w = *worms[i];
 
     // Only check keyboard bindings for players using keyboard
-    if (w.settings->inputDevice != WormSettingsExtensions::InputKeyboard) continue;
+    if (w.settings->input_device != WormSettingsExtensions::kInputKeyboard) continue;
 
-    uint32_t* controls = settings->extensions ? w.settings->controlsEx : w.settings->controls;
-    std::size_t maxControl =
-        settings->extensions ? WormSettings::MaxControlEx : WormSettings::MaxControl;
-    for (std::size_t c = 0; c < maxControl; ++c) {
+    uint32_t* controls = settings->kExtensions ? w.settings->controls_ex : w.settings->controls;
+    std::size_t max_control =
+        settings->kExtensions ? WormSettings::kMaxControlEx : WormSettings::kMaxControl;
+    for (std::size_t c = 0; c < max_control; ++c) {
       if (controls[c] == key) {
         control = static_cast<Worm::Control>(c);
         return &w;
@@ -92,71 +92,71 @@ Worm* Game::findControlForKey(uint32_t key, Worm::Control& control) {
   return 0;
 }
 
-void Game::releaseControls() {
+void Game::ReleaseControls() {
   for (std::size_t i = 0; i < worms.size(); ++i) {
     Worm& w = *worms[i];
 
-    for (std::size_t control = 0; control < WormSettings::MaxControl; ++control) {
-      w.release(static_cast<Worm::Control>(control));
+    for (std::size_t control = 0; control < WormSettings::kMaxControl; ++control) {
+      w.Release(static_cast<Worm::Control>(control));
     }
   }
 }
 
-void Game::clearViewports() {
+void Game::ClearViewports() {
   viewports.clear();
-  spectatorViewports.clear();
+  spectator_viewports.clear();
 }
 
-void Game::addViewport(Viewport* vp) {
+void Game::AddViewport(Viewport* vp) {
   // vp->worm->viewport = vp;
   viewports.push_back(vp);
 }
 
-void Game::addSpectatorViewport(SpectatorViewport* vp) { spectatorViewports.push_back(vp); }
+void Game::AddSpectatorViewport(SpectatorViewport* vp) { spectator_viewports.push_back(vp); }
 
-void Game::processViewports() {
+void Game::ProcessViewports() {
   for (std::size_t i = 0; i < viewports.size(); ++i) {
-    viewports[i]->process(*this);
+    viewports[i]->Process(*this);
   }
-  for (std::size_t i = 0; i < spectatorViewports.size(); ++i) {
-    spectatorViewports[i]->process(*this);
+  for (std::size_t i = 0; i < spectator_viewports.size(); ++i) {
+    spectator_viewports[i]->Process(*this);
   }
 }
 
-void Game::drawViewports(Renderer& renderer, GameState state, bool isReplay) {
+void Game::DrawViewports(Renderer& renderer, GameState state, bool is_replay) {
   for (std::size_t i = 0; i < viewports.size(); ++i) {
-    viewports[i]->draw(*this, renderer, state, isReplay);
+    viewports[i]->Draw(*this, renderer, state, is_replay);
   }
 }
 
-void Game::drawSpectatorViewports(Renderer& renderer, GameState state, bool isReplay) {
-  for (std::size_t i = 0; i < spectatorViewports.size(); ++i) {
-    spectatorViewports[i]->draw(*this, renderer, state, isReplay);
+void Game::DrawSpectatorViewports(Renderer& renderer, GameState state, bool is_replay) {
+  for (std::size_t i = 0; i < spectator_viewports.size(); ++i) {
+    spectator_viewports[i]->Draw(*this, renderer, state, is_replay);
   }
 }
 
-void Game::clearWorms() { worms.clear(); }
+void Game::ClearWorms() { worms.clear(); }
 
-void Game::resetWorms() {
+void Game::ResetWorms() {
   for (std::size_t i = 0; i < worms.size(); ++i) {
     Worm& w = *worms[i];
     w.health = w.settings->health;
     w.lives = settings->lives;  // Not in the original!
     w.kills = 0;
     w.visible = false;
-    w.killedTimer = Worm::KilledTimerInitial;
+    w.killed_timer = Worm::kKilledTimerInitial;
 
-    w.currentWeapon = 0;
+    w.current_weapon = 0;
   }
 }
 
-void Game::addWorm(std::shared_ptr<Worm> worm) { worms.push_back(std::move(worm)); }
+void Game::AddWorm(std::shared_ptr<Worm> worm) { worms.push_back(std::move(worm)); }
 
-void Game::draw(Renderer& renderer, GameState state, bool useSpectatorViewports, bool isReplay) {
-  if (useSpectatorViewports) {
-    drawSpectatorViewports(renderer, state, isReplay);
+void Game::Draw(Renderer& renderer, GameState state, bool use_spectator_viewports, bool is_replay) {
+  if (use_spectator_viewports) {
+    DrawSpectatorViewports(renderer, state, is_replay);
   } else {
-    drawViewports(renderer, state, isReplay);
+    DrawViewports(renderer, state, is_replay);
   }
 
   // common->font.drawText(toString(cycles / 70), 10, 10, 7);
@@ -164,92 +164,92 @@ void Game::draw(Renderer& renderer, GameState state, bool useSpectatorViewports,
   renderer.pal = renderer.origpal;
 
   for (int w = 0; w < 4; ++w)
-    renderer.pal.rotateFrom(renderer.origpal, common->colorAnim[w].from, common->colorAnim[w].to,
+    renderer.pal.RotateFrom(renderer.origpal, common->color_anim[w].from, common->color_anim[w].to,
                             cycles >> 3);
 
-  renderer.pal.fade(renderer.fadeValue);
+  renderer.pal.Fade(renderer.fade_value);
 
-  if (screenFlash > 0) {
-    renderer.pal.lightUp(screenFlash);
+  if (screen_flash > 0) {
+    renderer.pal.LightUp(screen_flash);
   }
 }
 
-bool checkBonusSpawnPosition(Game& game, int x, int y) {
+bool CheckBonusSpawnPosition(Game& game, int x, int y) {
   Rect rect(x - 2, y - 2, x + 3, y + 3);
 
-  rect.intersect(game.level.rect());
+  rect.Intersect(game.level.Bounds());
 
   for (int cx = rect.x1; cx < rect.x2; ++cx)
     for (int cy = rect.y1; cy < rect.y2; ++cy) {
-      if (game.level.mat(cx, cy).dirtRock()) return false;
+      if (game.level.Mat(cx, cy).DirtRock()) return false;
     }
 
   return true;
 }
 
-void Game::createBonus() {
+void Game::CreateBonus() {
   Common& common = *this->common;
 
-  if (int(bonuses.size()) >= settings->maxBonuses) return;
+  if (int(bonuses.Size()) >= settings->max_bonuses) return;
 
   for (std::size_t i = 0; i < 50000; ++i) {
     int ix = rand(LC(BonusSpawnRectW));
     int iy = rand(LC(BonusSpawnRectH));
 
-    if (common.H[HBonusSpawnRect]) {
+    if (common.h[HBonusSpawnRect]) {
       ix += LC(BonusSpawnRectX);
       iy += LC(BonusSpawnRectY);
     }
 
-    if (checkBonusSpawnPosition(*this, ix, iy)) {
+    if (CheckBonusSpawnPosition(*this, ix, iy)) {
       int frame;
 
-      if (common.H[HBonusOnlyHealth])
+      if (common.h[HBonusOnlyHealth])
         frame = 1;
-      else if (common.H[HBonusOnlyWeapon])
+      else if (common.h[HBonusOnlyWeapon])
         frame = 0;
       else
         frame = rand(2);
 
-      Bonus* bonus = bonuses.newObject();
+      Bonus* bonus = bonuses.NewObject();
       if (!bonus) return;
 
-      bonus->x = itof(ix);
-      bonus->y = itof(iy);
-      bonus->velY = 0;
+      bonus->x = Itof(ix);
+      bonus->y = Itof(iy);
+      bonus->vel_y = 0;
       bonus->frame = frame;
-      bonus->timer = rand(common.bonusRandTimer[frame][1]) + common.bonusRandTimer[frame][0];
+      bonus->timer = rand(common.bonus_rand_timer[frame][1]) + common.bonus_rand_timer[frame][0];
       bonus->weapon = 0;
 
       if (frame == 0) {
         do {
           bonus->weapon = rand((uint32_t)common.weapons.size());
-        } while (settings->weapTable[bonus->weapon] == 2);
+        } while (settings->weap_table[bonus->weapon] == 2);
       }
 
-      common.sobjectTypes[7].create(*this, ix, iy, 0, 0);
+      common.sobject_types[7].Create(*this, ix, iy, 0, 0);
       return;
     }
   }  // 234F
 }
 
-void Game::processFrame() {
-  statsRecorder->preTick(*this);
+void Game::ProcessFrame() {
+  stats_recorder->PreTick(*this);
 
-  if (screenFlash > 0) --screenFlash;
+  if (screen_flash > 0) --screen_flash;
 
   for (std::size_t i = 0; i < viewports.size(); ++i) {
     if (viewports[i]->shake > 0) viewports[i]->shake -= 4000;  // TODO: Read 4000 from exe?
   }
 
-  for (std::size_t i = 0; i < spectatorViewports.size(); ++i) {
-    if (spectatorViewports[i]->shake > 0)
-      spectatorViewports[i]->shake -= 4000;  // TODO: Read 4000 from exe?
+  for (std::size_t i = 0; i < spectator_viewports.size(); ++i) {
+    if (spectator_viewports[i]->shake > 0)
+      spectator_viewports[i]->shake -= 4000;  // TODO: Read 4000 from exe?
   }
 
-  auto br = bonuses.all();
-  for (Bonus* i; (i = br.next());) {
-    i->process(*this);
+  auto br = bonuses.All();
+  for (Bonus* i; (i = br.Next());) {
+    i->Process(*this);
   }
 
   if ((cycles & 1) == 0) {
@@ -258,134 +258,134 @@ void Game::processFrame() {
 
       bool down = false;
 
-      if (wormByIdx(v.wormIdx)->killedTimer > 16) down = true;
+      if (WormByIdx(v.worm_idx)->killed_timer > 16) down = true;
 
       if (down) {
-        if (v.bannerY < 2) ++v.bannerY;
+        if (v.banner_y < 2) ++v.banner_y;
       } else {
-        if (v.bannerY > -8) --v.bannerY;
+        if (v.banner_y > -8) --v.banner_y;
       }
     }
     // FIXME duplicated code
-    for (std::size_t i = 0; i < spectatorViewports.size(); ++i) {
-      SpectatorViewport& v = *spectatorViewports[i];
+    for (std::size_t i = 0; i < spectator_viewports.size(); ++i) {
+      SpectatorViewport& v = *spectator_viewports[i];
 
       bool down = false;
 
-      if (wormByIdx(0)->killedTimer > 16 || wormByIdx(1)->killedTimer > 16) down = true;
+      if (WormByIdx(0)->killed_timer > 16 || WormByIdx(1)->killed_timer > 16) down = true;
 
       if (down) {
-        if (v.bannerY < 2) ++v.bannerY;
+        if (v.banner_y < 2) ++v.banner_y;
       } else {
-        if (v.bannerY > -8) --v.bannerY;
+        if (v.banner_y > -8) --v.banner_y;
       }
     }
   }
 
-  auto sr = sobjects.all();
-  for (SObject* i; (i = sr.next());) {
-    i->process(*this);
+  auto sr = sobjects.All();
+  for (SObject* i; (i = sr.Next());) {
+    i->Process(*this);
   }
 
-  auto wr = wobjects.all();
-  for (WObject* i; (i = wr.next());) {
-    i->process(*this);
+  auto wr = wobjects.All();
+  for (WObject* i; (i = wr.Next());) {
+    i->Process(*this);
   }
 
-  auto nr = nobjects.all();
-  for (NObject* i; (i = nr.next());) {
-    i->process(*this);
+  auto nr = nobjects.All();
+  for (NObject* i; (i = nr.Next());) {
+    i->Process(*this);
   }
 
-  for (BObjectList::iterator i = bobjects.begin(); i != bobjects.end();) {
-    if (i->process(*this))
+  for (BObjectList::Iterator i = bobjects.Begin(); i != bobjects.End();) {
+    if (i->Process(*this))
       ++i;
     else
-      bobjects.free(i);
+      bobjects.Free(i);
   }
 
   // NOTE: This was originally the beginning of the processing, but has been rotated down to
   // separate out the drawing
   ++cycles;
 
-  if (!common->H[HBonusDisable] && settings->maxBonuses > 0 &&
-      rand(common->C[CBonusDropChance]) == 0) {
-    createBonus();
+  if (!common->h[HBonusDisable] && settings->max_bonuses > 0 &&
+      rand(common->c[CBonusDropChance]) == 0) {
+    CreateBonus();
   }
 
   for (std::size_t i = 0; i < worms.size(); ++i) {
-    worms[i]->process(*this);
+    worms[i]->Process(*this);
   }
 
   for (std::size_t i = 0; i < worms.size(); ++i) {
-    worms[i]->ninjarope.process(*worms[i], *this);
+    worms[i]->ninjarope.Process(*worms[i], *this);
   }
 
-  switch (settings->gameMode) {
-    case Settings::GMGameOfTag: {
-      bool someInvisible = false;
+  switch (settings->game_mode) {
+    case Settings::kGmGameOfTag: {
+      bool some_invisible = false;
       for (std::size_t i = 0; i < worms.size(); ++i) {
         if (!worms[i]->visible) {
-          someInvisible = true;
+          some_invisible = true;
           break;
         }
       }
 
-      Worm* lastKilledBy = wormByIdx(lastKilledIdx);
+      Worm* last_killed_by = WormByIdx(last_killed_idx);
 
-      if (!someInvisible && lastKilledBy && (cycles % 70) == 0 &&
-          lastKilledBy->timer < settings->timeToLose) {
-        ++lastKilledBy->timer;
+      if (!some_invisible && last_killed_by && (cycles % 70) == 0 &&
+          last_killed_by->timer < settings->time_to_lose) {
+        ++last_killed_by->timer;
       }
     } break;
 
-    case Settings::GMHoldazone: {
-      int contenderIdx = -1;
+    case Settings::kGmHoldazone: {
+      int contender_idx = -1;
       int contenders = 0;
 
       for (auto const& w : worms) {
-        int x = ftoi(w->pos.x), y = ftoi(w->pos.y);
+        int x = Ftoi(w->pos.x), y = Ftoi(w->pos.y);
 
-        if (w->visible && holdazone.rect.inside(x, y)) {
-          contenderIdx = w->index;
+        if (w->visible && holdazone.rect.Inside(x, y)) {
+          contender_idx = w->index;
           ++contenders;
         }
       }
 
-      if (contenders == 0) contenderIdx = holdazone.holderIdx;
+      if (contenders == 0) contender_idx = holdazone.holder_idx;
 
       if (contenders <= 1) {
-        if (contenderIdx < 0 ||
-            (holdazone.contenderIdx != contenderIdx && holdazone.contenderFrames != 0)) {
-          if (holdazone.contenderFrames == 0 || --holdazone.contenderFrames == 0) {
-            holdazone.contenderIdx = contenderIdx;
-            holdazone.holderIdx = -1;
+        if (contender_idx < 0 ||
+            (holdazone.contender_idx != contender_idx && holdazone.contender_frames != 0)) {
+          if (holdazone.contender_frames == 0 || --holdazone.contender_frames == 0) {
+            holdazone.contender_idx = contender_idx;
+            holdazone.holder_idx = -1;
           }
         } else {
-          holdazone.contenderIdx = contenderIdx;
+          holdazone.contender_idx = contender_idx;
 
-          if (holdazone.contenderFrames < settings->zoneCaptureTime &&
-              ++holdazone.contenderFrames >= settings->zoneCaptureTime &&
-              holdazone.holderIdx != holdazone.contenderIdx) {
+          if (holdazone.contender_frames < settings->kZoneCaptureTime &&
+              ++holdazone.contender_frames >= settings->kZoneCaptureTime &&
+              holdazone.holder_idx != holdazone.contender_idx) {
             // New holder
 
-            int newTimeout = holdazone.timeoutLeft;
-            if (holdazone.contenderIdx >= 0)
-              newTimeout += settings->zoneTimeout * 70 / 4;
+            int new_timeout = holdazone.timeout_left;
+            if (holdazone.contender_idx >= 0)
+              new_timeout += settings->zone_timeout * 70 / 4;
             else
-              newTimeout += settings->zoneTimeout * 70 / 8;
+              new_timeout += settings->zone_timeout * 70 / 8;
 
-            holdazone.timeoutLeft = std::min(newTimeout, settings->zoneTimeout * 70);
+            holdazone.timeout_left = std::min(new_timeout, settings->zone_timeout * 70);
 
-            holdazone.holderIdx = holdazone.contenderIdx;
+            holdazone.holder_idx = holdazone.contender_idx;
           }
         }
       }
 
       bool dec = false;
 
-      if (holdazone.holderIdx >= 0) {
-        auto* holder = wormByIdx(holdazone.holderIdx);
+      if (holdazone.holder_idx >= 0) {
+        auto* holder = WormByIdx(holdazone.holder_idx);
 
         if ((cycles % 70) == 0) ++holder->timer;
 
@@ -395,95 +395,95 @@ void Game::processFrame() {
       }
 
       if (dec) {
-        if (--holdazone.timeoutLeft <= 0) {
-          spawnZone();
+        if (--holdazone.timeout_left <= 0) {
+          SpawnZone();
         }
       }
     } break;
   }
 
-  processViewports();
+  ProcessViewports();
 
   // Store old control states so we can see what changes (mainly for replays)
   for (std::size_t i = 0; i < worms.size(); ++i) {
-    worms[i]->prevControlStates = worms[i]->controlStates;
+    worms[i]->prev_control_states = worms[i]->control_states;
   }
 
-  statsRecorder->tick(*this);
+  stats_recorder->Tick(*this);
 }
 
-void Game::focus(Renderer& renderer) { updateSettings(renderer); }
+void Game::Focus(Renderer& renderer) { UpdateSettings(renderer); }
 
-void Game::updateSettings(Renderer& renderer) {
+void Game::UpdateSettings(Renderer& renderer) {
   renderer.origpal = level.origpal;  // Activate the Level palette
 
   for (std::size_t i = 0; i < worms.size(); ++i) {
     Worm& worm = *worms[i];
     if (worm.index >= 0 && worm.index < 2)
-      renderer.origpal.setWormColour(worm.index, *worm.settings);
+      renderer.origpal.SetWormColour(worm.index, *worm.settings);
   }
 }
 
-void Game::spawnZone() {
+void Game::SpawnZone() {
   IVec2 pos;
 
-  while (holdazone.zoneWidth >= 5) {
-    if (level.selectSpawn(rand, holdazone.zoneWidth, holdazone.zoneHeight - 8, pos)) {
+  while (holdazone.zone_width >= 5) {
+    if (level.SelectSpawn(rand, holdazone.zone_width, holdazone.zone_height - 8, pos)) {
       holdazone.rect.x1 = pos.x;
       holdazone.rect.y1 = pos.y;
-      holdazone.rect.x2 = pos.x + holdazone.zoneWidth;
-      holdazone.rect.y2 = pos.y + holdazone.zoneHeight;
-      holdazone.timeoutLeft = settings->zoneTimeout * 70;
-      holdazone.contenderIdx = -1;
-      holdazone.contenderFrames = 0;
-      holdazone.holderIdx = -1;
+      holdazone.rect.x2 = pos.x + holdazone.zone_width;
+      holdazone.rect.y2 = pos.y + holdazone.zone_height;
+      holdazone.timeout_left = settings->zone_timeout * 70;
+      holdazone.contender_idx = -1;
+      holdazone.contender_frames = 0;
+      holdazone.holder_idx = -1;
       break;
     }
 
-    holdazone.zoneWidth /= 2;
-    holdazone.zoneHeight /= 2;
+    holdazone.zone_width /= 2;
+    holdazone.zone_height /= 2;
   }
 }
 
-void Game::startGame() {
-  soundPlayer->play(common->soundHook[SoundBegin]);
-  bobjects.resize(settings->bloodParticleMax);
+void Game::StartGame() {
+  sound_player->Play(common->sound_hook[SoundBegin]);
+  bobjects.Resize(settings->blood_particle_max);
 
-  if (settings->gameMode == Settings::GMHoldazone) {
-    spawnZone();
+  if (settings->game_mode == Settings::kGmHoldazone) {
+    SpawnZone();
   }
 }
 
-bool Game::isGameOver() {
-  if (settings->gameMode == Settings::GMKillEmAll ||
-      settings->gameMode == Settings::GMScalesOfJustice) {
+bool Game::IsGameOver() {
+  if (settings->game_mode == Settings::kGmKillEmAll ||
+      settings->game_mode == Settings::kGmScalesOfJustice) {
     for (std::size_t i = 0; i < worms.size(); ++i) {
       if (worms[i]->lives <= 0) return true;
     }
-  } else if (settings->gameMode == Settings::GMGameOfTag) {
+  } else if (settings->game_mode == Settings::kGmGameOfTag) {
     for (std::size_t i = 0; i < worms.size(); ++i) {
-      if (worms[i]->timer >= settings->timeToLose) return true;
+      if (worms[i]->timer >= settings->time_to_lose) return true;
     }
-  } else if (settings->gameMode == Settings::GMHoldazone) {
+  } else if (settings->game_mode == Settings::kGmHoldazone) {
     for (auto const& w : worms)
-      if (w->timer >= settings->timeToLose) return true;
+      if (w->timer >= settings->time_to_lose) return true;
   }
 
   return false;
 }
 
-void Game::doDamageDirect(Worm& w, int amount, int byIdx) {
+void Game::DoDamageDirect(Worm& w, int amount, int by_idx) {
   if (amount > 0) {
     w.health -= amount;
     if (w.health <= 0) {
-      w.lastKilledByIdx = byIdx;
+      w.last_killed_by_idx = by_idx;
     }
   }
 }
 
-void Game::doHealingDirect(Worm& w, int amount) {
+void Game::DoHealingDirect(Worm& w, int amount) {
   w.health += amount;
-  if (settings->gameMode == Settings::GMScalesOfJustice) {
+  if (settings->game_mode == Settings::kGmScalesOfJustice) {
     while (w.health > w.settings->health) {
       w.lives += 1;
       w.health -= w.settings->health;
@@ -495,41 +495,41 @@ void Game::doHealingDirect(Worm& w, int amount) {
   }
 }
 
-void Game::doDamage(Worm& w, int amount, int byIdx) {
-  doDamageDirect(w, amount, byIdx);
+void Game::DoDamage(Worm& w, int amount, int by_idx) {
+  DoDamageDirect(w, amount, by_idx);
 
   if (amount > 0) {
-    if (settings->gameMode == Settings::GMScalesOfJustice) {
-      if (byIdx < 0 || byIdx == w.index) {
+    if (settings->game_mode == Settings::kGmScalesOfJustice) {
+      if (by_idx < 0 || by_idx == w.index) {
         int parts = (int)worms.size() - 1;
         int left = amount;
 
         for (auto const& other : worms) {
           if (other.get() != &w) {
             int k = left / parts;
-            doHealingDirect(*other, k);
+            DoHealingDirect(*other, k);
             parts -= 1;
             left -= k;
           }
         }
       } else {
-        doHealingDirect(*worms[byIdx], amount);
+        DoHealingDirect(*worms[by_idx], amount);
       }
     }
   }
 }
 
-void Game::doHealing(Worm& w, int amount) {
-  doHealingDirect(w, amount);
+void Game::DoHealing(Worm& w, int amount) {
+  DoHealingDirect(w, amount);
 
-  if (settings->gameMode == Settings::GMScalesOfJustice) {
+  if (settings->game_mode == Settings::kGmScalesOfJustice) {
     int parts = (int)worms.size() - 1;
     int left = amount;
 
     for (auto const& other : worms) {
       if (other.get() != &w) {
         int k = left / parts;
-        doDamageDirect(*other, k, w.index);
+        DoDamageDirect(*other, k, w.index);
         parts -= 1;
         left -= k;
       }
@@ -539,33 +539,33 @@ void Game::doHealing(Worm& w, int amount) {
   }
 }
 
-bool checkRespawnPosition(Game& game, int x2, int y2, int oldX, int oldY, int x, int y) {
+bool CheckRespawnPosition(Game& game, int x2, int y2, int old_x, int old_y, int x, int y) {
   Common& common = *game.common;
 
-  int deltaX = oldX;
-  int deltaY = oldY - y;
-  int enemyDX = x2 - x;
-  int enemyDY = y2 - y;
+  int delta_x = old_x;
+  int delta_y = old_y - y;
+  int enemy_dx = x2 - x;
+  int enemy_dy = y2 - y;
 
-  if ((std::abs(deltaX) <= LC(WormMinSpawnDistLast) &&
-       std::abs(deltaY) <= LC(WormMinSpawnDistLast)) ||
-      (std::abs(enemyDX) <= LC(WormMinSpawnDistEnemy) &&
-       std::abs(enemyDY) <= LC(WormMinSpawnDistEnemy)))
+  if ((std::abs(delta_x) <= LC(WormMinSpawnDistLast) &&
+       std::abs(delta_y) <= LC(WormMinSpawnDistLast)) ||
+      (std::abs(enemy_dx) <= LC(WormMinSpawnDistEnemy) &&
+       std::abs(enemy_dy) <= LC(WormMinSpawnDistEnemy)))
     return false;
 
-  int maxX = x + 3;
-  int maxY = y + 4;
-  int minX = x - 3;
-  int minY = y - 4;
+  int max_x = x + 3;
+  int max_y = y + 4;
+  int min_x = x - 3;
+  int min_y = y - 4;
 
-  if (maxX >= game.level.width) maxX = game.level.width - 1;
-  if (maxY >= game.level.height) maxY = game.level.height - 1;
-  if (minX < 0) minX = 0;
-  if (minY < 0) minY = 0;
+  if (max_x >= game.level.width) max_x = game.level.width - 1;
+  if (max_y >= game.level.height) max_y = game.level.height - 1;
+  if (min_x < 0) min_x = 0;
+  if (min_y < 0) min_y = 0;
 
-  for (int i = minX; i != maxX; ++i)
-    for (int j = minY; j != maxY; ++j) {
-      if (game.level.mat(i, j).rock())  // TODO: The special rock respawn bug is here, consider an
+  for (int i = min_x; i != max_x; ++i)
+    for (int j = min_y; j != max_y; ++j) {
+      if (game.level.Mat(i, j).Rock())  // TODO: The special rock respawn bug is here, consider an
                                         // option to turn it off
         return false;
     }
@@ -573,15 +573,15 @@ bool checkRespawnPosition(Game& game, int x2, int y2, int oldX, int oldY, int x,
   return true;
 }
 
-void Game::postClone(Game& original, bool complete) {
-  soundPlayerInstalled = false;
-  prevSoundPlayer = nullptr;
+void Game::PostClone(Game& original, bool complete) {
+  sound_player_installed = false;
+  prev_sound_player = nullptr;
   if (!complete) {
-    statsRecorder.reset(new StatsRecorder);
-    soundPlayer.reset(new NullSoundPlayer);
+    stats_recorder.reset(new StatsRecorder);
+    sound_player.reset(new NullSoundPlayer);
     viewports.clear();
   } else {
-    statsRecorder.reset(new NormalStatsRecorder(static_cast<NormalStatsRecorder&>(*statsRecorder)));
+    stats_recorder.reset(new NormalStatsRecorder(static_cast<NormalStatsRecorder&>(*stats_recorder)));
 
     for (auto& vp : viewports) {
       vp = new Viewport(*vp);
@@ -593,33 +593,33 @@ void Game::postClone(Game& original, bool complete) {
   }
 }
 
-void Game::saveSnapshot(std::vector<uint8_t>& out) const {
+void Game::SaveSnapshot(std::vector<uint8_t>& out) const {
   std::ostringstream ss(std::ios::binary);
   {
     cereal::PortableBinaryOutputArchive ar(ss);
-    saveGameSnapshot(ar, *this);
+    SaveGameSnapshot(ar, *this);
   }
   std::string const& buf = ss.str();
   out.assign(buf.begin(), buf.end());
 }
 
-void Game::loadSnapshot(std::vector<uint8_t> const& in) {
+void Game::LoadSnapshot(std::vector<uint8_t> const& in) {
   std::string buf(in.begin(), in.end());
   std::istringstream ss(std::move(buf), std::ios::binary);
   cereal::PortableBinaryInputArchive ar(ss);
-  loadGameSnapshot(ar, *this);
+  LoadGameSnapshot(ar, *this);
 }
 
-void Game::saveSnapshotFast(GameSnapshot& snap) const {
+void Game::SaveSnapshotFast(GameSnapshot& snap) const {
   snap.rand = rand;
   snap.cycles = cycles;
-  snap.screenFlash = screenFlash;
-  snap.lastKilledIdx = lastKilledIdx;
-  snap.gotChanged = gotChanged;
+  snap.screen_flash = screen_flash;
+  snap.last_killed_idx = last_killed_idx;
+  snap.got_changed = got_changed;
   snap.holdazone = holdazone;
 
   for (std::size_t i = 0; i < worms.size() && i < snap.worms.size(); ++i)
-    saveWormSimState(snap.worms[i], *worms[i]);
+    SaveWormSimState(snap.worms[i], *worms[i]);
 
   // ExactObjectList<T,N> contents are trivially copyable POD blocks; the
   // compiler-generated copy assignment is a straight memcpy of the fixed
@@ -629,45 +629,45 @@ void Game::saveSnapshotFast(GameSnapshot& snap) const {
   snap.sobjects = sobjects;
   snap.nobjects = nobjects;
 
-  snap.bobjectsCount = bobjects.count;
-  if (snap.bobjectsArr.size() < bobjects.limit) snap.bobjectsArr.resize(bobjects.limit);
+  snap.bobjects_count = bobjects.count;
+  if (snap.bobjects_arr.size() < bobjects.limit) snap.bobjects_arr.resize(bobjects.limit);
   if (bobjects.count > 0)
-    std::memcpy(snap.bobjectsArr.data(), bobjects.arr.data(), bobjects.count * sizeof(BObject));
+    std::memcpy(snap.bobjects_arr.data(), bobjects.arr.data(), bobjects.count * sizeof(BObject));
 
-  std::size_t const cells =
+  std::size_t const kCells =
       static_cast<std::size_t>(level.width) * static_cast<std::size_t>(level.height);
-  if (snap.levelData.size() != cells) snap.levelData.resize(cells);
-  if (snap.levelMaterials.size() != cells) snap.levelMaterials.resize(cells);
-  if (cells > 0) {
-    std::memcpy(snap.levelData.data(), level.data.data(), cells);
-    std::memcpy(snap.levelMaterials.data(), level.materials.data(), cells * sizeof(Material));
+  if (snap.level_data.size() != kCells) snap.level_data.resize(kCells);
+  if (snap.level_materials.size() != kCells) snap.level_materials.resize(kCells);
+  if (kCells > 0) {
+    std::memcpy(snap.level_data.data(), level.data.data(), kCells);
+    std::memcpy(snap.level_materials.data(), level.materials.data(), kCells * sizeof(Material));
   }
 }
 
-void Game::loadSnapshotFast(GameSnapshot const& snap) {
+void Game::LoadSnapshotFast(GameSnapshot const& snap) {
   rand = snap.rand;
   cycles = snap.cycles;
-  screenFlash = snap.screenFlash;
-  lastKilledIdx = snap.lastKilledIdx;
-  gotChanged = snap.gotChanged;
+  screen_flash = snap.screen_flash;
+  last_killed_idx = snap.last_killed_idx;
+  got_changed = snap.got_changed;
   holdazone = snap.holdazone;
 
   for (std::size_t i = 0; i < worms.size() && i < snap.worms.size(); ++i)
-    restoreWormSimState(*worms[i], snap.worms[i]);
+    RestoreWormSimState(*worms[i], snap.worms[i]);
 
   bonuses = snap.bonuses;
   wobjects = snap.wobjects;
   sobjects = snap.sobjects;
   nobjects = snap.nobjects;
 
-  bobjects.count = snap.bobjectsCount;
-  if (snap.bobjectsCount > 0)
-    std::memcpy(bobjects.arr.data(), snap.bobjectsArr.data(), snap.bobjectsCount * sizeof(BObject));
+  bobjects.count = snap.bobjects_count;
+  if (snap.bobjects_count > 0)
+    std::memcpy(bobjects.arr.data(), snap.bobjects_arr.data(), snap.bobjects_count * sizeof(BObject));
 
-  std::size_t const cells =
+  std::size_t const kCells =
       static_cast<std::size_t>(level.width) * static_cast<std::size_t>(level.height);
-  if (cells > 0) {
-    std::memcpy(level.data.data(), snap.levelData.data(), cells);
-    std::memcpy(level.materials.data(), snap.levelMaterials.data(), cells * sizeof(Material));
+  if (kCells > 0) {
+    std::memcpy(level.data.data(), snap.level_data.data(), kCells);
+    std::memcpy(level.materials.data(), snap.level_materials.data(), kCells * sizeof(Material));
   }
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -42,7 +42,8 @@ Game::Game(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings_in
 Game::~Game() {
   ClearViewports();
   ClearWorms();
-  if (sound_player_installed && g_sound_player == sound_player.get()) g_sound_player = prev_sound_player;
+  if (sound_player_installed && g_sound_player == sound_player.get())
+    g_sound_player = prev_sound_player;
 }
 
 void Game::OnKey(uint32_t key, bool state) {
@@ -581,7 +582,8 @@ void Game::PostClone(Game& original, bool complete) {
     sound_player.reset(new NullSoundPlayer);
     viewports.clear();
   } else {
-    stats_recorder.reset(new NormalStatsRecorder(static_cast<NormalStatsRecorder&>(*stats_recorder)));
+    stats_recorder.reset(
+        new NormalStatsRecorder(static_cast<NormalStatsRecorder&>(*stats_recorder)));
 
     for (auto& vp : viewports) {
       vp = new Viewport(*vp);
@@ -662,7 +664,8 @@ void Game::LoadSnapshotFast(GameSnapshot const& snap) {
 
   bobjects.count = snap.bobjects_count;
   if (snap.bobjects_count > 0)
-    std::memcpy(bobjects.arr.data(), snap.bobjects_arr.data(), snap.bobjects_count * sizeof(BObject));
+    std::memcpy(bobjects.arr.data(), snap.bobjects_arr.data(),
+                snap.bobjects_count * sizeof(BObject));
 
   std::size_t const kCells =
       static_cast<std::size_t>(level.width) * static_cast<std::size_t>(level.height);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -70,7 +70,8 @@ struct Game {
   void ClearWorms();
   void AddWorm(std::shared_ptr<Worm>);
   void ResetWorms();
-  void Draw(Renderer& renderer, GameState state, bool use_spectator_viewports, bool is_replay = false);
+  void Draw(Renderer& renderer, GameState state, bool use_spectator_viewports,
+            bool is_replay = false);
   void StartGame();
   bool IsGameOver();
   void DoDamageDirect(Worm& w, int amount, int by_idx);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -21,105 +21,105 @@ struct Worm;
 struct Renderer;
 
 typedef enum {
-  StateInitial,
-  StateWeaponSelection,
-  StateGame,
-  StateGameEnded,
+  kStateInitial,
+  kStateWeaponSelection,
+  kStateGame,
+  kStateGameEnded,
 } GameState;
 
 struct Holdazone {
   Holdazone()
-      : holderIdx(-1),
-        contenderIdx(-1),
-        contenderFrames(0),
-        timeoutLeft(0),
-        zoneWidth(50),
-        zoneHeight(34) {}
+      : holder_idx(-1),
+        contender_idx(-1),
+        contender_frames(0),
+        timeout_left(0),
+        zone_width(50),
+        zone_height(34) {}
 
   Rect rect;
-  int holderIdx;
+  int holder_idx;
 
-  int contenderIdx, contenderFrames;
+  int contender_idx, contender_frames;
 
-  int timeoutLeft;
+  int timeout_left;
 
-  int zoneWidth, zoneHeight;
+  int zone_width, zone_height;
 };
 
 struct Game {
   Game(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings,
-       std::shared_ptr<SoundPlayer> soundPlayer);
+       std::shared_ptr<SoundPlayer> sound_player);
   ~Game();
 
-  void onKey(uint32_t key, bool state);
-  Worm* findControlForKey(uint32_t key, Worm::Control& control);
-  void releaseControls();
-  void processFrame();
-  void focus(Renderer& renderer);
-  void updateSettings(Renderer& renderer);
+  void OnKey(uint32_t key, bool state);
+  Worm* FindControlForKey(uint32_t key, Worm::Control& control);
+  void ReleaseControls();
+  void ProcessFrame();
+  void Focus(Renderer& renderer);
+  void UpdateSettings(Renderer& renderer);
 
-  void createBObject(fixedvec pos, fixedvec vel);
-  void createBonus();
+  void CreateBObject(fixedvec pos, fixedvec vel);
+  void CreateBonus();
 
-  void clearViewports();
-  void addViewport(Viewport*);
-  void addSpectatorViewport(SpectatorViewport*);
-  void processViewports();
-  void drawViewports(Renderer& renderer, GameState state, bool isReplay = false);
-  void drawSpectatorViewports(Renderer& renderer, GameState state, bool isReplay = false);
-  void clearWorms();
-  void addWorm(std::shared_ptr<Worm>);
-  void resetWorms();
-  void draw(Renderer& renderer, GameState state, bool useSpectatorViewports, bool isReplay = false);
-  void startGame();
-  bool isGameOver();
-  void doDamageDirect(Worm& w, int amount, int byIdx);
-  void doHealingDirect(Worm& w, int amount);
-  void doDamage(Worm& w, int amount, int byIdx);
-  void doHealing(Worm& w, int amount);
-  void postClone(Game& original, bool complete = false);
+  void ClearViewports();
+  void AddViewport(Viewport*);
+  void AddSpectatorViewport(SpectatorViewport*);
+  void ProcessViewports();
+  void DrawViewports(Renderer& renderer, GameState state, bool is_replay = false);
+  void DrawSpectatorViewports(Renderer& renderer, GameState state, bool is_replay = false);
+  void ClearWorms();
+  void AddWorm(std::shared_ptr<Worm>);
+  void ResetWorms();
+  void Draw(Renderer& renderer, GameState state, bool use_spectator_viewports, bool is_replay = false);
+  void StartGame();
+  bool IsGameOver();
+  void DoDamageDirect(Worm& w, int amount, int by_idx);
+  void DoHealingDirect(Worm& w, int amount);
+  void DoDamage(Worm& w, int amount, int by_idx);
+  void DoHealing(Worm& w, int amount);
+  void PostClone(Game& original, bool complete = false);
 
   // Full mid-game state snapshot (cereal-based). Round-trips every
   // sim-affecting field; correctness oracle for the fast path.
-  void saveSnapshot(std::vector<uint8_t>& out) const;
-  void loadSnapshot(std::vector<uint8_t> const& in);
+  void SaveSnapshot(std::vector<uint8_t>& out) const;
+  void LoadSnapshot(std::vector<uint8_t> const& in);
 
   // Fast in-memory snapshot path used by the rollback ring buffer.
   // Writes/reads directly into a pre-allocated GameSnapshot — no
   // serialisation, no allocation in the steady state.
-  void saveSnapshotFast(struct GameSnapshot& out) const;
-  void loadSnapshotFast(struct GameSnapshot const& in);
+  void SaveSnapshotFast(struct GameSnapshot& out) const;
+  void LoadSnapshotFast(struct GameSnapshot const& in);
 
-  void spawnZone();
+  void SpawnZone();
 
   // While speculative is true, sim-driven side effects
   // (SoundPlayer::play/stop, StatsRecorder writes) are suppressed.
   // Set during predicted frames and during rollback resim.
-  void setSpeculative(bool s) {
+  void SetSpeculative(bool s) {
     speculative = s;
-    if (soundPlayer) soundPlayer->speculative = s;
-    if (statsRecorder) statsRecorder->speculative = s;
+    if (sound_player) sound_player->speculative = s;
+    if (stats_recorder) stats_recorder->speculative = s;
   }
 
-  Material pixelMat(int x, int y) { return common->materials[level.pixel(x, y)]; }
+  Material PixelMat(int x, int y) { return common->materials[level.Pixel(x, y)]; }
 
-  Worm* wormByIdx(int idx) {
+  Worm* WormByIdx(int idx) {
     if (idx < 0) return 0;
     return worms[idx].get();
   }
 
   std::shared_ptr<Common> common;
-  std::shared_ptr<SoundPlayer> soundPlayer;
-  SoundPlayer* prevSoundPlayer;
-  bool soundPlayerInstalled;
+  std::shared_ptr<SoundPlayer> sound_player;
+  SoundPlayer* prev_sound_player;
+  bool sound_player_installed;
   std::shared_ptr<Settings> settings;
-  std::shared_ptr<StatsRecorder> statsRecorder;
+  std::shared_ptr<StatsRecorder> stats_recorder;
 
   Level level;
 
-  int screenFlash;
-  bool gotChanged;
-  int lastKilledIdx;
+  int screen_flash;
+  bool got_changed;
+  int last_killed_idx;
   bool paused;
   int cycles;
   Rand rand;
@@ -127,7 +127,7 @@ struct Game {
   Holdazone holdazone;
 
   std::vector<Viewport*> viewports;
-  std::vector<SpectatorViewport*> spectatorViewports;
+  std::vector<SpectatorViewport*> spectator_viewports;
   std::vector<std::shared_ptr<Worm>> worms;
 
   typedef ExactObjectList<Bonus, 99> BonusList;
@@ -141,7 +141,7 @@ struct Game {
   NObjectList nobjects;
   BObjectList bobjects;
 
-  bool quickSim;
+  bool quick_sim;
 
   // True during predicted/resim frames. Mirrored onto soundPlayer /
   // statsRecorder via setSpeculative(). Read by Game-internal code
@@ -149,7 +149,7 @@ struct Game {
   bool speculative = false;
 };
 
-bool checkRespawnPosition(Game& game, int x2, int y2, int oldX, int oldY, int x, int y);
+bool CheckRespawnPosition(Game& game, int x2, int y2, int old_x, int old_y, int x, int y);
 
 // Checksum of game state for desync detection. Folds in RNG state,
 // worm pos/vel/health/lives/ammo/aim, projectile pools, level damage,
@@ -157,4 +157,4 @@ bool checkRespawnPosition(Game& game, int x2, int y2, int oldX, int oldY, int x,
 // projectile drift with worm position still matching) trip the
 // receiver's checksum comparison instead of going undetected. Used
 // by both the rollback controller and the replay format.
-uint32_t wideRollbackChecksum(Game& game);
+uint32_t WideRollbackChecksum(Game& game);

--- a/src/game/gameEntry.cpp
+++ b/src/game/gameEntry.cpp
@@ -17,62 +17,62 @@
 #include <ctime>
 #include <exception>
 
-int gameEntry(int argc, char* argv[]) try {
+int GameEntry(int argc, char* argv[]) try {
   // TODO: Better PRNG seeding
-  gfx.rand.seed(uint32_t(std::time(0)));
+  gfx.rand.Seed(uint32_t(std::time(0)));
 
 #if OPENLIERO_EMSCRIPTEN
   // Emscripten preloads all data under /openliero; use single-dir mode.
   const char* emscriptenArgv[] = {argv[0], "--config-root", "/openliero", nullptr};
   auto r = paths::resolve(3, const_cast<char**>(emscriptenArgv));
 #else
-  auto r = paths::resolve(argc, argv);
+  auto r = paths::Resolve(argc, argv);
 #endif
 
-  gfx.onlinePort = r.port != 0 ? r.port : gfx.onlinePort;
-  gfx.setConfigNodes(r.configNode, r.userConfigNode);
+  gfx.online_port = r.port != 0 ? r.port : gfx.online_port;
+  gfx.SetConfigNodes(r.config_node, r.user_config_node);
 
-  std::string tcName;
-  bool tcSet = !r.positionalArgs.empty();
-  if (tcSet) tcName = r.positionalArgs[0];
+  std::string tc_name;
+  bool tc_set = !r.positional_args.empty();
+  if (tc_set) tc_name = r.positional_args[0];
 
   SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD);
 
-  initKeys();
+  InitKeys();
 
-  precomputeTables();
+  PrecomputeTables();
 
-  gfx.loadMenus();
+  gfx.LoadMenus();
 
-  gfx.init();
+  gfx.Init();
 
-  FsNode configNode(gfx.getConfigNode());
-  FsNode userConfigNode(gfx.getUserConfigNode());
+  FsNode config_node(gfx.GetConfigNode());
+  FsNode user_config_node(gfx.GetUserConfigNode());
 
-  if (!gfx.loadSettings(configNode / "Setups" / "liero.cfg")) {
+  if (!gfx.LoadSettings(config_node / "Setups" / "liero.cfg")) {
     gfx.settings.reset(new Settings);
-    gfx.saveSettings(userConfigNode / "Setups" / "liero.cfg");
+    gfx.SaveSettings(user_config_node / "Setups" / "liero.cfg");
   }
 
-  if (tcSet) gfx.settings->tc = tcName;
+  if (tc_set) gfx.settings->tc = tc_name;
 
   // TC loading
-  FsNode lieroRoot(configNode / "TC" / gfx.settings->tc);
+  FsNode liero_root(config_node / "TC" / gfx.settings->tc);
   std::shared_ptr<Common> common(new Common());
-  common->load(std::move(lieroRoot));
+  common->load(std::move(liero_root));
   gfx.common = common;
-  gfx.playRenderer.loadPalette(*common);
+  gfx.play_renderer.LoadPalette(*common);
 
-  gfx.setVideoMode();
-  gfx.soundPlayer = std::make_shared<DefaultSoundPlayer>(*common);
-  g_soundPlayer = gfx.soundPlayer.get();
+  gfx.SetVideoMode();
+  gfx.sound_player = std::make_shared<DefaultSoundPlayer>(*common);
+  g_sound_player = gfx.sound_player.get();
 
-  gfx.mainLoop();
+  gfx.MainLoop();
 
-  gfx.settings->save(userConfigNode / "Setups" / "liero.cfg", gfx.rand);
+  gfx.settings->save(user_config_node / "Setups" / "liero.cfg", gfx.rand);
 
-  g_soundPlayer = nullptr;
-  gfx.soundPlayer.reset();
+  g_sound_player = nullptr;
+  gfx.sound_player.reset();
   SDL_Quit();
 
   return 0;

--- a/src/game/gameEntry.cpp
+++ b/src/game/gameEntry.cpp
@@ -24,7 +24,7 @@ int GameEntry(int argc, char* argv[]) try {
 #if OPENLIERO_EMSCRIPTEN
   // Emscripten preloads all data under /openliero; use single-dir mode.
   const char* emscriptenArgv[] = {argv[0], "--config-root", "/openliero", nullptr};
-  auto r = paths::resolve(3, const_cast<char**>(emscriptenArgv));
+  auto r = paths::Resolve(3, const_cast<char**>(emscriptenArgv));
 #else
   auto r = paths::Resolve(argc, argv);
 #endif

--- a/src/game/gamePlayState.cpp
+++ b/src/game/gamePlayState.cpp
@@ -9,40 +9,40 @@
 #include "statsState.hpp"
 #include "stats_recorder.hpp"
 
-void GamePlayState::enter() { gfx->controller->focus(); }
+void GamePlayState::Enter() { gfx->controller->Focus(); }
 
-void GamePlayState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev, gfx->controller.get()); }
+void GamePlayState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev, gfx->controller.get()); }
 
-bool GamePlayState::update() {
+bool GamePlayState::Update() {
   // Poll network session if active
-  if (gfx->netSession) {
-    gfx->netSession->update();
-    auto state = gfx->netSession->sessionState();
-    if (state == NetSession::Disconnected || state == NetSession::Failed) {
-      gfx->controller->markUnresumable();
-      gfx->netSession.reset();
-      gfx->stateStack.scheduleReplaceTop(
+  if (gfx->net_session) {
+    gfx->net_session->Update();
+    auto state = gfx->net_session->State();
+    if (state == NetSession::kDisconnected || state == NetSession::kFailed) {
+      gfx->controller->MarkUnresumable();
+      gfx->net_session.reset();
+      gfx->state_stack.ScheduleReplaceTop(
           std::make_unique<InfoBoxState>("PEER DISCONNECTED", 320 / 2, 200 / 2, true));
       return false;
     }
-    if (gfx->netSession->desyncDetected()) {
-      uint32_t frame = gfx->netSession->desyncFrame();
+    if (gfx->net_session->DesyncDetected()) {
+      uint32_t frame = gfx->net_session->DesyncFrame();
       char msg[64];
       snprintf(msg, sizeof(msg), "DESYNC AT FRAME %u", frame);
-      gfx->controller->markUnresumable();
-      gfx->netSession.reset();
-      gfx->stateStack.scheduleReplaceTop(
+      gfx->controller->MarkUnresumable();
+      gfx->net_session.reset();
+      gfx->state_stack.ScheduleReplaceTop(
           std::make_unique<InfoBoxState>(msg, 320 / 2, 200 / 2, true));
       return false;
     }
   }
 
-  if (!gfx->controller->process()) {
+  if (!gfx->controller->Process()) {
     // Check for pending error message
-    if (!gfx->pendingErrorMessage.empty()) {
-      std::string msg = std::move(gfx->pendingErrorMessage);
-      gfx->pendingErrorMessage.clear();
-      gfx->stateStack.scheduleReplaceTop(
+    if (!gfx->pending_error_message.empty()) {
+      std::string msg = std::move(gfx->pending_error_message);
+      gfx->pending_error_message.clear();
+      gfx->state_stack.ScheduleReplaceTop(
           std::make_unique<InfoBoxState>(std::move(msg), 320 / 2, 200 / 2, true));
       return false;
     }
@@ -51,26 +51,26 @@ bool GamePlayState::update() {
     // statsGame() is the live game for single-player/replay and the
     // shadow Game for rollback multiplayer (live's recorder is a
     // no-op there — see RollbackController::setupShadowGame).
-    Game* game = gfx->controller->statsGame();
-    if (game && game->statsRecorder) {
-      auto* stats = dynamic_cast<NormalStatsRecorder*>(game->statsRecorder.get());
-      if (stats && stats->gameTime > 0) {
-        bool isMultiplayer = gfx->netSession != nullptr;
+    Game* game = gfx->controller->StatsGame();
+    if (game && game->stats_recorder) {
+      auto* stats = dynamic_cast<NormalStatsRecorder*>(game->stats_recorder.get());
+      if (stats && stats->game_time > 0) {
+        bool is_multiplayer = gfx->net_session != nullptr;
 
         // Transition network session to rematch state to keep connection alive
-        if (isMultiplayer) gfx->netSession->enterRematch();
+        if (is_multiplayer) gfx->net_session->EnterRematch();
 
-        gfx->stateStack.scheduleReplaceTop(
-            std::make_unique<StatsState>(*stats, *game, isMultiplayer));
+        gfx->state_stack.ScheduleReplaceTop(
+            std::make_unique<StatsState>(*stats, *game, is_multiplayer));
         return false;
       }
     }
 
     // Clear framebuffer so menu doesn't capture stale overlay content
-    if (gfx->netSession) {
-      gfx->netSession.reset();
-      fill(gfx->playRenderer.bmp, 0);
-      fill(gfx->singleScreenRenderer.bmp, 0);
+    if (gfx->net_session) {
+      gfx->net_session.reset();
+      Fill(gfx->play_renderer.bmp, 0);
+      Fill(gfx->single_screen_renderer.bmp, 0);
     }
     return false;
   }
@@ -78,10 +78,10 @@ bool GamePlayState::update() {
   return true;
 }
 
-void GamePlayState::draw() {
-  gfx->playRenderer.clear();
-  gfx->controller->draw(gfx->playRenderer, false);
+void GamePlayState::Draw() {
+  gfx->play_renderer.Clear();
+  gfx->controller->Draw(gfx->play_renderer, false);
 
-  gfx->singleScreenRenderer.clear();
-  gfx->controller->draw(gfx->singleScreenRenderer, true);
+  gfx->single_screen_renderer.Clear();
+  gfx->controller->Draw(gfx->single_screen_renderer, true);
 }

--- a/src/game/gamePlayState.hpp
+++ b/src/game/gamePlayState.hpp
@@ -6,9 +6,9 @@
 // Pushed onto the state stack when the player starts or resumes a game.
 // Pops itself when the controller signals the game is over (process() returns false).
 struct GamePlayState : AppState {
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
-  bool wantsMenuFlip() const override { return false; }
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
+  bool WantsMenuFlip() const override { return false; }
 };

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -41,37 +41,37 @@
 Gfx gfx;
 
 struct KeyBehavior : ItemBehavior {
-  KeyBehavior(Common& common, uint32_t& key, uint32_t& keyEx, uint32_t& gamepadKey,
-              uint32_t& inputDevice, bool extended = false)
+  KeyBehavior(Common& common, uint32_t& key, uint32_t& key_ex, uint32_t& gamepad_key,
+              uint32_t& input_device, bool extended = false)
       : common(common),
         key(key),
-        keyEx(keyEx),
-        gamepadKey(gamepadKey),
-        inputDevice(inputDevice),
+        key_ex(key_ex),
+        gamepad_key(gamepad_key),
+        input_device(input_device),
         extended(extended) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    if (inputDevice != WormSettingsExtensions::InputKeyboard)
-      item.value = gfx.getGamepadKeyName(gamepadKey);
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    if (input_device != WormSettingsExtensions::kInputKeyboard)
+      item.value = gfx.GetGamepadKeyName(gamepad_key);
     else
-      item.value = gfx.getKeyName(extended ? keyEx : key);
-    item.hasValue = true;
+      item.value = gfx.GetKeyName(extended ? key_ex : key);
+    item.has_value = true;
   }
 
   Common& common;
   uint32_t& key;
-  uint32_t& keyEx;
-  uint32_t& gamepadKey;
-  uint32_t& inputDevice;
+  uint32_t& key_ex;
+  uint32_t& gamepad_key;
+  uint32_t& input_device;
   bool extended;
 };
 
 struct WormNameBehavior : ItemBehavior {
   WormNameBehavior(Common& common, WormSettings& ws) : common(common), ws(ws) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
+  void OnUpdate(Menu& menu, MenuItem& item) {
     item.value = ws.name;
-    item.hasValue = true;
+    item.has_value = true;
   }
 
   Common& common;
@@ -82,106 +82,106 @@ struct InputDeviceBehavior : ItemBehavior {
   struct GamepadOption {
     std::string name;
     std::string serial;
-    std::string displayName;
-    int joystickIdx;
+    std::string display_name;
+    int joystick_idx;
   };
 
   InputDeviceBehavior(Common& common, WormSettings& ws) : common(common), ws(ws) {}
 
-  std::vector<GamepadOption> buildOptions() {
+  std::vector<GamepadOption> BuildOptions() {
     std::vector<GamepadOption> opts;
     // Count names to detect duplicates
-    std::unordered_map<std::string, int> nameCounts;
+    std::unordered_map<std::string, int> name_counts;
     for (int i = 0; i < (int)gfx.joysticks.size(); ++i) {
-      char const* n = SDL_GetGamepadName(gfx.joysticks[i].sdlGamepad);
+      char const* n = SDL_GetGamepadName(gfx.joysticks[i].sdl_gamepad);
       std::string name = n ? n : "Gamepad";
-      nameCounts[name]++;
+      name_counts[name]++;
     }
 
-    std::unordered_map<std::string, int> nameSeenSoFar;
+    std::unordered_map<std::string, int> name_seen_so_far;
     for (int i = 0; i < (int)gfx.joysticks.size(); ++i) {
       GamepadOption opt;
-      char const* n = SDL_GetGamepadName(gfx.joysticks[i].sdlGamepad);
+      char const* n = SDL_GetGamepadName(gfx.joysticks[i].sdl_gamepad);
       opt.name = n ? n : "Gamepad";
-      char const* s = SDL_GetGamepadSerial(gfx.joysticks[i].sdlGamepad);
+      char const* s = SDL_GetGamepadSerial(gfx.joysticks[i].sdl_gamepad);
       opt.serial = s ? s : "";
-      opt.joystickIdx = i;
+      opt.joystick_idx = i;
 
       // Disambiguate display name if duplicates exist
-      if (nameCounts[opt.name] > 1) {
-        int idx = ++nameSeenSoFar[opt.name];
-        std::string suffix = " #" + toString(idx);
+      if (name_counts[opt.name] > 1) {
+        int idx = ++name_seen_so_far[opt.name];
+        std::string suffix = " #" + ToString(idx);
         std::string base = opt.name.substr(0, 20 - suffix.size());
-        opt.displayName = base + suffix;
+        opt.display_name = base + suffix;
       } else {
-        opt.displayName = opt.name.substr(0, 20);
+        opt.display_name = opt.name.substr(0, 20);
       }
       opts.push_back(opt);
     }
     return opts;
   }
 
-  int findCurrentOption(std::vector<GamepadOption> const& opts) {
-    if (ws.inputDevice == WormSettingsExtensions::InputKeyboard) return -1;
+  int FindCurrentOption(std::vector<GamepadOption> const& opts) {
+    if (ws.input_device == WormSettingsExtensions::kInputKeyboard) return -1;
     // Try serial match first
-    if (!ws.gamepadSerial.empty()) {
+    if (!ws.gamepad_serial.empty()) {
       for (int i = 0; i < (int)opts.size(); ++i)
-        if (opts[i].name == ws.gamepadName && opts[i].serial == ws.gamepadSerial) return i;
+        if (opts[i].name == ws.gamepad_name && opts[i].serial == ws.gamepad_serial) return i;
     }
     // Fall back to name match
     for (int i = 0; i < (int)opts.size(); ++i)
-      if (opts[i].name == ws.gamepadName) return i;
+      if (opts[i].name == ws.gamepad_name) return i;
     return -1;
   }
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    if (ws.inputDevice == WormSettingsExtensions::InputKeyboard) {
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    if (ws.input_device == WormSettingsExtensions::kInputKeyboard) {
       item.value = "Keyboard";
     } else {
-      auto opts = buildOptions();
-      int cur = findCurrentOption(opts);
+      auto opts = BuildOptions();
+      int cur = FindCurrentOption(opts);
       if (cur >= 0)
-        item.value = opts[cur].displayName;
+        item.value = opts[cur].display_name;
       else {
         std::string display =
-            ws.gamepadName.empty() ? "Gamepad (none)" : ws.gamepadName.substr(0, 20);
+            ws.gamepad_name.empty() ? "Gamepad (none)" : ws.gamepad_name.substr(0, 20);
         item.value = display;
       }
     }
-    item.hasValue = true;
+    item.has_value = true;
   }
 
-  bool onLeftRight(Menu& menu, MenuItem& item, int dir) {
-    g_soundPlayer->play(common.soundHook[dir > 0 ? SoundMenuMoveUp : SoundMenuMoveDown]);
-    cycle(menu, dir);
+  bool OnLeftRight(Menu& menu, MenuItem& item, int dir) {
+    g_sound_player->Play(common.sound_hook[dir > 0 ? SoundMenuMoveUp : SoundMenuMoveDown]);
+    Cycle(menu, dir);
     return false;
   }
 
-  int onEnter(Menu& menu, MenuItem& item) {
-    g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-    cycle(menu, 1);
+  int OnEnter(Menu& menu, MenuItem& item) {
+    g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+    Cycle(menu, 1);
     return -1;
   }
 
-  void cycle(Menu& menu, int dir) {
-    auto opts = buildOptions();
+  void Cycle(Menu& menu, int dir) {
+    auto opts = BuildOptions();
     // Options: -1 = keyboard, 0..N-1 = gamepads
     int count = (int)opts.size() + 1;
-    int cur = findCurrentOption(opts) + 1;  // shift so keyboard=0, gamepads=1..N
+    int cur = FindCurrentOption(opts) + 1;  // shift so keyboard=0, gamepads=1..N
     cur = ((cur + dir) % count + count) % count;
 
     if (cur == 0) {
-      ws.inputDevice = WormSettingsExtensions::InputKeyboard;
-      ws.gamepadName.clear();
-      ws.gamepadSerial.clear();
+      ws.input_device = WormSettingsExtensions::kInputKeyboard;
+      ws.gamepad_name.clear();
+      ws.gamepad_serial.clear();
     } else {
       auto& opt = opts[cur - 1];
-      ws.inputDevice = 1;
-      ws.gamepadName = opt.name;
-      ws.gamepadSerial = opt.serial;
+      ws.input_device = 1;
+      ws.gamepad_name = opt.name;
+      ws.gamepad_serial = opt.serial;
     }
 
-    menu.updateItems(common);
+    menu.UpdateItems(common);
   }
 
   Common& common;
@@ -189,49 +189,49 @@ struct InputDeviceBehavior : ItemBehavior {
 };
 
 struct ProfileSaveBehavior : ItemBehavior {
-  ProfileSaveBehavior(Common& common, WormSettings& ws, bool saveAs = false)
-      : common(common), ws(ws), saveAs(saveAs) {}
+  ProfileSaveBehavior(Common& common, WormSettings& ws, bool save_as = false)
+      : common(common), ws(ws), save_as(save_as) {}
 
-  int onEnter(Menu& menu, MenuItem& item) {
-    g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+  int OnEnter(Menu& menu, MenuItem& item) {
+    g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
 
-    if (!saveAs) {
+    if (!save_as) {
       // Save in-place always writes to the user dir, even when the
       // profile was loaded from shipped data. saveProfile retargets
       // profileNode so subsequent saves stay on the user copy.
-      std::string leaf = getLeaf(ws.profileNode.fullPath());
-      ws.saveProfile(gfx.getUserConfigNode() / "Profiles" / leaf);
+      std::string leaf = GetLeaf(ws.profile_node.FullPath());
+      ws.SaveProfile(gfx.GetUserConfigNode() / "Profiles" / leaf);
     }
     // saveAs path is intercepted by MainMenuState
 
-    menu.updateItems(common);
+    menu.UpdateItems(common);
     return -1;
   }
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    if (!saveAs) {
-      item.visible = (bool)ws.profileNode;
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    if (!save_as) {
+      item.visible = (bool)ws.profile_node;
     }
   }
 
   Common& common;
   WormSettings& ws;
-  bool saveAs;
+  bool save_as;
 };
 
 struct ProfileLoadedBehavior : ItemBehavior {
   ProfileLoadedBehavior(Common& common, WormSettings& ws) : common(common), ws(ws) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    if (ws.profileNode) {
-      item.value = getBasename(getLeaf(ws.profileNode.fullPath()));
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    if (ws.profile_node) {
+      item.value = GetBasename(GetLeaf(ws.profile_node.FullPath()));
       item.visible = true;
     } else {
       item.value.clear();
       item.visible = false;
     }
 
-    item.hasValue = true;
+    item.has_value = true;
   }
 
   Common& common;
@@ -242,313 +242,313 @@ struct WeaponEnumBehavior : EnumBehavior {
   WeaponEnumBehavior(Common& common, uint32_t& v)
       : EnumBehavior(common, v, 1, (uint32_t)common.weapons.size(), false) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    item.value = common.weapons[common.weapOrder[v - 1]].name;
-    item.hasValue = true;
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    item.value = common.weapons[common.weap_order[v - 1]].name;
+    item.has_value = true;
   }
 };
 
 Gfx::Gfx()
-    : mainMenu(53, 20),
-      settingsMenu(178, 20),
-      playerMenu(178, 20),
-      hiddenMenu(178, 20),
-      curMenu(0),
-      sdlDrawSurface(0),
+    : main_menu(53, 20),
+      settings_menu(178, 20),
+      player_menu(178, 20),
+      hidden_menu(178, 20),
+      cur_menu(0),
+      sdl_draw_surface(0),
       running(true),
-      doubleRes(true),
-      menuCycles(0),
-      windowW(320 * 2),
-      windowH(200 * 2),
-      prevMag(0),
-      keyBufPtr(keyBuf) {
-  clearKeys();
-  primaryRenderer = &playRenderer;
-  soundPlayer = std::make_shared<NullSoundPlayer>();
+      double_res(true),
+      menu_cycles(0),
+      window_w(320 * 2),
+      window_h(200 * 2),
+      prev_mag(0),
+      key_buf_ptr(key_buf) {
+  ClearKeys();
+  primary_renderer = &play_renderer;
+  sound_player = std::make_shared<NullSoundPlayer>();
 }
 
-void Gfx::init() {
+void Gfx::Init() {
   SDL_HideCursor();
-  lastFrame = SDL_GetTicks();
+  last_frame = SDL_GetTicks();
 
-  playRenderer.init(320, 200);
-  singleScreenRenderer.init(640, 400);
+  play_renderer.Init(320, 200);
+  single_screen_renderer.Init(640, 400);
   // Gamepad init
   SDL_SetGamepadEventsEnabled(true);
-  int numGamepads = 0;
-  SDL_JoystickID* gamepadIds = SDL_GetGamepads(&numGamepads);
-  joysticks.resize(numGamepads);
-  for (int i = 0; i < numGamepads; ++i) {
-    joysticks[i].sdlGamepad = SDL_OpenGamepad(gamepadIds[i]);
-    joysticks[i].instanceId = gamepadIds[i];
-    joysticks[i].clearState();
+  int num_gamepads = 0;
+  SDL_JoystickID* gamepad_ids = SDL_GetGamepads(&num_gamepads);
+  joysticks.resize(num_gamepads);
+  for (int i = 0; i < num_gamepads; ++i) {
+    joysticks[i].sdl_gamepad = SDL_OpenGamepad(gamepad_ids[i]);
+    joysticks[i].instance_id = gamepad_ids[i];
+    joysticks[i].ClearState();
   }
-  SDL_free(gamepadIds);
+  SDL_free(gamepad_ids);
 }
 
-void Gfx::setVideoMode() {
-  if (sdlSpectatorRenderer) {
-    SDL_DestroyRenderer(sdlSpectatorRenderer);
-    sdlSpectatorRenderer = NULL;
+void Gfx::SetVideoMode() {
+  if (sdl_spectator_renderer) {
+    SDL_DestroyRenderer(sdl_spectator_renderer);
+    sdl_spectator_renderer = NULL;
   }
-  if (settings->spectatorWindow) {
-    if (!sdlSpectatorWindow) {
-      std::string spectatorWindowTitle = std::string("Liero Spectator Window - ") + build_version();
-      sdlSpectatorWindow = SDL_CreateWindow(
-          spectatorWindowTitle.c_str(), windowW, windowH,
-          SDL_WINDOW_RESIZABLE | (spectatorFullscreen ? SDL_WINDOW_FULLSCREEN : 0));
+  if (settings->spectator_window) {
+    if (!sdl_spectator_window) {
+      std::string spectator_window_title = std::string("Liero Spectator Window - ") + BuildVersion();
+      sdl_spectator_window = SDL_CreateWindow(
+          spectator_window_title.c_str(), window_w, window_h,
+          SDL_WINDOW_RESIZABLE | (spectator_fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
     } else {
-      SDL_SetWindowFullscreen(sdlSpectatorWindow, spectatorFullscreen);
+      SDL_SetWindowFullscreen(sdl_spectator_window, spectator_fullscreen);
     }
-    sdlSpectatorRenderer = SDL_CreateRenderer(sdlSpectatorWindow, NULL);
-    onWindowResize(SDL_GetWindowID(sdlSpectatorWindow));
+    sdl_spectator_renderer = SDL_CreateRenderer(sdl_spectator_window, NULL);
+    OnWindowResize(SDL_GetWindowID(sdl_spectator_window));
   } else {
-    if (sdlSpectatorTexture) {
-      SDL_DestroyTexture(sdlSpectatorTexture);
-      sdlSpectatorTexture = NULL;
+    if (sdl_spectator_texture) {
+      SDL_DestroyTexture(sdl_spectator_texture);
+      sdl_spectator_texture = NULL;
     }
-    if (sdlSpectatorDrawSurface) {
-      SDL_DestroySurface(sdlSpectatorDrawSurface);
-      sdlSpectatorDrawSurface = NULL;
+    if (sdl_spectator_draw_surface) {
+      SDL_DestroySurface(sdl_spectator_draw_surface);
+      sdl_spectator_draw_surface = NULL;
     }
-    if (sdlSpectatorWindow) {
-      SDL_DestroyWindow(sdlSpectatorWindow);
-      sdlSpectatorWindow = NULL;
+    if (sdl_spectator_window) {
+      SDL_DestroyWindow(sdl_spectator_window);
+      sdl_spectator_window = NULL;
     }
   }
 
-  if (!sdlWindow) {
-    std::string windowTitle = std::string("Liero ") + build_version();
-    sdlWindow =
-        SDL_CreateWindow(windowTitle.c_str(), windowW, windowH,
+  if (!sdl_window) {
+    std::string window_title = std::string("Liero ") + BuildVersion();
+    sdl_window =
+        SDL_CreateWindow(window_title.c_str(), window_w, window_h,
                          SDL_WINDOW_RESIZABLE | (settings->fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
 
 #ifndef __APPLE__
-    std::string s = (getConfigNode() / "Resources" / "icon.png").fullPath();
+    std::string s = (GetConfigNode() / "Resources" / "icon.png").FullPath();
     SDL_Surface* icon = IMG_Load(s.c_str());
     if (icon) {
-      SDL_SetWindowIcon(sdlWindow, icon);
+      SDL_SetWindowIcon(sdl_window, icon);
       SDL_DestroySurface(icon);
     }
 #endif
   } else {
-    SDL_SetWindowFullscreen(sdlWindow, settings->fullscreen);
+    SDL_SetWindowFullscreen(sdl_window, settings->fullscreen);
   }
-  if (sdlRenderer) {
-    SDL_DestroyRenderer(sdlRenderer);
-    sdlRenderer = NULL;
+  if (sdl_renderer) {
+    SDL_DestroyRenderer(sdl_renderer);
+    sdl_renderer = NULL;
   }
   // vertical sync is always disabled. Frame limiting is done manually below,
   // to keep the correct speed
-  sdlRenderer = SDL_CreateRenderer(sdlWindow, NULL);
-  onWindowResize(SDL_GetWindowID(sdlWindow));
+  sdl_renderer = SDL_CreateRenderer(sdl_window, NULL);
+  OnWindowResize(SDL_GetWindowID(sdl_window));
 
   // Set the spectator window's icon after the main window has been initialized.
   // On Windows, this makes sure the icon in the stacked taskbar is the main icon.
   // On MacOS this is commented out, because it only allows one icon and the spectator icon
   // will override the main icon
 #ifndef __APPLE__
-  if (sdlSpectatorWindow) {
-    std::string s = (getConfigNode() / "Resources" / "spectator_icon.png").fullPath();
+  if (sdl_spectator_window) {
+    std::string s = (GetConfigNode() / "Resources" / "spectator_icon.png").FullPath();
     SDL_Surface* spectator_icon = IMG_Load(s.c_str());
     if (spectator_icon) {
-      SDL_SetWindowIcon(sdlSpectatorWindow, spectator_icon);
+      SDL_SetWindowIcon(sdl_spectator_window, spectator_icon);
       SDL_DestroySurface(spectator_icon);
     }
   }
 #endif
 }
 
-void Gfx::onWindowResize(uint32_t windowID) {
-  if (windowID == SDL_GetWindowID(sdlWindow)) {
-    if (sdlTexture) {
-      SDL_DestroyTexture(sdlTexture);
-      sdlTexture = NULL;
+void Gfx::OnWindowResize(uint32_t window_id) {
+  if (window_id == SDL_GetWindowID(sdl_window)) {
+    if (sdl_texture) {
+      SDL_DestroyTexture(sdl_texture);
+      sdl_texture = NULL;
     }
-    sdlTexture =
-        SDL_CreateTexture(sdlRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
-                          doubleRes ? 640 : 320, doubleRes ? 400 : 200);
+    sdl_texture =
+        SDL_CreateTexture(sdl_renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
+                          double_res ? 640 : 320, double_res ? 400 : 200);
 
-    if (sdlDrawSurface) {
-      SDL_DestroySurface(sdlDrawSurface);
-      sdlDrawSurface = NULL;
+    if (sdl_draw_surface) {
+      SDL_DestroySurface(sdl_draw_surface);
+      sdl_draw_surface = NULL;
     }
-    sdlDrawSurface =
-        SDL_CreateSurface(doubleRes ? 640 : 320, doubleRes ? 400 : 200, SDL_PIXELFORMAT_ARGB8888);
+    sdl_draw_surface =
+        SDL_CreateSurface(double_res ? 640 : 320, double_res ? 400 : 200, SDL_PIXELFORMAT_ARGB8888);
     // linear for that old-school chunky look, but consider adding a user
     // option for this
-    SDL_SetTextureScaleMode(sdlTexture, SDL_SCALEMODE_LINEAR);
-    SDL_SetRenderLogicalPresentation(sdlRenderer, doubleRes ? 640 : 320, doubleRes ? 400 : 200,
+    SDL_SetTextureScaleMode(sdl_texture, SDL_SCALEMODE_LINEAR);
+    SDL_SetRenderLogicalPresentation(sdl_renderer, double_res ? 640 : 320, double_res ? 400 : 200,
                                      SDL_LOGICAL_PRESENTATION_LETTERBOX);
   } else {
-    if (sdlSpectatorTexture) {
-      SDL_DestroyTexture(sdlSpectatorTexture);
-      sdlSpectatorTexture = NULL;
+    if (sdl_spectator_texture) {
+      SDL_DestroyTexture(sdl_spectator_texture);
+      sdl_spectator_texture = NULL;
     }
-    if (sdlSpectatorDrawSurface) {
-      SDL_DestroySurface(sdlSpectatorDrawSurface);
-      sdlSpectatorDrawSurface = NULL;
+    if (sdl_spectator_draw_surface) {
+      SDL_DestroySurface(sdl_spectator_draw_surface);
+      sdl_spectator_draw_surface = NULL;
     }
 
-    if (settings->spectatorWindow) {
-      sdlSpectatorTexture = SDL_CreateTexture(sdlSpectatorRenderer, SDL_PIXELFORMAT_ARGB8888,
+    if (settings->spectator_window) {
+      sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
                                               SDL_TEXTUREACCESS_STREAMING, 640, 400);
-      sdlSpectatorDrawSurface = SDL_CreateSurface(640, 400, SDL_PIXELFORMAT_ARGB8888);
-      SDL_SetRenderLogicalPresentation(sdlSpectatorRenderer, 640, 400,
+      sdl_spectator_draw_surface = SDL_CreateSurface(640, 400, SDL_PIXELFORMAT_ARGB8888);
+      SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, 640, 400,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);
     }
   }
 }
 
-void Gfx::loadMenus() {
-  hiddenMenu.addItem(MenuItem(48, 7, "FULLSCREEN (F11)", HiddenMenu::Fullscreen));
-  hiddenMenu.addItem(MenuItem(48, 7, "DOUBLE SIZE", HiddenMenu::DoubleRes));
-  hiddenMenu.addItem(MenuItem(48, 7, "POWERLEVEL PALETTES", HiddenMenu::LoadPowerLevels));
-  hiddenMenu.addItem(MenuItem(48, 7, "SHADOWS", HiddenMenu::Shadows));
-  hiddenMenu.addItem(MenuItem(48, 7, "AUTO-RECORD REPLAYS", HiddenMenu::RecordReplays));
-  hiddenMenu.addItem(MenuItem(48, 7, "AI FRAMES", HiddenMenu::AiFrames));
-  hiddenMenu.addItem(MenuItem(48, 7, "AI MUTATIONS", HiddenMenu::AiMutations));
-  hiddenMenu.addItem(MenuItem(48, 7, "AI PARALLELS", HiddenMenu::AiParallels));
-  hiddenMenu.addItem(MenuItem(48, 7, "AI TRACES", HiddenMenu::AiTraces));
-  hiddenMenu.addItem(MenuItem(48, 7, "PALETTE", HiddenMenu::PaletteSelect));
-  hiddenMenu.addItem(MenuItem(48, 7, "BOT WEAPONS", HiddenMenu::SelectBotWeapons));
-  hiddenMenu.addItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::AllowViewingSpawnPoint));
-  hiddenMenu.addItem(MenuItem(48, 7, "SINGLE SCREEN REPLAY", HiddenMenu::SingleScreenReplay));
-  hiddenMenu.addItem(MenuItem(48, 7, "SPECTATOR WINDOW", HiddenMenu::SpectatorWindow));
+void Gfx::LoadMenus() {
+  hidden_menu.AddItem(MenuItem(48, 7, "FULLSCREEN (F11)", HiddenMenu::kFullscreen));
+  hidden_menu.AddItem(MenuItem(48, 7, "DOUBLE SIZE", HiddenMenu::kDoubleRes));
+  hidden_menu.AddItem(MenuItem(48, 7, "POWERLEVEL PALETTES", HiddenMenu::kLoadPowerLevels));
+  hidden_menu.AddItem(MenuItem(48, 7, "SHADOWS", HiddenMenu::kShadows));
+  hidden_menu.AddItem(MenuItem(48, 7, "AUTO-RECORD REPLAYS", HiddenMenu::kRecordReplays));
+  hidden_menu.AddItem(MenuItem(48, 7, "AI FRAMES", HiddenMenu::kAiFrames));
+  hidden_menu.AddItem(MenuItem(48, 7, "AI MUTATIONS", HiddenMenu::kAiMutations));
+  hidden_menu.AddItem(MenuItem(48, 7, "AI PARALLELS", HiddenMenu::kAiParallels));
+  hidden_menu.AddItem(MenuItem(48, 7, "AI TRACES", HiddenMenu::kAiTraces));
+  hidden_menu.AddItem(MenuItem(48, 7, "PALETTE", HiddenMenu::kPaletteSelect));
+  hidden_menu.AddItem(MenuItem(48, 7, "BOT WEAPONS", HiddenMenu::kSelectBotWeapons));
+  hidden_menu.AddItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::kAllowViewingSpawnPoint));
+  hidden_menu.AddItem(MenuItem(48, 7, "SINGLE SCREEN REPLAY", HiddenMenu::kSingleScreenReplay));
+  hidden_menu.AddItem(MenuItem(48, 7, "SPECTATOR WINDOW", HiddenMenu::kSpectatorWindow));
 
-  playerMenu.addItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::PlLoadedProfile));
-  playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::PlSaveProfile));
-  playerMenu.addItem(MenuItem(3, 7, "SAVE PROFILE AS...", PlayerMenu::PlSaveProfileAs));
-  playerMenu.addItem(MenuItem(3, 7, "LOAD PROFILE", PlayerMenu::PlLoadProfile));
-  playerMenu.addItem(MenuItem(48, 7, "NAME", PlayerMenu::PlName));
-  playerMenu.addItem(MenuItem(48, 7, "HEALTH", PlayerMenu::PlHealth));
-  playerMenu.addItem(MenuItem(48, 7, "Red", PlayerMenu::PlRed));
-  playerMenu.addItem(MenuItem(48, 7, "Green", PlayerMenu::PlGreen));
-  playerMenu.addItem(MenuItem(48, 7, "Blue", PlayerMenu::PlBlue));
-  playerMenu.addItem(MenuItem(48, 7, "INPUT", PlayerMenu::PlInput));
-  playerMenu.addItem(MenuItem(48, 7, "AIM UP", PlayerMenu::PlUp));
-  playerMenu.addItem(MenuItem(48, 7, "AIM DOWN", PlayerMenu::PlDown));
-  playerMenu.addItem(MenuItem(48, 7, "MOVE LEFT", PlayerMenu::PlLeft));
-  playerMenu.addItem(MenuItem(48, 7, "MOVE RIGHT", PlayerMenu::PlRight));
-  playerMenu.addItem(MenuItem(48, 7, "FIRE", PlayerMenu::PlFire));
-  playerMenu.addItem(MenuItem(48, 7, "CHANGE", PlayerMenu::PlChange));
-  playerMenu.addItem(MenuItem(48, 7, "JUMP", PlayerMenu::PlJump));
-  playerMenu.addItem(MenuItem(48, 7, "DIG", PlayerMenu::PlDig));
+  player_menu.AddItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::kPlLoadedProfile));
+  player_menu.AddItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::kPlSaveProfile));
+  player_menu.AddItem(MenuItem(3, 7, "SAVE PROFILE AS...", PlayerMenu::kPlSaveProfileAs));
+  player_menu.AddItem(MenuItem(3, 7, "LOAD PROFILE", PlayerMenu::kPlLoadProfile));
+  player_menu.AddItem(MenuItem(48, 7, "NAME", PlayerMenu::kPlName));
+  player_menu.AddItem(MenuItem(48, 7, "HEALTH", PlayerMenu::kPlHealth));
+  player_menu.AddItem(MenuItem(48, 7, "Red", PlayerMenu::kPlRed));
+  player_menu.AddItem(MenuItem(48, 7, "Green", PlayerMenu::kPlGreen));
+  player_menu.AddItem(MenuItem(48, 7, "Blue", PlayerMenu::kPlBlue));
+  player_menu.AddItem(MenuItem(48, 7, "INPUT", PlayerMenu::kPlInput));
+  player_menu.AddItem(MenuItem(48, 7, "AIM UP", PlayerMenu::kPlUp));
+  player_menu.AddItem(MenuItem(48, 7, "AIM DOWN", PlayerMenu::kPlDown));
+  player_menu.AddItem(MenuItem(48, 7, "MOVE LEFT", PlayerMenu::kPlLeft));
+  player_menu.AddItem(MenuItem(48, 7, "MOVE RIGHT", PlayerMenu::kPlRight));
+  player_menu.AddItem(MenuItem(48, 7, "FIRE", PlayerMenu::kPlFire));
+  player_menu.AddItem(MenuItem(48, 7, "CHANGE", PlayerMenu::kPlChange));
+  player_menu.AddItem(MenuItem(48, 7, "JUMP", PlayerMenu::kPlJump));
+  player_menu.AddItem(MenuItem(48, 7, "DIG", PlayerMenu::kPlDig));
 
   for (int i = 0; i < 5; ++i)
-    playerMenu.addItem(
-        MenuItem(48, 7, std::string("WEAPON ") + (char)(i + '1'), PlayerMenu::PlWeap0 + i));
+    player_menu.AddItem(
+        MenuItem(48, 7, std::string("WEAPON ") + (char)(i + '1'), PlayerMenu::kPlWeap0 + i));
 
-  playerMenu.addItem(MenuItem(48, 7, "CONTROLLER", PlayerMenu::PlController));
+  player_menu.AddItem(MenuItem(48, 7, "CONTROLLER", PlayerMenu::kPlController));
 
-  settingsMenu.addItem(MenuItem(48, 7, "GAME MODE", SettingsMenu::SiGameMode));
-  settingsMenu.addItem(MenuItem(48, 7, "TIME TO LOSE", SettingsMenu::SiTimeToLose));
-  settingsMenu.addItem(MenuItem(48, 7, "TIME TO WIN", SettingsMenu::SiTimeToWin));
-  settingsMenu.addItem(MenuItem(48, 7, "ZONE TIMEOUT", SettingsMenu::SiZoneTimeout));
-  settingsMenu.addItem(MenuItem(48, 7, "FLAGS TO WIN", SettingsMenu::SiFlagsToWin));
-  settingsMenu.addItem(MenuItem(48, 7, "LIVES", SettingsMenu::SiLives));
-  settingsMenu.addItem(MenuItem(48, 7, "LEVEL", SettingsMenu::SiLevel));
-  settingsMenu.addItem(MenuItem(48, 7, "LOADING TIMES", SettingsMenu::SiLoadingTimes));
-  settingsMenu.addItem(MenuItem(48, 7, "WEAPON OPTIONS", SettingsMenu::SiWeaponOptions));
-  settingsMenu.addItem(MenuItem(48, 7, "MAX BONUSES", SettingsMenu::SiMaxBonuses));
-  settingsMenu.addItem(MenuItem(48, 7, "NAMES ON BONUSES", SettingsMenu::SiNamesOnBonuses));
-  settingsMenu.addItem(MenuItem(48, 7, "MAP", SettingsMenu::SiMap));
-  settingsMenu.addItem(MenuItem(48, 7, "AMOUNT OF BLOOD", SettingsMenu::SiAmountOfBlood));
-  settingsMenu.addItem(MenuItem(48, 7, "LOAD+CHANGE", SettingsMenu::LoadChange));
-  settingsMenu.addItem(MenuItem(48, 7, "REGENERATE LEVEL", SettingsMenu::SiRegenerateLevel));
-  settingsMenu.addItem(MenuItem(48, 7, "SAVE SETUP AS...", SettingsMenu::SaveOptions));
-  settingsMenu.addItem(MenuItem(48, 7, "LOAD SETUP", SettingsMenu::LoadOptions));
+  settings_menu.AddItem(MenuItem(48, 7, "GAME MODE", SettingsMenu::kSiGameMode));
+  settings_menu.AddItem(MenuItem(48, 7, "TIME TO LOSE", SettingsMenu::kSiTimeToLose));
+  settings_menu.AddItem(MenuItem(48, 7, "TIME TO WIN", SettingsMenu::kSiTimeToWin));
+  settings_menu.AddItem(MenuItem(48, 7, "ZONE TIMEOUT", SettingsMenu::kSiZoneTimeout));
+  settings_menu.AddItem(MenuItem(48, 7, "FLAGS TO WIN", SettingsMenu::kSiFlagsToWin));
+  settings_menu.AddItem(MenuItem(48, 7, "LIVES", SettingsMenu::kSiLives));
+  settings_menu.AddItem(MenuItem(48, 7, "LEVEL", SettingsMenu::kSiLevel));
+  settings_menu.AddItem(MenuItem(48, 7, "LOADING TIMES", SettingsMenu::kSiLoadingTimes));
+  settings_menu.AddItem(MenuItem(48, 7, "WEAPON OPTIONS", SettingsMenu::kSiWeaponOptions));
+  settings_menu.AddItem(MenuItem(48, 7, "MAX BONUSES", SettingsMenu::kSiMaxBonuses));
+  settings_menu.AddItem(MenuItem(48, 7, "NAMES ON BONUSES", SettingsMenu::kSiNamesOnBonuses));
+  settings_menu.AddItem(MenuItem(48, 7, "MAP", SettingsMenu::kSiMap));
+  settings_menu.AddItem(MenuItem(48, 7, "AMOUNT OF BLOOD", SettingsMenu::kSiAmountOfBlood));
+  settings_menu.AddItem(MenuItem(48, 7, "LOAD+CHANGE", SettingsMenu::kLoadChange));
+  settings_menu.AddItem(MenuItem(48, 7, "REGENERATE LEVEL", SettingsMenu::kSiRegenerateLevel));
+  settings_menu.AddItem(MenuItem(48, 7, "SAVE SETUP AS...", SettingsMenu::kSaveOptions));
+  settings_menu.AddItem(MenuItem(48, 7, "LOAD SETUP", SettingsMenu::kLoadOptions));
 
-  mainMenu.addItem(
-      MenuItem(10, 10, "", MainMenu::MaResumeGame));  // string set in MainMenuState::enter()
-  mainMenu.addItem(
-      MenuItem(10, 10, "", MainMenu::MaNewGame));  // string set in MainMenuState::enter()
-  mainMenu.addItem(MenuItem(48, 48, "HOST LAN GAME", MainMenu::MaHostGame));
-  mainMenu.addItem(MenuItem(48, 48, "JOIN LAN GAME", MainMenu::MaJoinGame));
-  mainMenu.addItem(MenuItem(48, 48, "HOST ONLINE", MainMenu::MaHostOnline));
-  mainMenu.addItem(MenuItem(48, 48, "JOIN ONLINE", MainMenu::MaJoinOnline));
-  mainMenu.addItem(MenuItem(48, 48, "OPTIONS (F2)", MainMenu::MaAdvanced));
-  mainMenu.addItem(MenuItem(48, 48, "REPLAYS (F3)", MainMenu::MaReplays));
-  mainMenu.addItem(MenuItem(48, 48, "TC", MainMenu::MaTc));
-  mainMenu.addItem(MenuItem(6, 6, "QUIT TO OS", MainMenu::MaQuit));
-  mainMenu.addItem(MenuItem::space());
-  mainMenu.addItem(MenuItem(48, 48, "LEFT PLAYER (F5)", MainMenu::MaPlayer1Settings));
-  mainMenu.addItem(MenuItem(48, 48, "RIGHT PLAYER (F6)", MainMenu::MaPlayer2Settings));
-  mainMenu.addItem(MenuItem(48, 48, "NETWORK PLAYER (F9)", MainMenu::MaNetPlayerSettings));
-  mainMenu.addItem(MenuItem(48, 48, "MATCH SETUP (F7)", MainMenu::MaSettings));
+  main_menu.AddItem(
+      MenuItem(10, 10, "", MainMenu::kMaResumeGame));  // string set in MainMenuState::enter()
+  main_menu.AddItem(
+      MenuItem(10, 10, "", MainMenu::kMaNewGame));  // string set in MainMenuState::enter()
+  main_menu.AddItem(MenuItem(48, 48, "HOST LAN GAME", MainMenu::kMaHostGame));
+  main_menu.AddItem(MenuItem(48, 48, "JOIN LAN GAME", MainMenu::kMaJoinGame));
+  main_menu.AddItem(MenuItem(48, 48, "HOST ONLINE", MainMenu::kMaHostOnline));
+  main_menu.AddItem(MenuItem(48, 48, "JOIN ONLINE", MainMenu::kMaJoinOnline));
+  main_menu.AddItem(MenuItem(48, 48, "OPTIONS (F2)", MainMenu::kMaAdvanced));
+  main_menu.AddItem(MenuItem(48, 48, "REPLAYS (F3)", MainMenu::kMaReplays));
+  main_menu.AddItem(MenuItem(48, 48, "TC", MainMenu::kMaTc));
+  main_menu.AddItem(MenuItem(6, 6, "QUIT TO OS", MainMenu::kMaQuit));
+  main_menu.AddItem(MenuItem::Space());
+  main_menu.AddItem(MenuItem(48, 48, "LEFT PLAYER (F5)", MainMenu::kMaPlayer1Settings));
+  main_menu.AddItem(MenuItem(48, 48, "RIGHT PLAYER (F6)", MainMenu::kMaPlayer2Settings));
+  main_menu.AddItem(MenuItem(48, 48, "NETWORK PLAYER (F9)", MainMenu::kMaNetPlayerSettings));
+  main_menu.AddItem(MenuItem(48, 48, "MATCH SETUP (F7)", MainMenu::kMaSettings));
 
-  settingsMenu.valueOffsetX = 100;
-  playerMenu.valueOffsetX = 95;
-  hiddenMenu.valueOffsetX = 120;
+  settings_menu.value_offset_x = 100;
+  player_menu.value_offset_x = 95;
+  hidden_menu.value_offset_x = 120;
 }
 
-void Gfx::setSpectatorFullscreen(bool newFullscreen) {
-  if (newFullscreen == spectatorFullscreen) return;
-  spectatorFullscreen = newFullscreen;
+void Gfx::SetSpectatorFullscreen(bool new_fullscreen) {
+  if (new_fullscreen == spectator_fullscreen) return;
+  spectator_fullscreen = new_fullscreen;
 
-  if (!spectatorFullscreen) {
-    if (doubleRes) {
-      windowW = 640;
-      windowH = 400;
+  if (!spectator_fullscreen) {
+    if (double_res) {
+      window_w = 640;
+      window_h = 400;
     } else {
-      windowW = 320;
-      windowH = 200;
+      window_w = 320;
+      window_h = 200;
     }
   }
-  setVideoMode();
+  SetVideoMode();
 }
 
-void Gfx::setFullscreen(bool newFullscreen) {
-  if (newFullscreen == settings->fullscreen) return;
-  settings->fullscreen = newFullscreen;
+void Gfx::SetFullscreen(bool new_fullscreen) {
+  if (new_fullscreen == settings->fullscreen) return;
+  settings->fullscreen = new_fullscreen;
 
   // fullscreen will automatically set window size
   if (!settings->fullscreen) {
-    if (doubleRes) {
-      windowW = 640;
-      windowH = 400;
+    if (double_res) {
+      window_w = 640;
+      window_h = 400;
     } else {
-      windowW = 320;
-      windowH = 200;
+      window_w = 320;
+      window_h = 200;
     }
   }
-  setVideoMode();
-  hiddenMenu.updateItems(*common);
+  SetVideoMode();
+  hidden_menu.UpdateItems(*common);
 }
 
-void Gfx::setDoubleRes(bool newDoubleRes) {
-  if (newDoubleRes == doubleRes) return;
-  doubleRes = newDoubleRes;
+void Gfx::SetDoubleRes(bool new_double_res) {
+  if (new_double_res == double_res) return;
+  double_res = new_double_res;
 
-  if (!newDoubleRes) {
-    windowW = 320;
-    windowH = 200;
+  if (!new_double_res) {
+    window_w = 320;
+    window_h = 200;
   } else {
-    windowW = 640;
-    windowH = 400;
+    window_w = 640;
+    window_h = 400;
   }
-  setVideoMode();
-  hiddenMenu.updateItems(*common);
+  SetVideoMode();
+  hidden_menu.UpdateItems(*common);
 }
 
-void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
+void Gfx::ProcessEvent(SDL_Event& ev, Controller* controller) {
   switch (ev.type) {
     case SDL_EVENT_KEY_DOWN: {
       SDL_Scancode s = ev.key.scancode;
 
-      if (keyBufPtr < keyBuf + 32) *keyBufPtr++ = ev.key.scancode;
+      if (key_buf_ptr < key_buf + 32) *key_buf_ptr++ = ev.key.scancode;
 
-      uint32_t dosScan = SDLToDOSKey(ev.key.scancode);
-      if (dosScan) {
-        dosKeys[dosScan] = true;
-        if (controller && !ev.key.repeat) controller->onKey(dosScan, true);
+      uint32_t dos_scan = SDLToDOSKey(ev.key.scancode);
+      if (dos_scan) {
+        dos_keys[dos_scan] = true;
+        if (controller && !ev.key.repeat) controller->OnKey(dos_scan, true);
       }
 
       if (s == SDL_SCANCODE_F11) {
-        if (SDL_GetWindowFromID(ev.key.windowID) == sdlWindow) {
-          setFullscreen(!settings->fullscreen);
+        if (SDL_GetWindowFromID(ev.key.windowID) == sdl_window) {
+          SetFullscreen(!settings->fullscreen);
         } else {
-          setSpectatorFullscreen(!spectatorFullscreen);
+          SetSpectatorFullscreen(!spectator_fullscreen);
         }
       }
 
@@ -560,15 +560,15 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
     case SDL_EVENT_KEY_UP: {
       SDL_Scancode s = ev.key.scancode;
 
-      uint32_t dosScan = SDLToDOSKey(s);
-      if (dosScan) {
-        dosKeys[dosScan] = false;
-        if (controller) controller->onKey(dosScan, false);
+      uint32_t dos_scan = SDLToDOSKey(s);
+      if (dos_scan) {
+        dos_keys[dos_scan] = false;
+        if (controller) controller->OnKey(dos_scan, false);
       }
     } break;
 
     case SDL_EVENT_WINDOW_RESIZED: {
-      onWindowResize(ev.window.windowID);
+      OnWindowResize(ev.window.windowID);
     } break;
 
     case SDL_EVENT_QUIT: {
@@ -576,41 +576,41 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
     } break;
 
     case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
-      int gpIdx = findGamepadIndex(ev.gaxis.which);
-      if (gpIdx < 0) break;
-      Joystick& js = joysticks[gpIdx];
+      int gp_idx = FindGamepadIndex(ev.gaxis.which);
+      if (gp_idx < 0) break;
+      Joystick& js = joysticks[gp_idx];
       int axis = ev.gaxis.axis;
 
-      bool posState = (ev.gaxis.value > JoyAxisThreshold);
-      bool negState = (ev.gaxis.value < -JoyAxisThreshold);
+      bool pos_state = (ev.gaxis.value > kJoyAxisThreshold);
+      bool neg_state = (ev.gaxis.value < -kJoyAxisThreshold);
 
-      int posIdx = axis * 2;
-      int negIdx = axis * 2 + 1;
+      int pos_idx = axis * 2;
+      int neg_idx = axis * 2 + 1;
 
-      if (posState != js.axisButtonState[posIdx]) {
-        js.axisButtonState[posIdx] = posState;
-        if (posState) js.axisPressed[posIdx] = true;
-        dispatchGamepadInput(gpIdx, WormSettingsExtensions::gamepadAxisPositive(axis), posState,
+      if (pos_state != js.axis_button_state[pos_idx]) {
+        js.axis_button_state[pos_idx] = pos_state;
+        if (pos_state) js.axis_pressed[pos_idx] = true;
+        DispatchGamepadInput(gp_idx, WormSettingsExtensions::GamepadAxisPositive(axis), pos_state,
                              controller);
       }
-      if (negState != js.axisButtonState[negIdx]) {
-        js.axisButtonState[negIdx] = negState;
-        if (negState) js.axisPressed[negIdx] = true;
-        dispatchGamepadInput(gpIdx, WormSettingsExtensions::gamepadAxisNegative(axis), negState,
+      if (neg_state != js.axis_button_state[neg_idx]) {
+        js.axis_button_state[neg_idx] = neg_state;
+        if (neg_state) js.axis_pressed[neg_idx] = true;
+        DispatchGamepadInput(gp_idx, WormSettingsExtensions::GamepadAxisNegative(axis), neg_state,
                              controller);
       }
     } break;
 
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
     case SDL_EVENT_GAMEPAD_BUTTON_UP: {
-      int gpIdx = findGamepadIndex(ev.gbutton.which);
-      if (gpIdx < 0) break;
-      Joystick& js = joysticks[gpIdx];
+      int gp_idx = FindGamepadIndex(ev.gbutton.which);
+      if (gp_idx < 0) break;
+      Joystick& js = joysticks[gp_idx];
       int btn = ev.gbutton.button;
       bool state = ev.gbutton.down;
-      js.btnState[btn] = state;
-      if (state) js.btnPressed[btn] = true;
-      dispatchGamepadInput(gpIdx, (uint32_t)btn, state, controller);
+      js.btn_state[btn] = state;
+      if (state) js.btn_pressed[btn] = true;
+      DispatchGamepadInput(gp_idx, (uint32_t)btn, state, controller);
     } break;
 
     case SDL_EVENT_GAMEPAD_ADDED: {
@@ -618,9 +618,9 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
       // Only track up to 2 gamepads
       if (joysticks.size() < 2) {
         Joystick js;
-        js.sdlGamepad = SDL_OpenGamepad(id);
-        js.instanceId = id;
-        js.clearState();
+        js.sdl_gamepad = SDL_OpenGamepad(id);
+        js.instance_id = id;
+        js.ClearState();
         joysticks.push_back(js);
       }
     } break;
@@ -628,8 +628,8 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
     case SDL_EVENT_GAMEPAD_REMOVED: {
       SDL_JoystickID id = ev.gdevice.which;
       for (auto it = joysticks.begin(); it != joysticks.end(); ++it) {
-        if (it->instanceId == id) {
-          SDL_CloseGamepad(it->sdlGamepad);
+        if (it->instance_id == id) {
+          SDL_CloseGamepad(it->sdl_gamepad);
           joysticks.erase(it);
           break;
         }
@@ -641,37 +641,37 @@ void Gfx::processEvent(SDL_Event& ev, Controller* controller) {
   }
 }
 
-void Gfx::process(Controller* controller) {
+void Gfx::Process(Controller* controller) {
   SDL_Event ev;
-  keyBufPtr = keyBuf;
+  key_buf_ptr = key_buf;
   while (SDL_PollEvent(&ev)) {
-    processEvent(ev, controller);
+    ProcessEvent(ev, controller);
   }
 }
 
-int Gfx::findGamepadIndex(SDL_JoystickID id) {
+int Gfx::FindGamepadIndex(SDL_JoystickID id) {
   for (int i = 0; i < (int)joysticks.size(); ++i) {
-    if (joysticks[i].instanceId == id) return i;
+    if (joysticks[i].instance_id == id) return i;
   }
   return -1;
 }
 
-int Gfx::findGamepadForPlayer(int playerIdx) {
-  if (!settings || playerIdx < 0 || playerIdx >= 2) return -1;
-  WormSettings& ws = *settings->wormSettings[playerIdx];
-  if (ws.inputDevice == WormSettingsExtensions::InputKeyboard) return -1;
-  if (ws.gamepadName.empty()) return -1;
+int Gfx::FindGamepadForPlayer(int player_idx) {
+  if (!settings || player_idx < 0 || player_idx >= 2) return -1;
+  WormSettings& ws = *settings->worm_settings[player_idx];
+  if (ws.input_device == WormSettingsExtensions::kInputKeyboard) return -1;
+  if (ws.gamepad_name.empty()) return -1;
 
   // Collect indices of gamepads matching by name
   std::vector<int> candidates;
   for (int i = 0; i < (int)joysticks.size(); ++i) {
-    char const* n = SDL_GetGamepadName(joysticks[i].sdlGamepad);
-    if (!n || ws.gamepadName != n) continue;
+    char const* n = SDL_GetGamepadName(joysticks[i].sdl_gamepad);
+    if (!n || ws.gamepad_name != n) continue;
 
     // Exact serial match is best
-    if (!ws.gamepadSerial.empty()) {
-      char const* s = SDL_GetGamepadSerial(joysticks[i].sdlGamepad);
-      if (s && ws.gamepadSerial == s) return i;
+    if (!ws.gamepad_serial.empty()) {
+      char const* s = SDL_GetGamepadSerial(joysticks[i].sdl_gamepad);
+      if (s && ws.gamepad_serial == s) return i;
     }
     candidates.push_back(i);
   }
@@ -681,109 +681,109 @@ int Gfx::findGamepadForPlayer(int playerIdx) {
   // No serial match — resolve by position among same-name candidates.
   // If the other player also wants a gamepad with the same name,
   // give the first candidate to player 0 and the second to player 1.
-  int otherPlayer = 1 - playerIdx;
-  WormSettings& otherWs = *settings->wormSettings[otherPlayer];
-  if (candidates.size() >= 2 && otherWs.inputDevice != WormSettingsExtensions::InputKeyboard &&
-      otherWs.gamepadName == ws.gamepadName) {
+  int other_player = 1 - player_idx;
+  WormSettings& other_ws = *settings->worm_settings[other_player];
+  if (candidates.size() >= 2 && other_ws.input_device != WormSettingsExtensions::kInputKeyboard &&
+      other_ws.gamepad_name == ws.gamepad_name) {
     // Both players want same-named gamepad — split by player index
-    return candidates[playerIdx < otherPlayer ? 0 : 1];
+    return candidates[player_idx < other_player ? 0 : 1];
   }
 
   return candidates[0];
 }
 
-void Gfx::dispatchGamepadInput(int gpIdx, uint32_t gamepadKey, bool state, Controller* controller) {
-  if (gpIdx < 0 || gpIdx >= 2) return;
+void Gfx::DispatchGamepadInput(int gp_idx, uint32_t gamepad_key, bool state, Controller* controller) {
+  if (gp_idx < 0 || gp_idx >= 2) return;
 
   // Start button acts as ESC for menu access
-  if (gamepadKey == (uint32_t)SDL_GAMEPAD_BUTTON_START && state) {
-    dosKeys[DkEscape] = true;
-    if (controller) controller->onKey(DkEscape, true);
+  if (gamepad_key == (uint32_t)SDL_GAMEPAD_BUTTON_START && state) {
+    dos_keys[kDkEscape] = true;
+    if (controller) controller->OnKey(kDkEscape, true);
     return;
   }
 
   // Dispatch to the controller for the player who has this gamepad assigned
   if (controller) {
     for (int p = 0; p < 2; ++p) {
-      WormSettings& ws = *settings->wormSettings[p];
-      if (ws.inputDevice == WormSettingsExtensions::InputKeyboard) continue;
-      if (findGamepadForPlayer(p) != gpIdx) continue;
+      WormSettings& ws = *settings->worm_settings[p];
+      if (ws.input_device == WormSettingsExtensions::kInputKeyboard) continue;
+      if (FindGamepadForPlayer(p) != gp_idx) continue;
 
-      for (int c = 0; c < WormSettings::MaxControlEx; ++c) {
-        if (ws.gamepadControls[c] == gamepadKey)
-          controller->onKey(gamepadControlToExKey(p, c), state);
+      for (int c = 0; c < WormSettings::kMaxControlEx; ++c) {
+        if (ws.gamepad_controls[c] == gamepad_key)
+          controller->OnKey(GamepadControlToExKey(p, c), state);
       }
     }
   }
 }
 
-std::string Gfx::getKeyName(uint32_t key) {
-  if (key < MaxDOSKey) {
-    return common->texts.keyNames[key];
-  } else if (key >= JoyKeysStart) {
-    key -= JoyKeysStart;
-    int joyNum = key / MaxJoyButtons;
-    key -= joyNum * MaxJoyButtons;
-    return "J" + toString(joyNum) + "_" + toString(key);
+std::string Gfx::GetKeyName(uint32_t key) {
+  if (key < kMaxDosKey) {
+    return common->texts.key_names[key];
+  } else if (key >= kJoyKeysStart) {
+    key -= kJoyKeysStart;
+    int joy_num = key / kMaxJoyButtons;
+    key -= joy_num * kMaxJoyButtons;
+    return "J" + ToString(joy_num) + "_" + ToString(key);
   }
 
   return "";
 }
 
-std::string Gfx::getGamepadKeyName(uint32_t gamepadKey) {
-  if (WormSettingsExtensions::isGamepadAxis(gamepadKey)) {
-    int axis = (gamepadKey - WormSettingsExtensions::GamepadAxisBase) / 2;
-    bool negative = (gamepadKey - WormSettingsExtensions::GamepadAxisBase) % 2;
-    static char const* axisNames[] = {"LX", "LY", "RX", "RY", "LT", "RT"};
-    std::string name = (axis < 6) ? axisNames[axis] : "A" + toString(axis);
+std::string Gfx::GetGamepadKeyName(uint32_t gamepad_key) {
+  if (WormSettingsExtensions::IsGamepadAxis(gamepad_key)) {
+    int axis = (gamepad_key - WormSettingsExtensions::kGamepadAxisBase) / 2;
+    bool negative = (gamepad_key - WormSettingsExtensions::kGamepadAxisBase) % 2;
+    static char const* axis_names[] = {"LX", "LY", "RX", "RY", "LT", "RT"};
+    std::string name = (axis < 6) ? axis_names[axis] : "A" + ToString(axis);
     return name + (negative ? "-" : "+");
   }
 
-  static char const* buttonNames[] = {"A",  "B",  "X",  "Y",  "Back", "Guide", "Start", "LS",
+  static char const* button_names[] = {"A",  "B",  "X",  "Y",  "Back", "Guide", "Start", "LS",
                                       "RS", "LB", "RB", "Up", "Down", "Left",  "Right"};
 
-  if (gamepadKey < 15) return buttonNames[gamepadKey];
+  if (gamepad_key < 15) return button_names[gamepad_key];
 
-  return "Btn" + toString(gamepadKey);
+  return "Btn" + ToString(gamepad_key);
 }
 
-void Gfx::clearKeys() {
-  std::memset(dosKeys, 0, sizeof(dosKeys));
-  exKeys.clear();
-  for (auto& js : joysticks) js.clearState();
+void Gfx::ClearKeys() {
+  std::memset(dos_keys, 0, sizeof(dos_keys));
+  ex_keys.clear();
+  for (auto& js : joysticks) js.ClearState();
 }
 
-bool Gfx::testControlOnce(int control) {
+bool Gfx::TestControlOnce(int control) {
   // Check keyboard bindings for all player profiles (left, right, network)
-  for (int p = 0; p < Settings::NumWormSettings; ++p) {
-    if (settings->wormSettings[p]->inputDevice != WormSettingsExtensions::InputKeyboard) continue;
-    uint32_t key = settings->extensions ? settings->wormSettings[p]->controlsEx[control]
-                                        : settings->wormSettings[p]->controls[control];
-    if (testAnyKeyOnce(key)) return true;
+  for (int p = 0; p < Settings::kNumWormSettings; ++p) {
+    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard) continue;
+    uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
+                                        : settings->worm_settings[p]->controls[control];
+    if (TestAnyKeyOnce(key)) return true;
   }
   return false;
 }
 
-bool Gfx::testGamepadButtonOnce(int button) {
+bool Gfx::TestGamepadButtonOnce(int button) {
   for (int gp = 0; gp < (int)joysticks.size(); ++gp) {
-    if (joysticks[gp].btnPressed[button]) {
-      joysticks[gp].btnPressed[button] = false;
+    if (joysticks[gp].btn_pressed[button]) {
+      joysticks[gp].btn_pressed[button] = false;
       return true;
     }
   }
   return false;
 }
 
-bool Gfx::testGamepadButton(int button) {
+bool Gfx::TestGamepadButton(int button) {
   for (int gp = 0; gp < (int)joysticks.size(); ++gp) {
-    if (joysticks[gp].btnState[button]) return true;
+    if (joysticks[gp].btn_state[button]) return true;
   }
   return false;
 }
 
 // Map DPad button to left stick axis index (-1 if not a directional button)
-static int dpadToAxisIndex(int dpadButton) {
-  switch (dpadButton) {
+static int DpadToAxisIndex(int dpad_button) {
+  switch (dpad_button) {
     case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
       return 0;  // LEFTX positive
     case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
@@ -797,157 +797,157 @@ static int dpadToAxisIndex(int dpadButton) {
   }
 }
 
-bool Gfx::testGamepadDirOnce(int dpadButton) {
-  int axisIdx = dpadToAxisIndex(dpadButton);
+bool Gfx::TestGamepadDirOnce(int dpad_button) {
+  int axis_idx = DpadToAxisIndex(dpad_button);
   for (int gp = 0; gp < (int)joysticks.size(); ++gp) {
-    if (joysticks[gp].btnPressed[dpadButton]) {
-      joysticks[gp].btnPressed[dpadButton] = false;
-      if (axisIdx >= 0) joysticks[gp].axisPressed[axisIdx] = false;
+    if (joysticks[gp].btn_pressed[dpad_button]) {
+      joysticks[gp].btn_pressed[dpad_button] = false;
+      if (axis_idx >= 0) joysticks[gp].axis_pressed[axis_idx] = false;
       return true;
     }
-    if (axisIdx >= 0 && joysticks[gp].axisPressed[axisIdx]) {
-      joysticks[gp].axisPressed[axisIdx] = false;
-      joysticks[gp].btnPressed[dpadButton] = false;
+    if (axis_idx >= 0 && joysticks[gp].axis_pressed[axis_idx]) {
+      joysticks[gp].axis_pressed[axis_idx] = false;
+      joysticks[gp].btn_pressed[dpad_button] = false;
       return true;
     }
   }
   return false;
 }
 
-bool Gfx::testGamepadDir(int dpadButton) {
-  int axisIdx = dpadToAxisIndex(dpadButton);
+bool Gfx::TestGamepadDir(int dpad_button) {
+  int axis_idx = DpadToAxisIndex(dpad_button);
   for (int gp = 0; gp < (int)joysticks.size(); ++gp) {
-    if (joysticks[gp].btnState[dpadButton]) return true;
-    if (axisIdx >= 0 && joysticks[gp].axisButtonState[axisIdx]) return true;
+    if (joysticks[gp].btn_state[dpad_button]) return true;
+    if (axis_idx >= 0 && joysticks[gp].axis_button_state[axis_idx]) return true;
   }
   return false;
 }
 
-bool Gfx::testControl(int control) {
+bool Gfx::TestControl(int control) {
   // Check keyboard bindings for all player profiles (left, right, network)
-  for (int p = 0; p < Settings::NumWormSettings; ++p) {
-    if (settings->wormSettings[p]->inputDevice != WormSettingsExtensions::InputKeyboard) continue;
-    uint32_t key = settings->extensions ? settings->wormSettings[p]->controlsEx[control]
-                                        : settings->wormSettings[p]->controls[control];
-    if (testAnyKey(key)) return true;
+  for (int p = 0; p < Settings::kNumWormSettings; ++p) {
+    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard) continue;
+    uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
+                                        : settings->worm_settings[p]->controls[control];
+    if (TestAnyKey(key)) return true;
   }
   return false;
 }
 
-void Gfx::releaseControl(int control) {
-  for (int p = 0; p < Settings::NumWormSettings; ++p) {
-    uint32_t key = settings->extensions ? settings->wormSettings[p]->controlsEx[control]
-                                        : settings->wormSettings[p]->controls[control];
-    releaseAnyKey(key);
+void Gfx::ReleaseControl(int control) {
+  for (int p = 0; p < Settings::kNumWormSettings; ++p) {
+    uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
+                                        : settings->worm_settings[p]->controls[control];
+    ReleaseAnyKey(key);
   }
 }
 
-void Gfx::preparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette,
-                         Color realPal[256], uint32_t (&pal32)[256]) {
+void Gfx::PreparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette,
+                         Color real_pal[256], uint32_t (&pal32)[256]) {
   for (int i = 0; i < 256; ++i) {
-    pal32[i] = SDL_MapRGB(format, palette, realPal[i].r, realPal[i].g, realPal[i].b);
+    pal32[i] = SDL_MapRGB(format, palette, real_pal[i].r, real_pal[i].g, real_pal[i].b);
   }
 }
 
-void Gfx::menuFlip(bool quitting) {
-  if (playRenderer.fadeValue < 32 && !quitting) ++playRenderer.fadeValue;
-  if (singleScreenRenderer.fadeValue < 32 && !quitting) ++singleScreenRenderer.fadeValue;
+void Gfx::MenuFlip(bool quitting) {
+  if (play_renderer.fade_value < 32 && !quitting) ++play_renderer.fade_value;
+  if (single_screen_renderer.fade_value < 32 && !quitting) ++single_screen_renderer.fade_value;
 
-  ++menuCycles;
-  playRenderer.pal = playRenderer.origpal;
-  playRenderer.pal.rotateFrom(playRenderer.origpal, 168, 174, menuCycles);
-  playRenderer.pal.setWormColours(*settings);
-  if (curMenu == &playerMenu && playerMenu.ws == settings->wormSettings[Settings::NetworkPlayerIdx])
-    playRenderer.pal.setWormColour(0, *playerMenu.ws);
-  playRenderer.pal.fade(playRenderer.fadeValue);
-  singleScreenRenderer.pal = singleScreenRenderer.origpal;
-  singleScreenRenderer.pal.rotateFrom(singleScreenRenderer.origpal, 168, 174, menuCycles);
-  singleScreenRenderer.pal.setWormColours(*settings);
-  if (curMenu == &playerMenu && playerMenu.ws == settings->wormSettings[Settings::NetworkPlayerIdx])
-    singleScreenRenderer.pal.setWormColour(0, *playerMenu.ws);
-  singleScreenRenderer.pal.fade(singleScreenRenderer.fadeValue);
-  flip();
+  ++menu_cycles;
+  play_renderer.pal = play_renderer.origpal;
+  play_renderer.pal.RotateFrom(play_renderer.origpal, 168, 174, menu_cycles);
+  play_renderer.pal.SetWormColours(*settings);
+  if (cur_menu == &player_menu && player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
+    play_renderer.pal.SetWormColour(0, *player_menu.ws);
+  play_renderer.pal.Fade(play_renderer.fade_value);
+  single_screen_renderer.pal = single_screen_renderer.origpal;
+  single_screen_renderer.pal.RotateFrom(single_screen_renderer.origpal, 168, 174, menu_cycles);
+  single_screen_renderer.pal.SetWormColours(*settings);
+  if (cur_menu == &player_menu && player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
+    single_screen_renderer.pal.SetWormColour(0, *player_menu.ws);
+  single_screen_renderer.pal.Fade(single_screen_renderer.fade_value);
+  Flip();
 }
 
-void Gfx::draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdlRenderer,
+void Gfx::Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_renderer,
                Renderer& renderer) {
-  Rect updateRect;
-  Color realPal[256];
-  renderer.pal.activate(realPal);
-  int offsetX, offsetY;
+  Rect update_rect;
+  Color real_pal[256];
+  renderer.pal.Activate(real_pal);
+  int offset_x, offset_y;
   int mag =
-      fitScreen(surface.w, surface.h, renderer.renderResX, renderer.renderResY, offsetX, offsetY);
+      FitScreen(surface.w, surface.h, renderer.render_res_x, renderer.render_res_y, offset_x, offset_y);
 
-  Rect newRect(offsetX, offsetY, renderer.renderResX * mag, renderer.renderResY * mag);
+  Rect new_rect(offset_x, offset_y, renderer.render_res_x * mag, renderer.render_res_y * mag);
 
-  if (mag != prevMag) {
+  if (mag != prev_mag) {
     // Clear background if magnification is decreased to
     // avoid leftovers.
     SDL_FillSurfaceRect(&surface, 0, 0);
-    updateRect = lastUpdateRect | newRect;
+    update_rect = last_update_rect | new_rect;
   } else
-    updateRect = newRect;
-  prevMag = mag;
+    update_rect = new_rect;
+  prev_mag = mag;
 
-  std::size_t destPitch = surface.pitch;
-  std::size_t srcPitch = renderer.bmp.pitch;
+  std::size_t dest_pitch = surface.pitch;
+  std::size_t src_pitch = renderer.bmp.pitch;
 
-  SDL_PixelFormatDetails const* formatDetails = SDL_GetPixelFormatDetails(surface.format);
-  PalIdx* dest = reinterpret_cast<PalIdx*>(surface.pixels) + offsetY * destPitch +
-                 offsetX * formatDetails->bytes_per_pixel;
+  SDL_PixelFormatDetails const* format_details = SDL_GetPixelFormatDetails(surface.format);
+  PalIdx* dest = reinterpret_cast<PalIdx*>(surface.pixels) + offset_y * dest_pitch +
+                 offset_x * format_details->bytes_per_pixel;
   PalIdx* src = renderer.bmp.pixels;
 
   uint32_t pal32[256];
-  preparePalette(formatDetails, NULL, realPal, pal32);
-  scaleDraw(src, renderer.renderResX, renderer.renderResY, srcPitch, dest, destPitch, mag, pal32);
+  PreparePalette(format_details, NULL, real_pal, pal32);
+  ScaleDraw(src, renderer.render_res_x, renderer.render_res_y, src_pitch, dest, dest_pitch, mag, pal32);
 
   SDL_UpdateTexture(&texture, NULL, surface.pixels, surface.w * 4);
-  SDL_RenderClear(&sdlRenderer);
-  SDL_RenderTexture(&sdlRenderer, &texture, NULL, NULL);
-  SDL_RenderPresent(&sdlRenderer);
+  SDL_RenderClear(&sdl_renderer);
+  SDL_RenderTexture(&sdl_renderer, &texture, NULL, NULL);
+  SDL_RenderPresent(&sdl_renderer);
 
-  lastUpdateRect = updateRect;
+  last_update_rect = update_rect;
 }
 
-void Gfx::flip() {
+void Gfx::Flip() {
   // draw into the play window. This uses either the normal split screen renderer
   // or the single screen renderer if this is a replay and single screen replay
   // is turned on
-  draw(*sdlDrawSurface, *sdlTexture, *sdlRenderer, *primaryRenderer);
-  if (settings->spectatorWindow) {
-    draw(*sdlSpectatorDrawSurface, *sdlSpectatorTexture, *sdlSpectatorRenderer,
-         singleScreenRenderer);
+  Draw(*sdl_draw_surface, *sdl_texture, *sdl_renderer, *primary_renderer);
+  if (settings->spectator_window) {
+    Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer,
+         single_screen_renderer);
   }
 
-  static unsigned int const delay = 14u;
+  static unsigned int const kDelay = 14u;
 
-  auto wantedTime = lastFrame + delay;
+  auto wanted_time = last_frame + kDelay;
 
   while (true) {
     auto now = SDL_GetTicks();
-    if (now >= wantedTime) break;
+    if (now >= wanted_time) break;
 
-    SDL_Delay((uint32_t)(wantedTime - now));
+    SDL_Delay((uint32_t)(wanted_time - now));
   }
 
-  lastFrame = wantedTime;
+  last_frame = wanted_time;
 }
 
-void playChangeSound(Common& common, int change) {
+void PlayChangeSound(Common& common, int change) {
   if (change > 0) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
   } else {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
   }
 }
 
-void resetLeftRight() {
-  gfx.releaseSDLKey(SDL_SCANCODE_LEFT);
-  gfx.releaseSDLKey(SDL_SCANCODE_RIGHT);
+void ResetLeftRight() {
+  gfx.ReleaseSdlKey(SDL_SCANCODE_LEFT);
+  gfx.ReleaseSdlKey(SDL_SCANCODE_RIGHT);
 }
 
 template <typename T>
-void changeVariable(T& var, T change, T min, T max, T scale) {
+void ChangeVariable(T& var, T change, T min, T max, T scale) {
   if (change < 0 && var > min) {
     var += change * scale;
   }
@@ -966,14 +966,14 @@ struct ProfileLoadBehavior : ItemBehavior {
 struct LevelSelectBehavior : ItemBehavior {
   LevelSelectBehavior(Common& common) : common(common) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    item.hasValue = true;
-    if (!gfx.settings->randomLevel) {
-      item.value = '"' + getBasename(getLeaf(gfx.settings->levelFile)) + '"';
-      menu.itemFromId(SettingsMenu::SiRegenerateLevel)->string = LS(ReloadLevel);  // Not string?
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    item.has_value = true;
+    if (!gfx.settings->random_level) {
+      item.value = '"' + GetBasename(GetLeaf(gfx.settings->level_file)) + '"';
+      menu.ItemFromId(SettingsMenu::kSiRegenerateLevel)->string = LS(ReloadLevel);  // Not string?
     } else {
       item.value = LS(Random2);
-      menu.itemFromId(SettingsMenu::SiRegenerateLevel)->string = LS(RegenLevel);
+      menu.ItemFromId(SettingsMenu::kSiRegenerateLevel)->string = LS(RegenLevel);
     }
   }
 
@@ -989,9 +989,9 @@ struct WeaponOptionsBehavior : ItemBehavior {
 struct OptionsSaveBehavior : ItemBehavior {
   OptionsSaveBehavior(Common& common) : common(common) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
-    item.value = getBasename(getLeaf(gfx.settingsNode.fullPath()));
-    item.hasValue = true;
+  void OnUpdate(Menu& menu, MenuItem& item) {
+    item.value = GetBasename(GetLeaf(gfx.settings_node.FullPath()));
+    item.has_value = true;
   }
 
   Common& common;
@@ -1003,73 +1003,73 @@ struct OptionsSelectBehavior : ItemBehavior {
   Common& common;
 };
 
-ItemBehavior* SettingsMenu::getItemBehavior(Common& common, MenuItem& item) {
+ItemBehavior* SettingsMenu::GetItemBehavior(Common& common, MenuItem& item) {
   switch (item.id) {
-    case SiNamesOnBonuses:
-      return new BooleanSwitchBehavior(common, gfx.settings->namesOnBonuses);
-    case SiMap:
+    case kSiNamesOnBonuses:
+      return new BooleanSwitchBehavior(common, gfx.settings->names_on_bonuses);
+    case kSiMap:
       return new BooleanSwitchBehavior(common, gfx.settings->map);
-    case SiRegenerateLevel:
-      return new BooleanSwitchBehavior(common, gfx.settings->regenerateLevel);
-    case SiLoadingTimes:
-      return new IntegerBehavior(common, gfx.settings->loadingTime, 0, 9999, 1, true);
-    case SiMaxBonuses:
-      return new IntegerBehavior(common, gfx.settings->maxBonuses, 0, 99, 1);
-    case SiAmountOfBlood: {
+    case kSiRegenerateLevel:
+      return new BooleanSwitchBehavior(common, gfx.settings->regenerate_level);
+    case kSiLoadingTimes:
+      return new IntegerBehavior(common, gfx.settings->loading_time, 0, 9999, 1, true);
+    case kSiMaxBonuses:
+      return new IntegerBehavior(common, gfx.settings->max_bonuses, 0, 99, 1);
+    case kSiAmountOfBlood: {
       IntegerBehavior* ret = new IntegerBehavior(common, gfx.settings->blood, 0, LC(BloodLimit),
                                                  LC(BloodStepUp), true);
-      ret->allowEntry = false;
+      ret->allow_entry = false;
       return ret;
     }
 
-    case SiLives:
+    case kSiLives:
       return new IntegerBehavior(common, gfx.settings->lives, 1, 999, 1);
-    case SiTimeToLose:
-    case SiTimeToWin:
-      return new TimeBehavior(common, gfx.settings->timeToLose, 60, 3600, 10);
-    case SiZoneTimeout:
-      return new TimeBehavior(common, gfx.settings->zoneTimeout, 10, 3600, 10);
-    case SiFlagsToWin:
-      return new IntegerBehavior(common, gfx.settings->flagsToWin, 1, 999, 1);
+    case kSiTimeToLose:
+    case kSiTimeToWin:
+      return new TimeBehavior(common, gfx.settings->time_to_lose, 60, 3600, 10);
+    case kSiZoneTimeout:
+      return new TimeBehavior(common, gfx.settings->zone_timeout, 10, 3600, 10);
+    case kSiFlagsToWin:
+      return new IntegerBehavior(common, gfx.settings->flags_to_win, 1, 999, 1);
 
-    case SiLevel:
+    case kSiLevel:
       return new LevelSelectBehavior(common);
 
-    case SiGameMode:
-      return new ArrayEnumBehavior(common, gfx.settings->gameMode, common.texts.gameModes);
-    case SiWeaponOptions:
+    case kSiGameMode:
+      return new ArrayEnumBehavior(common, gfx.settings->game_mode, common.texts.game_modes);
+    case kSiWeaponOptions:
       return new WeaponOptionsBehavior(common);
-    case LoadOptions:
+    case kLoadOptions:
       return new OptionsSelectBehavior(common);
-    case SaveOptions:
+    case kSaveOptions:
       return new OptionsSaveBehavior(common);
-    case LoadChange:
-      return new BooleanSwitchBehavior(common, gfx.settings->loadChange);
+    case kLoadChange:
+      return new BooleanSwitchBehavior(common, gfx.settings->load_change);
     default:
-      return Menu::getItemBehavior(common, item);
+      return Menu::GetItemBehavior(common, item);
   }
 }
 
-void SettingsMenu::onUpdate() {
-  setVisibility(SiLives, false);
-  setVisibility(SiTimeToLose, false);
-  setVisibility(SiTimeToWin, false);
-  setVisibility(SiZoneTimeout, false);
-  setVisibility(SiFlagsToWin, false);
+void SettingsMenu::OnUpdate() {
+  SetVisibility(kSiLives, false);
+  SetVisibility(kSiTimeToLose, false);
+  SetVisibility(kSiTimeToWin, false);
+  SetVisibility(kSiZoneTimeout, false);
+  SetVisibility(kSiFlagsToWin, false);
 
-  switch (gfx.settings->gameMode) {
-    case Settings::GMKillEmAll:
-    case Settings::GMScalesOfJustice:
-      setVisibility(SiLives, true);
+  switch (gfx.settings->game_mode) {
+    case Settings::kGmKillEmAll:
+    case Settings::kGmScalesOfJustice:
+      SetVisibility(kSiLives, true);
       break;
 
-    case Settings::GMGameOfTag:
-      setVisibility(SiTimeToLose, true);
+    case Settings::kGmGameOfTag:
+      SetVisibility(kSiTimeToLose, true);
       break;
 
-    case Settings::GMHoldazone:
-      setVisibility(SiTimeToWin, true);
-      setVisibility(SiZoneTimeout, true);
+    case Settings::kGmHoldazone:
+      SetVisibility(kSiTimeToWin, true);
+      SetVisibility(kSiZoneTimeout, true);
       break;
   }
 }
@@ -1077,187 +1077,187 @@ void SettingsMenu::onUpdate() {
 using std::string;
 using std::vector;
 
-void PlayerMenu::drawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
+void PlayerMenu::DrawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
                                  bool disabled) {
-  if (item.id >= PlayerMenu::PlRed && item.id <= PlayerMenu::PlBlue)  // Color settings
+  if (item.id >= PlayerMenu::kPlRed && item.id <= PlayerMenu::kPlBlue)  // Color settings
   {
-    int rgbcol = item.id - PlayerMenu::PlRed;
+    int rgbcol = item.id - PlayerMenu::kPlRed;
 
     if (selected) {
-      drawRoundedBox(gfx.playRenderer.bmp, x + 24, y, 168, 7, ws->rgb[rgbcol] - 1);
+      DrawRoundedBox(gfx.play_renderer.bmp, x + 24, y, 168, 7, ws->rgb[rgbcol] - 1);
     } else  // CE98
     {
-      drawRoundedBox(gfx.playRenderer.bmp, x + 24, y, 0, 7, ws->rgb[rgbcol] - 1);
+      DrawRoundedBox(gfx.play_renderer.bmp, x + 24, y, 0, 7, ws->rgb[rgbcol] - 1);
     }
 
-    fillRect(gfx.playRenderer.bmp, x + 25, y + 1, ws->rgb[rgbcol], 5, ws->color);
+    FillRect(gfx.play_renderer.bmp, x + 25, y + 1, ws->rgb[rgbcol], 5, ws->color);
   }  // CED9
 }
 
-ItemBehavior* PlayerMenu::getItemBehavior(Common& common, MenuItem& item) {
-  if (item.id >= PlWeap0 && item.id < PlWeap0 + 5)
-    return new WeaponEnumBehavior(common, ws->weapons[item.id - PlWeap0]);
+ItemBehavior* PlayerMenu::GetItemBehavior(Common& common, MenuItem& item) {
+  if (item.id >= kPlWeap0 && item.id < kPlWeap0 + 5)
+    return new WeaponEnumBehavior(common, ws->weapons[item.id - kPlWeap0]);
 
   switch (item.id) {
-    case PlName:
+    case kPlName:
       return new WormNameBehavior(common, *ws);
-    case PlHealth: {
+    case kPlHealth: {
       auto* b = new IntegerBehavior(common, ws->health, 1, 10000, 1, true);
-      b->scrollInterval = 4;
+      b->scroll_interval = 4;
       return b;
     }
 
-    case PlRed:
-    case PlGreen:
-    case PlBlue: {
-      auto* b = new IntegerBehavior(common, ws->rgb[item.id - PlRed], 0, 63, 1, false);
-      b->scrollInterval = 4;
+    case kPlRed:
+    case kPlGreen:
+    case kPlBlue: {
+      auto* b = new IntegerBehavior(common, ws->rgb[item.id - kPlRed], 0, 63, 1, false);
+      b->scroll_interval = 4;
       return b;
     }
 
-    case PlInput:
+    case kPlInput:
       return new InputDeviceBehavior(common, *ws);
 
-    case PlUp:  // D2AB
-    case PlDown:
-    case PlLeft:
-    case PlRight:
-    case PlFire:
-    case PlChange:
-    case PlJump:
-      return new KeyBehavior(common, ws->controls[item.id - PlUp], ws->controlsEx[item.id - PlUp],
-                             ws->gamepadControls[item.id - PlUp], ws->inputDevice,
-                             gfx.settings->extensions);
+    case kPlUp:  // D2AB
+    case kPlDown:
+    case kPlLeft:
+    case kPlRight:
+    case kPlFire:
+    case kPlChange:
+    case kPlJump:
+      return new KeyBehavior(common, ws->controls[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
+                             ws->gamepad_controls[item.id - kPlUp], ws->input_device,
+                             gfx.settings->kExtensions);
 
-    case PlDig:  // Controls Extension
-      return new KeyBehavior(common, ws->controlsEx[item.id - PlUp], ws->controlsEx[item.id - PlUp],
-                             ws->gamepadControls[item.id - PlUp], ws->inputDevice,
-                             gfx.settings->extensions);
+    case kPlDig:  // Controls Extension
+      return new KeyBehavior(common, ws->controls_ex[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
+                             ws->gamepad_controls[item.id - kPlUp], ws->input_device,
+                             gfx.settings->kExtensions);
 
-    case PlController:  // Controller
+    case kPlController:  // Controller
       return new ArrayEnumBehavior(common, ws->controller, common.texts.controllers);
 
-    case PlSaveProfile:  // Save profile
+    case kPlSaveProfile:  // Save profile
       return new ProfileSaveBehavior(common, *ws, false);
 
-    case PlSaveProfileAs:  // Save profile as
+    case kPlSaveProfileAs:  // Save profile as
       return new ProfileSaveBehavior(common, *ws, true);
 
-    case PlLoadProfile:
+    case kPlLoadProfile:
       return new ProfileLoadBehavior(common, *ws);
 
-    case PlLoadedProfile:
+    case kPlLoadedProfile:
       return new ProfileLoadedBehavior(common, *ws);
 
     default:
-      return Menu::getItemBehavior(common, item);
+      return Menu::GetItemBehavior(common, item);
   }
 }
 
-void Gfx::playerSettings(int player) {
-  playerMenu.ws = settings->wormSettings[player];
+void Gfx::PlayerSettings(int player) {
+  player_menu.ws = settings->worm_settings[player];
 
-  playerMenu.updateItems(*common);
-  playerMenu.moveToFirstVisible();
+  player_menu.UpdateItems(*common);
+  player_menu.MoveToFirstVisible();
 
-  curMenu = &playerMenu;
+  cur_menu = &player_menu;
   return;
 }
 
-void Gfx::initFrameStepping() {
+void Gfx::InitFrameStepping() {
   tcChangeRequested_ = false;
 
   controller.reset(new LocalController(common, settings));
 
   {
-    Level newLevel(*common);
-    newLevel.generateFromSettings(*common, *settings, rand);
-    controller->swapLevel(newLevel);
+    Level new_level(*common);
+    new_level.GenerateFromSettings(*common, *settings, rand);
+    controller->SwapLevel(new_level);
   }
 
-  controller->currentGame()->focus(this->playRenderer);
-  controller->currentGame()->focus(this->singleScreenRenderer);
+  controller->CurrentGame()->Focus(this->play_renderer);
+  controller->CurrentGame()->Focus(this->single_screen_renderer);
 
   // Draw the initial game state so the menu has a proper background
-  playRenderer.clear();
-  controller->draw(this->playRenderer, false);
-  singleScreenRenderer.clear();
-  controller->draw(this->singleScreenRenderer, true);
+  play_renderer.Clear();
+  controller->Draw(this->play_renderer, false);
+  single_screen_renderer.Clear();
+  controller->Draw(this->single_screen_renderer, true);
 
   // Push the initial menu state
-  auto menuState = std::make_unique<MainMenuState>();
-  menuStatePtr_ = menuState.get();
-  stateStack.push(std::move(menuState), this);
+  auto menu_state = std::make_unique<MainMenuState>();
+  menuStatePtr_ = menu_state.get();
+  state_stack.Push(std::move(menu_state), this);
 }
 
-bool Gfx::runOneFrame() {
-  if (stateStack.empty()) return false;
+bool Gfx::RunOneFrame() {
+  if (state_stack.Empty()) return false;
 
   // Poll events
   SDL_Event ev;
-  keyBufPtr = keyBuf;
+  key_buf_ptr = key_buf;
   while (SDL_PollEvent(&ev)) {
     if (ev.type == SDL_EVENT_QUIT) return false;
     if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.scancode == SDL_SCANCODE_F4 &&
         (ev.key.mod & SDL_KMOD_ALT))
       return false;
-    stateStack.handleEvent(ev);
+    state_stack.HandleEvent(ev);
   }
 
   // Capture menu selection before update() might pop and destroy the state
-  int menuSelection = menuStatePtr_ ? menuStatePtr_->selection() : -1;
-  bool menuFadingOut = menuStatePtr_ && menuStatePtr_->isFadingOut();
+  int menu_selection = menuStatePtr_ ? menuStatePtr_->Selection() : -1;
+  bool menu_fading_out = menuStatePtr_ && menuStatePtr_->IsFadingOut();
 
-  if (!stateStack.update()) {
+  if (!state_stack.Update()) {
     // Top state popped. Determine what to do next.
-    if (menuSelection >= 0) {
+    if (menu_selection >= 0) {
       menuStatePtr_ = nullptr;
 
-      if (menuSelection == MainMenu::MaQuit) return false;
+      if (menu_selection == MainMenu::kMaQuit) return false;
 
-      if (menuSelection == MainMenu::MaTc) {
+      if (menu_selection == MainMenu::kMaTc) {
         tcChangeRequested_ = true;
         controller.reset();
         return false;
       }
 
       // Handle new game / resume / replay selection
-      if (menuSelection == MainMenu::MaNewGame) {
-        netSession.reset();
-        std::unique_ptr<Controller> newController(new LocalController(common, settings));
-        Level* oldLevel = controller->currentLevel();
+      if (menu_selection == MainMenu::kMaNewGame) {
+        net_session.reset();
+        std::unique_ptr<Controller> new_controller(new LocalController(common, settings));
+        Level* old_level = controller->CurrentLevel();
 
-        if (oldLevel && !settings->regenerateLevel &&
-            settings->randomLevel == oldLevel->oldRandomLevel &&
-            settings->levelFile == oldLevel->oldLevelFile) {
-          newController->swapLevel(*oldLevel);
+        if (old_level && !settings->regenerate_level &&
+            settings->random_level == old_level->old_random_level &&
+            settings->level_file == old_level->old_level_file) {
+          new_controller->SwapLevel(*old_level);
         } else {
-          Level newLevel(*common);
-          newLevel.generateFromSettings(*common, *settings, rand);
-          newController->swapLevel(newLevel);
+          Level new_level(*common);
+          new_level.GenerateFromSettings(*common, *settings, rand);
+          new_controller->SwapLevel(new_level);
         }
-        controller = std::move(newController);
-      } else if (menuSelection == MainMenu::MaResumeGame) {
-        if (controller->isReplay()) primaryRenderer = &singleScreenRenderer;
-      } else if (menuSelection == MainMenu::MaReplay) {
-        if (settings->singleScreenReplay) primaryRenderer = &singleScreenRenderer;
-      } else if (menuSelection == MainMenu::MaHostGame) {
-        stateStack.push(std::make_unique<NetConnectState>(NetSession::Host, "", gfx.onlinePort),
+        controller = std::move(new_controller);
+      } else if (menu_selection == MainMenu::kMaResumeGame) {
+        if (controller->IsReplay()) primary_renderer = &single_screen_renderer;
+      } else if (menu_selection == MainMenu::kMaReplay) {
+        if (settings->single_screen_replay) primary_renderer = &single_screen_renderer;
+      } else if (menu_selection == MainMenu::kMaHostGame) {
+        state_stack.Push(std::make_unique<NetConnectState>(NetSession::kHost, "", gfx.online_port),
                         this);
         return true;
-      } else if (menuSelection == MainMenu::MaJoinGame) {
+      } else if (menu_selection == MainMenu::kMaJoinGame) {
         // Parse address — support "host:port" and "[ipv6]:port" formats
-        std::string addr = std::move(pendingNetAddress);
-        uint16_t port = gfx.onlinePort;
+        std::string addr = std::move(pending_net_address);
+        uint16_t port = gfx.online_port;
 
         if (!addr.empty() && addr[0] == '[') {
           // IPv6 bracket notation: [::1]:port
-          auto closeBracket = addr.find(']');
-          if (closeBracket != std::string::npos) {
-            std::string ip6 = addr.substr(1, closeBracket - 1);
-            if (closeBracket + 1 < addr.size() && addr[closeBracket + 1] == ':') {
+          auto close_bracket = addr.find(']');
+          if (close_bracket != std::string::npos) {
+            std::string ip6 = addr.substr(1, close_bracket - 1);
+            if (close_bracket + 1 < addr.size() && addr[close_bracket + 1] == ':') {
               try {
-                port = static_cast<uint16_t>(std::stoi(addr.substr(closeBracket + 2)));
+                port = static_cast<uint16_t>(std::stoi(addr.substr(close_bracket + 2)));
               } catch (...) {
                 // Malformed port, keep default
               }
@@ -1266,73 +1266,73 @@ bool Gfx::runOneFrame() {
           }
         } else {
           // IPv4 or hostname: check for last colon
-          auto lastColon = addr.rfind(':');
-          if (lastColon != std::string::npos) {
+          auto last_colon = addr.rfind(':');
+          if (last_colon != std::string::npos) {
             // Only treat as port separator if there's at most one colon
             // (multiple colons = bare IPv6 without port)
-            auto firstColon = addr.find(':');
-            if (firstColon == lastColon) {
+            auto first_colon = addr.find(':');
+            if (first_colon == last_colon) {
               try {
-                port = static_cast<uint16_t>(std::stoi(addr.substr(lastColon + 1)));
+                port = static_cast<uint16_t>(std::stoi(addr.substr(last_colon + 1)));
               } catch (...) {
                 // Malformed port, keep default
               }
-              addr = addr.substr(0, lastColon);
+              addr = addr.substr(0, last_colon);
             }
           }
         }
 
-        stateStack.push(
-            std::make_unique<NetConnectState>(NetSession::Client, std::move(addr), port), this);
+        state_stack.Push(
+            std::make_unique<NetConnectState>(NetSession::kClient, std::move(addr), port), this);
         return true;
-      } else if (menuSelection == MainMenu::MaHostOnline) {
-        stateStack.push(std::make_unique<OnlineConnectState>(NetSession::Host), this);
+      } else if (menu_selection == MainMenu::kMaHostOnline) {
+        state_stack.Push(std::make_unique<OnlineConnectState>(NetSession::kHost), this);
         return true;
-      } else if (menuSelection == MainMenu::MaJoinOnline) {
-        std::string code = std::move(pendingNetAddress);
-        stateStack.push(std::make_unique<OnlineConnectState>(NetSession::Client, std::move(code)),
+      } else if (menu_selection == MainMenu::kMaJoinOnline) {
+        std::string code = std::move(pending_net_address);
+        state_stack.Push(std::make_unique<OnlineConnectState>(NetSession::kClient, std::move(code)),
                         this);
         return true;
       }
 
       // Push game state
-      stateStack.push(std::make_unique<GamePlayState>(), this);
+      state_stack.Push(std::make_unique<GamePlayState>(), this);
     } else {
       // Game state finished — go back to menu
-      netSession.reset();
-      primaryRenderer = &playRenderer;
-      controller->unfocus();
-      clearKeys();
+      net_session.reset();
+      primary_renderer = &play_renderer;
+      controller->Unfocus();
+      ClearKeys();
 
       // Draw one frame so the menu background captures the final game state
-      playRenderer.clear();
-      controller->draw(this->playRenderer, false);
-      singleScreenRenderer.clear();
-      controller->draw(this->singleScreenRenderer, true);
+      play_renderer.Clear();
+      controller->Draw(this->play_renderer, false);
+      single_screen_renderer.Clear();
+      controller->Draw(this->single_screen_renderer, true);
 
-      auto newMenu = std::make_unique<MainMenuState>();
-      menuStatePtr_ = newMenu.get();
-      stateStack.push(std::move(newMenu), this);
+      auto new_menu = std::make_unique<MainMenuState>();
+      menuStatePtr_ = new_menu.get();
+      state_stack.Push(std::move(new_menu), this);
     }
     return true;
   }
 
-  stateStack.draw();
+  state_stack.Draw();
 
   // Flip: game states use plain flip(), menu states use menuFlip()
-  auto* top = stateStack.top();
-  if (top && !top->wantsMenuFlip()) {
-    ++menuCycles;
-    flip();
+  auto* top = state_stack.Top();
+  if (top && !top->WantsMenuFlip()) {
+    ++menu_cycles;
+    Flip();
   } else {
-    menuFlip(menuFadingOut);
+    MenuFlip(menu_fading_out);
   }
 
   return true;
 }
 
-void Gfx::mainLoop() {
-  initFrameStepping();
+void Gfx::MainLoop() {
+  InitFrameStepping();
 
 #if OPENLIERO_EMSCRIPTEN
   emscripten_set_main_loop_arg(
@@ -1350,71 +1350,71 @@ void Gfx::mainLoop() {
       this, 0, true);
 #else
   while (true) {
-    while (runOneFrame()) {
+    while (RunOneFrame()) {
     }
 
-    if (!tcChangeRequested()) break;
+    if (!TcChangeRequested()) break;
 
     // TC was changed (common reloaded by TcSelectorState) — reinitialize
-    initFrameStepping();
+    InitFrameStepping();
   }
 
   controller.reset();
 #endif
 }
 
-void Gfx::saveSettings(FsNode node) {
-  settingsNode = node;
+void Gfx::SaveSettings(FsNode node) {
+  settings_node = node;
   settings->save(node, rand);
 }
 
-bool Gfx::loadSettings(FsNode node) {
-  settingsNode = node;
+bool Gfx::LoadSettings(FsNode node) {
+  settings_node = node;
   settings.reset(new Settings);
   return settings->load(node, rand);
 }
 
-void Gfx::drawBasicMenu(/*int curSel*/) {
-  playRenderer.bmp.copy(frozenScreen);
+void Gfx::DrawBasicMenu(/*int curSel*/) {
+  play_renderer.bmp.Copy(frozen_screen);
 
-  mainMenu.draw(*common, playRenderer, curMenu != &mainMenu, -1, true);
+  main_menu.Draw(*common, play_renderer, cur_menu != &main_menu, -1, true);
 }
 
-void Gfx::drawSpectatorInfo() {
+void Gfx::DrawSpectatorInfo() {
   Common& common = *this->common;
-  int centerX = singleScreenRenderer.renderResX / 2;
-  int centerY = singleScreenRenderer.renderResY / 4;
+  int center_x = single_screen_renderer.render_res_x / 2;
+  int center_y = single_screen_renderer.render_res_y / 4;
 
-  singleScreenRenderer.bmp.copy(frozenSpectatorScreen);
-  if (settings->levelFile.empty()) {
-    common.font.drawCenteredText(singleScreenRenderer.bmp, LS(LevelRandom), centerX, centerY - 32,
+  single_screen_renderer.bmp.Copy(frozen_spectator_screen);
+  if (settings->level_file.empty()) {
+    common.font.DrawCenteredText(single_screen_renderer.bmp, LS(LevelRandom), center_x, center_y - 32,
                                  7, 2);
   } else {
-    auto levelName = getBasename(getLeaf(gfx.settings->levelFile));
-    common.font.drawCenteredText(singleScreenRenderer.bmp, LS(LevelIs1) + levelName + LS(LevelIs2),
-                                 centerX, centerY - 32, 7, 2);
+    auto level_name = GetBasename(GetLeaf(gfx.settings->level_file));
+    common.font.DrawCenteredText(single_screen_renderer.bmp, LS(LevelIs1) + level_name + LS(LevelIs2),
+                                 center_x, center_y - 32, 7, 2);
   }
 
-  std::string vsText = settings->wormSettings[0]->name + " vs " + settings->wormSettings[1]->name;
+  std::string vs_text = settings->worm_settings[0]->name + " vs " + settings->worm_settings[1]->name;
   // put worm color boxes on a nice spot even if no player names have been entered
-  int textSize = std::max(common.font.getDims(vsText) * 2, 48);
-  common.font.drawCenteredText(singleScreenRenderer.bmp, vsText, centerX, centerY, 7, 2);
-  fillRect(singleScreenRenderer.bmp, centerX - (textSize / 2) - 1, centerY + 23 - 1, 16, 16, 7);
-  fillRect(singleScreenRenderer.bmp, centerX - textSize / 2, centerY + 23, 14, 14,
-           settings->wormSettings[0]->color);
-  fillRect(singleScreenRenderer.bmp, centerX + (textSize / 2) - 16 - 1, centerY + 23 - 1, 16, 16,
+  int text_size = std::max(common.font.GetDims(vs_text) * 2, 48);
+  common.font.DrawCenteredText(single_screen_renderer.bmp, vs_text, center_x, center_y, 7, 2);
+  FillRect(single_screen_renderer.bmp, center_x - (text_size / 2) - 1, center_y + 23 - 1, 16, 16, 7);
+  FillRect(single_screen_renderer.bmp, center_x - text_size / 2, center_y + 23, 14, 14,
+           settings->worm_settings[0]->color);
+  FillRect(single_screen_renderer.bmp, center_x + (text_size / 2) - 16 - 1, center_y + 23 - 1, 16, 16,
            7);
-  fillRect(singleScreenRenderer.bmp, centerX + textSize / 2 - 16, centerY + 23, 14, 14,
-           settings->wormSettings[1]->color);
+  FillRect(single_screen_renderer.bmp, center_x + text_size / 2 - 16, center_y + 23, 14, 14,
+           settings->worm_settings[1]->color);
 
-  if (controller->running()) {
-    common.font.drawCenteredText(singleScreenRenderer.bmp, "PAUSED", centerX, centerY + 48, 7, 2);
+  if (controller->Running()) {
+    common.font.DrawCenteredText(single_screen_renderer.bmp, "PAUSED", center_x, center_y + 48, 7, 2);
   } else {
-    common.font.drawCenteredText(singleScreenRenderer.bmp, "SETUP", centerX, centerY + 48, 7, 2);
+    common.font.DrawCenteredText(single_screen_renderer.bmp, "SETUP", center_x, center_y + 48, 7, 2);
   }
 }
 
-int upperCaseOnly(int k) {
+int UpperCaseOnly(int k) {
   k = std::toupper(k);
 
   if ((k >= 'A' && k <= 'Z') || (k == 0x8f || k == 0x8e || k == 0x99)  // � �and �
@@ -1424,9 +1424,9 @@ int upperCaseOnly(int k) {
   return 0;
 }
 
-void Gfx::openHiddenMenu() {
-  if (curMenu == &hiddenMenu) return;
-  curMenu = &hiddenMenu;
-  curMenu->updateItems(*common);
-  curMenu->moveToFirstVisible();
+void Gfx::OpenHiddenMenu() {
+  if (cur_menu == &hidden_menu) return;
+  cur_menu = &hidden_menu;
+  cur_menu->UpdateItems(*common);
+  cur_menu->MoveToFirstVisible();
 }

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -293,7 +293,8 @@ void Gfx::SetVideoMode() {
   }
   if (settings->spectator_window) {
     if (!sdl_spectator_window) {
-      std::string spectator_window_title = std::string("Liero Spectator Window - ") + BuildVersion();
+      std::string spectator_window_title =
+          std::string("Liero Spectator Window - ") + BuildVersion();
       sdl_spectator_window = SDL_CreateWindow(
           spectator_window_title.c_str(), window_w, window_h,
           SDL_WINDOW_RESIZABLE | (spectator_fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
@@ -392,7 +393,7 @@ void Gfx::OnWindowResize(uint32_t window_id) {
 
     if (settings->spectator_window) {
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
-                                              SDL_TEXTUREACCESS_STREAMING, 640, 400);
+                                                SDL_TEXTUREACCESS_STREAMING, 640, 400);
       sdl_spectator_draw_surface = SDL_CreateSurface(640, 400, SDL_PIXELFORMAT_ARGB8888);
       SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, 640, 400,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);
@@ -692,7 +693,8 @@ int Gfx::FindGamepadForPlayer(int player_idx) {
   return candidates[0];
 }
 
-void Gfx::DispatchGamepadInput(int gp_idx, uint32_t gamepad_key, bool state, Controller* controller) {
+void Gfx::DispatchGamepadInput(int gp_idx, uint32_t gamepad_key, bool state,
+                               Controller* controller) {
   if (gp_idx < 0 || gp_idx >= 2) return;
 
   // Start button acts as ESC for menu access
@@ -740,7 +742,7 @@ std::string Gfx::GetGamepadKeyName(uint32_t gamepad_key) {
   }
 
   static char const* button_names[] = {"A",  "B",  "X",  "Y",  "Back", "Guide", "Start", "LS",
-                                      "RS", "LB", "RB", "Up", "Down", "Left",  "Right"};
+                                       "RS", "LB", "RB", "Up", "Down", "Left",  "Right"};
 
   if (gamepad_key < 15) return button_names[gamepad_key];
 
@@ -756,9 +758,10 @@ void Gfx::ClearKeys() {
 bool Gfx::TestControlOnce(int control) {
   // Check keyboard bindings for all player profiles (left, right, network)
   for (int p = 0; p < Settings::kNumWormSettings; ++p) {
-    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard) continue;
+    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard)
+      continue;
     uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
-                                        : settings->worm_settings[p]->controls[control];
+                                         : settings->worm_settings[p]->controls[control];
     if (TestAnyKeyOnce(key)) return true;
   }
   return false;
@@ -826,9 +829,10 @@ bool Gfx::TestGamepadDir(int dpad_button) {
 bool Gfx::TestControl(int control) {
   // Check keyboard bindings for all player profiles (left, right, network)
   for (int p = 0; p < Settings::kNumWormSettings; ++p) {
-    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard) continue;
+    if (settings->worm_settings[p]->input_device != WormSettingsExtensions::kInputKeyboard)
+      continue;
     uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
-                                        : settings->worm_settings[p]->controls[control];
+                                         : settings->worm_settings[p]->controls[control];
     if (TestAnyKey(key)) return true;
   }
   return false;
@@ -837,7 +841,7 @@ bool Gfx::TestControl(int control) {
 void Gfx::ReleaseControl(int control) {
   for (int p = 0; p < Settings::kNumWormSettings; ++p) {
     uint32_t key = settings->kExtensions ? settings->worm_settings[p]->controls_ex[control]
-                                        : settings->worm_settings[p]->controls[control];
+                                         : settings->worm_settings[p]->controls[control];
     ReleaseAnyKey(key);
   }
 }
@@ -857,13 +861,15 @@ void Gfx::MenuFlip(bool quitting) {
   play_renderer.pal = play_renderer.origpal;
   play_renderer.pal.RotateFrom(play_renderer.origpal, 168, 174, menu_cycles);
   play_renderer.pal.SetWormColours(*settings);
-  if (cur_menu == &player_menu && player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
+  if (cur_menu == &player_menu &&
+      player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
     play_renderer.pal.SetWormColour(0, *player_menu.ws);
   play_renderer.pal.Fade(play_renderer.fade_value);
   single_screen_renderer.pal = single_screen_renderer.origpal;
   single_screen_renderer.pal.RotateFrom(single_screen_renderer.origpal, 168, 174, menu_cycles);
   single_screen_renderer.pal.SetWormColours(*settings);
-  if (cur_menu == &player_menu && player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
+  if (cur_menu == &player_menu &&
+      player_menu.ws == settings->worm_settings[Settings::kNetworkPlayerIdx])
     single_screen_renderer.pal.SetWormColour(0, *player_menu.ws);
   single_screen_renderer.pal.Fade(single_screen_renderer.fade_value);
   Flip();
@@ -875,8 +881,8 @@ void Gfx::Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_ren
   Color real_pal[256];
   renderer.pal.Activate(real_pal);
   int offset_x, offset_y;
-  int mag =
-      FitScreen(surface.w, surface.h, renderer.render_res_x, renderer.render_res_y, offset_x, offset_y);
+  int mag = FitScreen(surface.w, surface.h, renderer.render_res_x, renderer.render_res_y, offset_x,
+                      offset_y);
 
   Rect new_rect(offset_x, offset_y, renderer.render_res_x * mag, renderer.render_res_y * mag);
 
@@ -899,7 +905,8 @@ void Gfx::Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_ren
 
   uint32_t pal32[256];
   PreparePalette(format_details, NULL, real_pal, pal32);
-  ScaleDraw(src, renderer.render_res_x, renderer.render_res_y, src_pitch, dest, dest_pitch, mag, pal32);
+  ScaleDraw(src, renderer.render_res_x, renderer.render_res_y, src_pitch, dest, dest_pitch, mag,
+            pal32);
 
   SDL_UpdateTexture(&texture, NULL, surface.pixels, surface.w * 4);
   SDL_RenderClear(&sdl_renderer);
@@ -1125,14 +1132,14 @@ ItemBehavior* PlayerMenu::GetItemBehavior(Common& common, MenuItem& item) {
     case kPlFire:
     case kPlChange:
     case kPlJump:
-      return new KeyBehavior(common, ws->controls[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
-                             ws->gamepad_controls[item.id - kPlUp], ws->input_device,
-                             gfx.settings->kExtensions);
+      return new KeyBehavior(
+          common, ws->controls[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
+          ws->gamepad_controls[item.id - kPlUp], ws->input_device, gfx.settings->kExtensions);
 
     case kPlDig:  // Controls Extension
-      return new KeyBehavior(common, ws->controls_ex[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
-                             ws->gamepad_controls[item.id - kPlUp], ws->input_device,
-                             gfx.settings->kExtensions);
+      return new KeyBehavior(
+          common, ws->controls_ex[item.id - kPlUp], ws->controls_ex[item.id - kPlUp],
+          ws->gamepad_controls[item.id - kPlUp], ws->input_device, gfx.settings->kExtensions);
 
     case kPlController:  // Controller
       return new ArrayEnumBehavior(common, ws->controller, common.texts.controllers);
@@ -1243,7 +1250,7 @@ bool Gfx::RunOneFrame() {
         if (settings->single_screen_replay) primary_renderer = &single_screen_renderer;
       } else if (menu_selection == MainMenu::kMaHostGame) {
         state_stack.Push(std::make_unique<NetConnectState>(NetSession::kHost, "", gfx.online_port),
-                        this);
+                         this);
         return true;
       } else if (menu_selection == MainMenu::kMaJoinGame) {
         // Parse address — support "host:port" and "[ipv6]:port" formats
@@ -1291,7 +1298,7 @@ bool Gfx::RunOneFrame() {
       } else if (menu_selection == MainMenu::kMaJoinOnline) {
         std::string code = std::move(pending_net_address);
         state_stack.Push(std::make_unique<OnlineConnectState>(NetSession::kClient, std::move(code)),
-                        this);
+                         this);
         return true;
       }
 
@@ -1387,30 +1394,35 @@ void Gfx::DrawSpectatorInfo() {
 
   single_screen_renderer.bmp.Copy(frozen_spectator_screen);
   if (settings->level_file.empty()) {
-    common.font.DrawCenteredText(single_screen_renderer.bmp, LS(LevelRandom), center_x, center_y - 32,
-                                 7, 2);
+    common.font.DrawCenteredText(single_screen_renderer.bmp, LS(LevelRandom), center_x,
+                                 center_y - 32, 7, 2);
   } else {
     auto level_name = GetBasename(GetLeaf(gfx.settings->level_file));
-    common.font.DrawCenteredText(single_screen_renderer.bmp, LS(LevelIs1) + level_name + LS(LevelIs2),
-                                 center_x, center_y - 32, 7, 2);
+    common.font.DrawCenteredText(single_screen_renderer.bmp,
+                                 LS(LevelIs1) + level_name + LS(LevelIs2), center_x, center_y - 32,
+                                 7, 2);
   }
 
-  std::string vs_text = settings->worm_settings[0]->name + " vs " + settings->worm_settings[1]->name;
+  std::string vs_text =
+      settings->worm_settings[0]->name + " vs " + settings->worm_settings[1]->name;
   // put worm color boxes on a nice spot even if no player names have been entered
   int text_size = std::max(common.font.GetDims(vs_text) * 2, 48);
   common.font.DrawCenteredText(single_screen_renderer.bmp, vs_text, center_x, center_y, 7, 2);
-  FillRect(single_screen_renderer.bmp, center_x - (text_size / 2) - 1, center_y + 23 - 1, 16, 16, 7);
+  FillRect(single_screen_renderer.bmp, center_x - (text_size / 2) - 1, center_y + 23 - 1, 16, 16,
+           7);
   FillRect(single_screen_renderer.bmp, center_x - text_size / 2, center_y + 23, 14, 14,
            settings->worm_settings[0]->color);
-  FillRect(single_screen_renderer.bmp, center_x + (text_size / 2) - 16 - 1, center_y + 23 - 1, 16, 16,
-           7);
+  FillRect(single_screen_renderer.bmp, center_x + (text_size / 2) - 16 - 1, center_y + 23 - 1, 16,
+           16, 7);
   FillRect(single_screen_renderer.bmp, center_x + text_size / 2 - 16, center_y + 23, 14, 14,
            settings->worm_settings[1]->color);
 
   if (controller->Running()) {
-    common.font.DrawCenteredText(single_screen_renderer.bmp, "PAUSED", center_x, center_y + 48, 7, 2);
+    common.font.DrawCenteredText(single_screen_renderer.bmp, "PAUSED", center_x, center_y + 48, 7,
+                                 2);
   } else {
-    common.font.DrawCenteredText(single_screen_renderer.bmp, "SETUP", center_x, center_y + 48, 7, 2);
+    common.font.DrawCenteredText(single_screen_renderer.bmp, "SETUP", center_x, center_y + 48, 7,
+                                 2);
   }
 }
 

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1345,9 +1345,9 @@ void Gfx::MainLoop() {
   emscripten_set_main_loop_arg(
       [](void* arg) {
         Gfx* self = static_cast<Gfx*>(arg);
-        if (!self->runOneFrame()) {
-          if (self->tcChangeRequested()) {
-            self->initFrameStepping();
+        if (!self->RunOneFrame()) {
+          if (self->TcChangeRequested()) {
+            self->InitFrameStepping();
           } else {
             self->controller.reset();
             emscripten_cancel_main_loop();

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -39,311 +39,311 @@ struct PlayerMenu : Menu {
   PlayerMenu(int x, int y) : Menu(x, y) {}
 
   enum {
-    PlName,
-    PlHealth,
-    PlRed,
-    PlGreen,
-    PlBlue,
-    PlInput,
-    PlUp,
-    PlDown,
-    PlLeft,
-    PlRight,
-    PlFire,
-    PlChange,
-    PlJump,
-    PlDig,
-    PlWeap0,
-    PlController = PlWeap0 + 5,
-    PlSaveProfile,
-    PlSaveProfileAs,
-    PlLoadProfile,
-    PlLoadedProfile,
+    kPlName,
+    kPlHealth,
+    kPlRed,
+    kPlGreen,
+    kPlBlue,
+    kPlInput,
+    kPlUp,
+    kPlDown,
+    kPlLeft,
+    kPlRight,
+    kPlFire,
+    kPlChange,
+    kPlJump,
+    kPlDig,
+    kPlWeap0,
+    kPlController = kPlWeap0 + 5,
+    kPlSaveProfile,
+    kPlSaveProfileAs,
+    kPlLoadProfile,
+    kPlLoadedProfile,
   };
 
-  virtual void drawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
+  virtual void DrawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
                                bool disabled);
 
-  virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item);
+  virtual ItemBehavior* GetItemBehavior(Common& common, MenuItem& item);
 
   std::shared_ptr<WormSettings> ws;
 };
 
 struct SettingsMenu : Menu {
   enum {
-    SiGameMode,
-    SiLives,
-    SiTimeToLose,  // Extra
-    SiTimeToWin,
-    SiZoneTimeout,
-    SiFlagsToWin,  // Extra
-    SiLoadingTimes,
-    SiMaxBonuses,
-    SiNamesOnBonuses,
-    SiMap,
-    SiAmountOfBlood,
-    SiLevel,
-    SiRegenerateLevel,
-    SiWeaponOptions,
-    LoadOptions,
-    SaveOptions,
-    LoadChange,
+    kSiGameMode,
+    kSiLives,
+    kSiTimeToLose,  // Extra
+    kSiTimeToWin,
+    kSiZoneTimeout,
+    kSiFlagsToWin,  // Extra
+    kSiLoadingTimes,
+    kSiMaxBonuses,
+    kSiNamesOnBonuses,
+    kSiMap,
+    kSiAmountOfBlood,
+    kSiLevel,
+    kSiRegenerateLevel,
+    kSiWeaponOptions,
+    kLoadOptions,
+    kSaveOptions,
+    kLoadChange,
   };
 
   SettingsMenu(int x, int y) : Menu(x, y) {}
 
-  virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item);
+  virtual ItemBehavior* GetItemBehavior(Common& common, MenuItem& item);
 
-  virtual void onUpdate();
+  virtual void OnUpdate();
 };
 
 struct Joystick {
-  SDL_Gamepad* sdlGamepad;
-  SDL_JoystickID instanceId;
-  bool btnState[SDL_GAMEPAD_BUTTON_COUNT];
-  bool btnPressed[SDL_GAMEPAD_BUTTON_COUNT];  // Latched on press, cleared by testGamepadButtonOnce
-  bool axisButtonState[12];                   // 6 axes * 2 directions
-  bool axisPressed[12];  // Latched on axis threshold cross, cleared by consumer
+  SDL_Gamepad* sdl_gamepad;
+  SDL_JoystickID instance_id;
+  bool btn_state[SDL_GAMEPAD_BUTTON_COUNT];
+  bool btn_pressed[SDL_GAMEPAD_BUTTON_COUNT];  // Latched on press, cleared by testGamepadButtonOnce
+  bool axis_button_state[12];                   // 6 axes * 2 directions
+  bool axis_pressed[12];  // Latched on axis threshold cross, cleared by consumer
 
-  void clearState() {
-    std::memset(btnState, 0, sizeof(btnState));
-    std::memset(btnPressed, 0, sizeof(btnPressed));
-    std::memset(axisButtonState, 0, sizeof(axisButtonState));
-    std::memset(axisPressed, 0, sizeof(axisPressed));
+  void ClearState() {
+    std::memset(btn_state, 0, sizeof(btn_state));
+    std::memset(btn_pressed, 0, sizeof(btn_pressed));
+    std::memset(axis_button_state, 0, sizeof(axis_button_state));
+    std::memset(axis_pressed, 0, sizeof(axis_pressed));
   }
 };
 
 struct Gfx {
   Gfx();
 
-  void init();
-  void setVideoMode();
-  void onWindowResize(uint32_t windowId);
-  void loadMenus();
+  void Init();
+  void SetVideoMode();
+  void OnWindowResize(uint32_t window_id);
+  void LoadMenus();
 
-  void process(Controller* controller = 0);
+  void Process(Controller* controller = 0);
   // draws a given surface onto an SDL texture/renderer, using a given Renderer
-  void draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdlRenderer,
+  void Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_renderer,
             Renderer& renderer);
-  void flip();
-  void menuFlip(bool quitting = false);
+  void Flip();
+  void MenuFlip(bool quitting = false);
 
-  void clearKeys();
+  void ClearKeys();
 
-  bool testKeyOnce(uint32_t key) {
-    bool state = dosKeys[key];
-    dosKeys[key] = false;
+  bool TestKeyOnce(uint32_t key) {
+    bool state = dos_keys[key];
+    dos_keys[key] = false;
     return state;
   }
 
-  bool testKey(uint32_t key) { return dosKeys[key]; }
+  bool TestKey(uint32_t key) { return dos_keys[key]; }
 
-  void releaseKey(uint32_t key) { dosKeys[key] = false; }
+  void ReleaseKey(uint32_t key) { dos_keys[key] = false; }
 
-  void pressKey(uint32_t key) { dosKeys[key] = true; }
+  void PressKey(uint32_t key) { dos_keys[key] = true; }
 
-  void setKey(uint32_t key, bool state) { dosKeys[key] = state; }
+  void SetKey(uint32_t key, bool state) { dos_keys[key] = state; }
 
-  void toggleKey(uint32_t key) { dosKeys[key] = !dosKeys[key]; }
+  void ToggleKey(uint32_t key) { dos_keys[key] = !dos_keys[key]; }
 
-  bool testSDLKeyOnce(SDL_Scancode key) {
+  bool TestSdlKeyOnce(SDL_Scancode key) {
     uint32_t k = SDLToDOSKey(key);
-    return k ? testKeyOnce(k) : false;
+    return k ? TestKeyOnce(k) : false;
   }
 
-  bool testSDLKey(SDL_Scancode key) {
+  bool TestSdlKey(SDL_Scancode key) {
     uint32_t k = SDLToDOSKey(key);
-    return k ? testKey(k) : false;
+    return k ? TestKey(k) : false;
   }
 
-  void releaseSDLKey(SDL_Scancode key) {
+  void ReleaseSdlKey(SDL_Scancode key) {
     uint32_t k = SDLToDOSKey(key);
-    if (k) dosKeys[k] = false;
+    if (k) dos_keys[k] = false;
   }
 
   // Test any key (both regular DOS keys and extended joystick keys)
-  bool testAnyKeyOnce(uint32_t key) {
+  bool TestAnyKeyOnce(uint32_t key) {
     if (key == 0) return false;
-    if (key < MaxDOSKey) return testKeyOnce(key);
-    auto it = exKeys.find(key);
-    if (it != exKeys.end() && it->second) {
+    if (key < kMaxDosKey) return TestKeyOnce(key);
+    auto it = ex_keys.find(key);
+    if (it != ex_keys.end() && it->second) {
       it->second = false;
       return true;
     }
     return false;
   }
 
-  bool testAnyKey(uint32_t key) {
+  bool TestAnyKey(uint32_t key) {
     if (key == 0) return false;
-    if (key < MaxDOSKey) return testKey(key);
-    auto it = exKeys.find(key);
-    return it != exKeys.end() && it->second;
+    if (key < kMaxDosKey) return TestKey(key);
+    auto it = ex_keys.find(key);
+    return it != ex_keys.end() && it->second;
   }
 
-  void releaseAnyKey(uint32_t key) {
+  void ReleaseAnyKey(uint32_t key) {
     if (key == 0) return;
-    if (key < MaxDOSKey)
-      dosKeys[key] = false;
+    if (key < kMaxDosKey)
+      dos_keys[key] = false;
     else
-      exKeys[key] = false;
+      ex_keys[key] = false;
   }
 
   // Test if any player's configured control for a given action was pressed.
   // Uses controlsEx which covers both keyboard and joystick bindings.
-  bool testControlOnce(int control);
+  bool TestControlOnce(int control);
 
   // Test if any connected gamepad has a raw button pressed (one-shot)
-  bool testGamepadButtonOnce(int button);
+  bool TestGamepadButtonOnce(int button);
 
   // Test if any connected gamepad has a raw button held (non-destructive)
-  bool testGamepadButton(int button);
+  bool TestGamepadButton(int button);
 
   // Directional input: checks both DPad button AND left stick axis (one-shot)
-  bool testGamepadDirOnce(int dpadButton);
+  bool TestGamepadDirOnce(int dpad_button);
 
   // Directional input: checks both DPad button AND left stick axis (held)
-  bool testGamepadDir(int dpadButton);
+  bool TestGamepadDir(int dpad_button);
 
   // Non-destructive version for held keys (left/right repeat)
-  bool testControl(int control);
+  bool TestControl(int control);
 
   // Release a control key for all players
-  void releaseControl(int control);
+  void ReleaseControl(int control);
 
-  std::string getKeyName(uint32_t key);
-  std::string getGamepadKeyName(uint32_t gamepadKey);
-  void setSpectatorFullscreen(bool newFullscreen);
-  void setFullscreen(bool newFullscreen);
-  void setDoubleRes(bool newDoubleRes);
+  std::string GetKeyName(uint32_t key);
+  std::string GetGamepadKeyName(uint32_t gamepad_key);
+  void SetSpectatorFullscreen(bool new_fullscreen);
+  void SetFullscreen(bool new_fullscreen);
+  void SetDoubleRes(bool new_double_res);
 
-  void saveSettings(FsNode node);
-  bool loadSettings(FsNode node);
+  void SaveSettings(FsNode node);
+  bool LoadSettings(FsNode node);
 
-  void processEvent(SDL_Event& ev, Controller* controller = 0);
+  void ProcessEvent(SDL_Event& ev, Controller* controller = 0);
 
-  int findGamepadIndex(SDL_JoystickID id);
-  int findGamepadForPlayer(int playerIdx);
-  void dispatchGamepadInput(int gpIdx, uint32_t gamepadKey, bool state, Controller* controller);
+  int FindGamepadIndex(SDL_JoystickID id);
+  int FindGamepadForPlayer(int player_idx);
+  void DispatchGamepadInput(int gp_idx, uint32_t gamepad_key, bool state, Controller* controller);
 
-  void mainLoop();
+  void MainLoop();
 
   // Initialize the state stack.
   // Call once before calling runOneFrame() in a loop.
-  void initFrameStepping();
+  void InitFrameStepping();
 
   // Advance the application by one frame. Returns false when the
   // application should exit (quit selected or TC change requested).
   // After a TC change, call initFrameStepping() again.
-  bool runOneFrame();
+  bool RunOneFrame();
 
   // True if a TC change was requested (caller should reload and re-init)
-  bool tcChangeRequested() const { return tcChangeRequested_; }
+  bool TcChangeRequested() const { return tcChangeRequested_; }
 
-  void drawBasicMenu(/*int curSel*/);
-  void drawSpectatorInfo();
-  void playerSettings(int player);
-  void openHiddenMenu();
+  void DrawBasicMenu(/*int curSel*/);
+  void DrawSpectatorInfo();
+  void PlayerSettings(int player);
+  void OpenHiddenMenu();
 
-  static void preparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette,
-                             Color realPal[256], uint32_t (&pal32)[256]);
+  static void PreparePalette(SDL_PixelFormatDetails const* format, SDL_Palette const* palette,
+                             Color real_pal[256], uint32_t (&pal32)[256]);
 
-  static void overlay(SDL_PixelFormatDetails const* format, uint8_t* src, int w, int h,
-                      std::size_t srcPitch, uint8_t* dest, std::size_t destPitch, int mag);
+  static void Overlay(SDL_PixelFormatDetails const* format, uint8_t* src, int w, int h,
+                      std::size_t src_pitch, uint8_t* dest, std::size_t dest_pitch, int mag);
 
-  void setConfigNodes(FsNode const& config, FsNode const& userConfig) {
-    configNode = config;
-    userConfigNode = userConfig;
+  void SetConfigNodes(FsNode const& config, FsNode const& user_config) {
+    config_node = config;
+    user_config_node = user_config;
   }
 
-  FsNode getConfigNode() { return configNode; }
+  FsNode GetConfigNode() { return config_node; }
 
-  FsNode getUserConfigNode() { return userConfigNode; }
+  FsNode GetUserConfigNode() { return user_config_node; }
 
   // PRNG for things that don't affect the game
   Rand rand;
 
   // renders everything for actual play
-  Renderer playRenderer;
+  Renderer play_renderer;
   // renders everything on a single screen, for single screen replay and
   // the spectator window
-  Renderer singleScreenRenderer;
+  Renderer single_screen_renderer;
 
   // the renderer currently in use by the primary window. Usually
   // playRenderer, but is singleScreenRenderer if watching a replay in
   // single screen mode.
-  Renderer* primaryRenderer;
+  Renderer* primary_renderer;
 
-  FsNode configNode;
-  FsNode userConfigNode;
+  FsNode config_node;
+  FsNode user_config_node;
 
   // Port for online play (default 19532, configurable via --port)
-  uint16_t onlinePort = 19532;
+  uint16_t online_port = 19532;
 
-  MainMenu mainMenu;
-  SettingsMenu settingsMenu;
-  PlayerMenu playerMenu;
-  HiddenMenu hiddenMenu;
+  MainMenu main_menu;
+  SettingsMenu settings_menu;
+  PlayerMenu player_menu;
+  HiddenMenu hidden_menu;
 
-  Menu* curMenu;
-  std::string prevSelectedReplayPath;
-  FsNode settingsNode;  // Currently loaded settings file. TODO: This is only used for display. We
+  Menu* cur_menu;
+  std::string prev_selected_replay_path;
+  FsNode settings_node;  // Currently loaded settings file. TODO: This is only used for display. We
                         // could just remember the name.
   std::shared_ptr<Settings> settings;
 
-  bool dosKeys[177];
-  std::unordered_map<uint32_t, bool> exKeys;
+  bool dos_keys[177];
+  std::unordered_map<uint32_t, bool> ex_keys;
 
   // the window to render into
-  SDL_Window* sdlWindow = NULL;
+  SDL_Window* sdl_window = NULL;
   // the window to render the spectator view into
-  SDL_Window* sdlSpectatorWindow = NULL;
+  SDL_Window* sdl_spectator_window = NULL;
   // the SDL renderer to use
-  SDL_Renderer* sdlRenderer = NULL;
+  SDL_Renderer* sdl_renderer = NULL;
   // the SDL renderer to use for the spectator window
-  SDL_Renderer* sdlSpectatorRenderer = NULL;
+  SDL_Renderer* sdl_spectator_renderer = NULL;
   // full window size texture that represents the window
-  SDL_Texture* sdlTexture = NULL;
+  SDL_Texture* sdl_texture = NULL;
   // full spectator window size texture that represents the spectator window
-  SDL_Texture* sdlSpectatorTexture = NULL;
+  SDL_Texture* sdl_spectator_texture = NULL;
   // a software surface to do the actual drawing into
-  SDL_Surface* sdlDrawSurface = NULL;
+  SDL_Surface* sdl_draw_surface = NULL;
   // a software surface to do the actual drawing of the spectator view into
-  SDL_Surface* sdlSpectatorDrawSurface = NULL;
+  SDL_Surface* sdl_spectator_draw_surface = NULL;
   // when the menu is open, the ongoing game on the screen is paused and
   // stored in this bitmap
-  Bitmap frozenScreen;
+  Bitmap frozen_screen;
   // when the menu is open, the ongoing game on the spectator screen is
   // paused and stored in this bitmap
-  Bitmap frozenSpectatorScreen;
+  Bitmap frozen_spectator_screen;
 
   bool running;
-  bool spectatorFullscreen, doubleRes;
+  bool spectator_fullscreen, double_res;
 
-  uint64_t lastFrame;
-  unsigned menuCycles;
-  int windowW, windowH;
-  int prevMag;          // Previous magnification used for drawing
-  Rect lastUpdateRect;  // Last region that was updated when flipping
+  uint64_t last_frame;
+  unsigned menu_cycles;
+  int window_w, window_h;
+  int prev_mag;          // Previous magnification used for drawing
+  Rect last_update_rect;  // Last region that was updated when flipping
   std::shared_ptr<Common> common;
-  std::shared_ptr<SoundPlayer> soundPlayer;
+  std::shared_ptr<SoundPlayer> sound_player;
   std::unique_ptr<Controller> controller;
-  std::unique_ptr<NetSession> netSession;
-  std::string pendingNetAddress;
+  std::unique_ptr<NetSession> net_session;
+  std::string pending_net_address;
 
-  StateStack stateStack;
+  StateStack state_stack;
 
   // Used by sub-states to communicate a menu selection back to MainMenuState
-  int pendingMenuSelection = -1;
+  int pending_menu_selection = -1;
 
   // Error message to display after GamePlayState pops (set by controllers)
-  std::string pendingErrorMessage;
+  std::string pending_error_message;
 
   std::vector<Joystick> joysticks;
 
-  SDL_Scancode keyBuf[32], *keyBufPtr;
+  SDL_Scancode key_buf[32], *key_buf_ptr;
 
-  std::vector<std::pair<int, int>> debugPoints;
-  std::string debugInfo;
+  std::vector<std::pair<int, int>> debug_points;
+  std::string debug_info;
 
  private:
   struct MainMenuState* menuStatePtr_ = nullptr;

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -102,7 +102,7 @@ struct Joystick {
   SDL_JoystickID instance_id;
   bool btn_state[SDL_GAMEPAD_BUTTON_COUNT];
   bool btn_pressed[SDL_GAMEPAD_BUTTON_COUNT];  // Latched on press, cleared by testGamepadButtonOnce
-  bool axis_button_state[12];                   // 6 axes * 2 directions
+  bool axis_button_state[12];                  // 6 axes * 2 directions
   bool axis_pressed[12];  // Latched on axis threshold cross, cleared by consumer
 
   void ClearState() {
@@ -287,7 +287,7 @@ struct Gfx {
   Menu* cur_menu;
   std::string prev_selected_replay_path;
   FsNode settings_node;  // Currently loaded settings file. TODO: This is only used for display. We
-                        // could just remember the name.
+                         // could just remember the name.
   std::shared_ptr<Settings> settings;
 
   bool dos_keys[177];
@@ -322,7 +322,7 @@ struct Gfx {
   uint64_t last_frame;
   unsigned menu_cycles;
   int window_w, window_h;
-  int prev_mag;          // Previous magnification used for drawing
+  int prev_mag;           // Previous magnification used for drawing
   Rect last_update_rect;  // Last region that was updated when flipping
   std::shared_ptr<Common> common;
   std::shared_ptr<SoundPlayer> sound_player;

--- a/src/game/gfx/bitmap.hpp
+++ b/src/game/gfx/bitmap.hpp
@@ -15,15 +15,15 @@ struct Bitmap {
   Bitmap(const Bitmap&) = delete;
   Bitmap& operator=(const Bitmap&) = delete;
 
-  void alloc(int w, int h) { alloc(w, h, w); }
+  void Alloc(int w, int h) { Alloc(w, h, w); }
 
-  void alloc(int newW, int newH, unsigned int newPitch) {
-    if (!pixels || w != newW || h != newH || pitch != newPitch) {
+  void Alloc(int new_w, int new_h, unsigned int new_pitch) {
+    if (!pixels || w != new_w || h != new_h || pitch != new_pitch) {
       delete[] pixels;
-      pixels = new unsigned char[newPitch * newH];
-      w = newW;
-      h = newH;
-      pitch = newPitch;
+      pixels = new unsigned char[new_pitch * new_h];
+      w = new_w;
+      h = new_h;
+      pitch = new_pitch;
     }
 
     clip_rect.x1 = 0;
@@ -32,16 +32,16 @@ struct Bitmap {
     clip_rect.y2 = h;
   }
 
-  unsigned char& getPixel(int x, int y) {
+  unsigned char& GetPixel(int x, int y) {
     return (static_cast<unsigned char*>(pixels) + y * pitch)[x];
   }
 
-  void setPixel(int x, int y, PalIdx v) {
-    if (clip_rect.inside(x, y)) (static_cast<unsigned char*>(pixels) + y * pitch)[x] = v;
+  void SetPixel(int x, int y, PalIdx v) {
+    if (clip_rect.Inside(x, y)) (static_cast<unsigned char*>(pixels) + y * pitch)[x] = v;
   }
 
-  void copy(Bitmap const& other) {
-    alloc(other.w, other.h, other.pitch);
+  void Copy(Bitmap const& other) {
+    Alloc(other.w, other.h, other.pitch);
     std::memcpy(pixels, other.pixels, other.pitch * other.h);
   }
 

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -14,7 +14,7 @@
 #include "macros.hpp"
 #include "math/rect.hpp"
 
-void fillRect(Bitmap& scr, int x, int y, int w, int h, int color) {
+void FillRect(Bitmap& scr, int x, int y, int w, int h, int color) {
   int x2 = x + w;
   int y2 = y + h;
   int clipx2 = scr.clip_rect.x2;
@@ -26,63 +26,63 @@ void fillRect(Bitmap& scr, int x, int y, int w, int h, int color) {
 
   if (x2 > x) {
     for (; y < y2; ++y) {
-      std::memset(&scr.getPixel(x, y), color, x2 - x);
+      std::memset(&scr.GetPixel(x, y), color, x2 - x);
     }
   }
 }
 
-void fill(Bitmap& scr, int color) { std::memset(scr.pixels, color, scr.pitch * scr.h); }
+void Fill(Bitmap& scr, int color) { std::memset(scr.pixels, color, scr.pitch * scr.h); }
 
-void drawBar(Bitmap& scr, int x, int y, int width, int color) {
-  drawBar(scr, x, y, width, 2, color);
+void DrawBar(Bitmap& scr, int x, int y, int width, int color) {
+  DrawBar(scr, x, y, width, 2, color);
 }
 
-void drawBar(Bitmap& scr, int x, int y, int width, int height, int color) {
+void DrawBar(Bitmap& scr, int x, int y, int width, int height, int color) {
   for (int h = 0; h < height; h++) {
     if (width > 0) {
-      std::memset(&scr.getPixel(x, y + h), color, width);
+      std::memset(&scr.GetPixel(x, y + h), color, width);
     }
   }
 }
 
-void vline(Bitmap& scr, int x, int y1, int y2, int color) {
+void Vline(Bitmap& scr, int x, int y1, int y2, int color) {
   if (x < scr.clip_rect.x1 || x >= scr.clip_rect.x2) return;
 
   y1 = std::max(y1, (int)scr.clip_rect.y1);
   y2 = std::min(y2, (int)scr.clip_rect.y2);
 
-  for (; y1 < y2; ++y1) scr.getPixel(x, y1) = color;
+  for (; y1 < y2; ++y1) scr.GetPixel(x, y1) = color;
 }
 
-void drawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width) {
-  fillRect(scr, x, y + 1, width + 3, height - 2, color);
-  fillRect(scr, x + 1, y, width + 1, 1, color);
-  fillRect(scr, x + 1, y + height - 1, width + 1, 1, color);
+void DrawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width) {
+  FillRect(scr, x, y + 1, width + 3, height - 2, color);
+  FillRect(scr, x + 1, y, width + 1, 1, color);
+  FillRect(scr, x + 1, y + height - 1, width + 1, 1, color);
   /*
   height--;
-  std::memset(&scr.getPixel(x+1,y), color, width+1);
+  std::memset(&scr.GetPixel(x+1,y), color, width+1);
   for(long i=1; i<height; i++)
   {
-          std::memset(&scr.getPixel(x,y+i), color, width+3);
+          std::memset(&scr.GetPixel(x,y+i), color, width+3);
   }
-  std::memset(&scr.getPixel(x+1,y+height), color, width+1);*/
+  std::memset(&scr.GetPixel(x+1,y+height), color, width+1);*/
 }
 
-void drawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int height) {
-  fillRect(scr, x + 1, y, width - 2, 1, color);
-  fillRect(scr, x + 1, y + height - 1, width - 2, 1, color);
-  fillRect(scr, x, y + 1, 1, height - 2, color);
-  fillRect(scr, x + width - 1, y + 1, 1, height - 2, color);
+void DrawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int height) {
+  FillRect(scr, x + 1, y, width - 2, 1, color);
+  FillRect(scr, x + 1, y + height - 1, width - 2, 1, color);
+  FillRect(scr, x, y + 1, 1, height - 2, color);
+  FillRect(scr, x + width - 1, y + 1, 1, height - 2, color);
 }
 
 #define DASH()                                                  \
   do {                                                          \
-    if (scr.clip_rect.inside(x1, y1) && ((p + phase) % 4) < 2)  \
-      scr.getPixel(x1, y1) = (p >= color2lim) ? color : color2; \
+    if (scr.clip_rect.Inside(x1, y1) && ((p + phase) % 4) < 2)  \
+      scr.GetPixel(x1, y1) = (p >= color2lim) ? color : color2; \
     ++p;                                                        \
   } while (0)
 
-void drawDashedLineBox(Bitmap& scr, int x, int y, int color, int color2, int num, int den,
+void DrawDashedLineBox(Bitmap& scr, int x, int y, int color, int color2, int num, int den,
                        int width, int height, int phase) {
   int p = 0;
   int x1, y1;
@@ -102,7 +102,7 @@ void drawDashedLineBox(Bitmap& scr, int x, int y, int color, int color2, int num
   for (x1 = x + width - 2; x1 > x; --x1) DASH();
 }
 
-void blitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height,
+void BlitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height,
                           int pitch) {
   CLIP_IMAGE(scr.clip_rect);
 
@@ -120,7 +120,7 @@ void blitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int
   int pitch = (s).pitch, width = (s).width, height = (s).height; \
   PalIdx* mem = (s).mem
 
-void blitImage(Bitmap& scr, Sprite spr, int x, int y) {
+void BlitImage(Bitmap& scr, Sprite spr, int x, int y) {
   UNPACK_SPRITE(spr);
 
   CLIP_IMAGE(scr.clip_rect);
@@ -143,7 +143,7 @@ void blitImage(Bitmap& scr, Sprite spr, int x, int y) {
   }
 }
 
-void blitImageTrans(Bitmap& scr, Sprite spr, int x, int y, int phase) {
+void BlitImageTrans(Bitmap& scr, Sprite spr, int x, int y, int phase) {
   UNPACK_SPRITE(spr);
 
   CLIP_IMAGE(scr.clip_rect);
@@ -232,18 +232,18 @@ void blitImageTrans(Bitmap& scr, Sprite spr, int x, int y, int phase) {
     }                                                     \
   } while (false)
 
-void blitImageR(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height) {
+void BlitImageR(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height) {
   int pitch = width;
 
   CLIP_IMAGE(scr.clip_rect);
 
   PalIdx* scrptr = static_cast<PalIdx*>(scr.pixels) + y * scr.pitch + x;
 
-  for (int y_ = 0; y_ < height; ++y_) {
+  for (int y = 0; y < height; ++y) {
     PalIdx* rowdest = scrptr;
     PalIdx* rowsrc = mem;
 
-    for (int x_ = 0; x_ < width; ++x_) {
+    for (int x = 0; x < width; ++x) {
       PalIdx c = *rowsrc;
       if (c && (PalIdx(*rowdest - 160) < 8)) *rowdest = c;
       ++rowsrc;
@@ -255,7 +255,7 @@ void blitImageR(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height) {
   }
 }
 
-void blitFireCone(Bitmap& scr, int fc, PalIdx* mem, int x, int y) {
+void BlitFireCone(Bitmap& scr, int fc, PalIdx* mem, int x, int y) {
   int width = 16;
   int height = 16;
   int pitch = width;
@@ -289,17 +289,17 @@ void blitFireCone(Bitmap& scr, int fc, PalIdx* mem, int x, int y) {
   }
 }
 
-void blitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int width,
+void BlitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int width,
                     int height) {
   int pitch = width;
-  Rect clipRect(0, 0, level.width, level.height);
+  Rect clip_rect(0, 0, level.width, level.height);
 
-  CLIP_IMAGE(clipRect);
+  CLIP_IMAGE(clip_rect);
 
   BLITL(&level.data[0], level.width, &level.materials[0], {
     if (c) {
       PalIdx n;
-      if (rowmatdest->dirtBack())
+      if (rowmatdest->DirtBack())
         n = c;
       else
         n = c + 3;
@@ -309,7 +309,7 @@ void blitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int
   });
 }
 
-void blitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int width,
+void BlitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int width,
                      int height) {
   int pitch = width;
 
@@ -317,13 +317,13 @@ void blitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int
 
   PalIdx* scrptr = static_cast<PalIdx*>(scr.pixels) + y * scr.pitch + x;
 
-  for (int y_ = 0; y_ < height; ++y_) {
+  for (int y = 0; y < height; ++y) {
     PalIdx* rowdest = scrptr;
     PalIdx* rowsrc = mem;
 
-    for (int x_ = 0; x_ < width; ++x_) {
+    for (int x = 0; x < width; ++x) {
       PalIdx c = *rowsrc;
-      if (c && common.materials[*rowdest].seeShadow())  // TODO: Speed up this test?
+      if (c && common.materials[*rowdest].SeeShadow())  // TODO: Speed up this test?
         *rowdest += 4;
       ++rowsrc;
       ++rowdest;
@@ -334,7 +334,7 @@ void blitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int
   }
 }
 
-void blitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y) {
+void BlitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y) {
   int width = 16;
   int height = 16;
   int pitch = width;
@@ -343,19 +343,19 @@ void blitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y)
 
   CLIP_IMAGE(clip);
 
-  PalIdx* dest = level.pixelp(x, y);
-  Material* matdest = level.matp(x, y);
+  PalIdx* dest = level.Pixelp(x, y);
+  Material* matdest = level.Matp(x, y);
 
   if (p1) {
-    for (int y_ = 0; y_ < height; ++y_) {
+    for (int y = 0; y < height; ++y) {
       PalIdx* rowdest = dest;
       Material* rowmatdest = matdest;
       PalIdx* rowsrc = mem;
 
-      for (int x_ = 0; x_ < width; ++x_) {
+      for (int x = 0; x < width; ++x) {
         PalIdx c = *rowsrc;
         PalIdx n;
-        if (c && rowmatdest->dirtBack())  // TODO: Speed up this test?
+        if (c && rowmatdest->DirtBack())  // TODO: Speed up this test?
           n = c;
         else
           n = c + 3;
@@ -371,12 +371,12 @@ void blitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y)
       mem += pitch;
     }
   } else {
-    for (int y_ = 0; y_ < height; ++y_) {
+    for (int y = 0; y < height; ++y) {
       PalIdx* rowdest = dest;
       Material* rowmatdest = matdest;
       PalIdx* rowsrc = mem;
 
-      for (int x_ = 0; x_ < width; ++x_) {
+      for (int x = 0; x < width; ++x) {
         PalIdx c = *rowsrc;
         if (c) {
           *rowdest = c;
@@ -395,40 +395,40 @@ void blitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y)
   }
 }
 
-void drawDirtEffect(Common& common, Rand& rand, Level& level, int dirtEffect, int x, int y) {
-  assert(dirtEffect >= 0 && dirtEffect < 9);
-  Texture& tex = common.textures[dirtEffect];
-  PalIdx* tFrame = common.largeSprites.spritePtr(tex.sFrame + rand(tex.rFrame));
-  PalIdx* mFrame = common.largeSprites.spritePtr(tex.mFrame);
+void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, int x, int y) {
+  assert(dirt_effect >= 0 && dirt_effect < 9);
+  Texture& tex = common.textures[dirt_effect];
+  PalIdx* t_frame = common.large_sprites.SpritePtr(tex.s_frame + rand(tex.r_frame));
+  PalIdx* m_frame = common.large_sprites.SpritePtr(tex.m_frame);
 
   int width = 16;
   int height = 16;
   int pitch = width;
-  PalIdx* mem = mFrame;
+  PalIdx* mem = m_frame;
 
   Rect clip(0, 0, level.width, level.height - 1);
 
   CLIP_IMAGE(clip);
 
-  if (tex.nDrawBack) {
+  if (tex.n_draw_back) {
     BLITL(&level.data[0], level.width, &level.materials[0], {
       switch (c) {
         case 6:
-          if (rowmatdest->anyDirt()) {
+          if (rowmatdest->AnyDirt()) {
             int mx = x + x_;
             int my = y + y_;
 
-            *rowdest = tFrame[((my & 15) << 4) + (mx & 15)];
+            *rowdest = t_frame[((my & 15) << 4) + (mx & 15)];
             *rowmatdest = common.materials[*rowdest];
           }
           break;
 
         case 1:
           Material m = *rowmatdest;
-          if (m.dirt2()) {
+          if (m.Dirt2()) {
             *rowdest = 2;
             *rowmatdest = common.materials[2];
-          } else if (m.dirt()) {
+          } else if (m.Dirt()) {
             *rowdest = 1;
             *rowmatdest = common.materials[1];
           }
@@ -439,24 +439,24 @@ void drawDirtEffect(Common& common, Rand& rand, Level& level, int dirtEffect, in
       switch (c) {
         case 10:
         case 6:
-          if (rowmatdest->background()) {
+          if (rowmatdest->Background()) {
             int mx = x + x_;
             int my = y + y_;
 
-            *rowdest = tFrame[((my & 15) << 4) + (mx & 15)];
+            *rowdest = t_frame[((my & 15) << 4) + (mx & 15)];
             *rowmatdest = common.materials[*rowdest];
           }
           break;
 
         case 2:
-          if (rowmatdest->background()) {
+          if (rowmatdest->Background()) {
             *rowdest = 2;
             *rowmatdest = common.materials[2];
           }
           break;
 
         case 1:
-          if (rowmatdest->background()) {
+          if (rowmatdest->Background()) {
             *rowdest = 1;
             *rowmatdest = common.materials[1];
           }
@@ -465,18 +465,18 @@ void drawDirtEffect(Common& common, Rand& rand, Level& level, int dirtEffect, in
   }
 }
 
-void correctShadow(Common& common, Level& level, Rect rect) {
-  rect.intersect(Rect(0, 3, level.width - 3, level.height));
+void CorrectShadow(Common& common, Level& level, Rect rect) {
+  rect.Intersect(Rect(0, 3, level.width - 3, level.height));
 
   for (int x = rect.x1; x < rect.x2; ++x)
     for (int y = rect.y1; y < rect.y2; ++y) {
-      PalIdx pix = level.pixel(x, y);
+      PalIdx pix = level.Pixel(x, y);
 
-      if (level.mat(x, y).seeShadow() && level.mat(x + 3, y - 3).dirtRock()) {
-        level.setPixel(x, y, pix + 4, common);
+      if (level.Mat(x, y).SeeShadow() && level.Mat(x + 3, y - 3).DirtRock()) {
+        level.SetPixel(x, y, pix + 4, common);
       } else if (pix >= 164  // Remove shadow
-                 && pix <= 167 && !level.mat(x + 3, y - 3).dirtRock()) {
-        level.setPixel(x, y, pix - 4, common);
+                 && pix <= 167 && !level.Mat(x + 3, y - 3).DirtRock()) {
+        level.SetPixel(x, y, pix - 4, common);
       }
     }
 }
@@ -518,7 +518,7 @@ inline int sign(int v) { return v < 0 ? -1 : (v > 0 ? 1 : 0); }
     }                     \
   }
 
-void drawNinjarope(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY) {
+void DrawNinjarope(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY) {
   int color = LC(NRColourBegin);
 
   Rect& clip = scr.clip_rect;
@@ -528,90 +528,90 @@ void drawNinjarope(Common& common, Bitmap& scr, int fromX, int fromY, int toX, i
   DO_LINE({
     if (++color == LC(NRColourEnd)) color = LC(NRColourBegin);
 
-    if (clip.inside(cx, cy)) ptr[cy * pitch + cx] = color;
+    if (clip.Inside(cx, cy)) ptr[cy * pitch + cx] = color;
   });
 }
 
-void drawLaserSight(Bitmap& scr, Rand& rand, int fromX, int fromY, int toX, int toY) {
+void DrawLaserSight(Bitmap& scr, Rand& rand, int fromX, int fromY, int toX, int toY) {
   Rect& clip = scr.clip_rect;
   PalIdx* ptr = scr.pixels;
   unsigned int pitch = scr.pitch;
 
   DO_LINE({
     if (rand(5) == 0) {
-      if (clip.inside(cx, cy)) ptr[cy * pitch + cx] = rand(2) + 83;
+      if (clip.Inside(cx, cy)) ptr[cy * pitch + cx] = rand(2) + 83;
     }
   });
 }
 
-void drawShadowLine(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY) {
+void DrawShadowLine(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY) {
   Rect& clip = scr.clip_rect;
   PalIdx* ptr = scr.pixels;
   unsigned int pitch = scr.pitch;
 
   DO_LINE({
-    if (clip.inside(cx, cy)) {
+    if (clip.Inside(cx, cy)) {
       PalIdx& pix = ptr[cy * pitch + cx];
-      if (common.materials[pix].seeShadow()) pix += 4;
+      if (common.materials[pix].SeeShadow()) pix += 4;
     }
   });
 }
 
-void drawLine(Bitmap& scr, int fromX, int fromY, int toX, int toY, int color) {
+void DrawLine(Bitmap& scr, int fromX, int fromY, int toX, int toY, int color) {
   Rect& clip = scr.clip_rect;
   PalIdx* ptr = scr.pixels;
   unsigned int pitch = scr.pitch;
 
   DO_LINE({
-    if (clip.inside(cx, cy)) {
+    if (clip.Inside(cx, cy)) {
       ptr[cy * pitch + cx] = color;
     }
   });
 }
 
-void drawGraph(Bitmap& scr, std::vector<double> const& data, int height, int startX, int startY,
-               int color, int negColor, bool balanced) {
+void DrawGraph(Bitmap& scr, std::vector<double> const& data, int height, int start_x, int start_y,
+               int color, int neg_color, bool balanced) {
   if (!data.empty()) {
-    int x = startX;
+    int x = start_x;
 
-    int baseY = startY + (balanced ? height / 2 : height);
+    int base_y = start_y + (balanced ? height / 2 : height);
 
     for (double v : data) {
-      int y1 = baseY - (int)std::floor(v + 0.5);
-      int y2 = baseY;
+      int y1 = base_y - (int)std::floor(v + 0.5);
+      int y2 = base_y;
       if (y1 > y2) std::swap(y1, y2);
-      vline(scr, x, y1, y2, v >= 0 ? color : negColor);
+      Vline(scr, x, y1, y2, v >= 0 ? color : neg_color);
       ++x;
     }
   }
 
-  drawRoundedLineBox(scr, startX, startY, 7, (int)data.size(), height);
+  DrawRoundedLineBox(scr, start_x, start_y, 7, (int)data.size(), height);
 }
 
-void drawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm) {
+void DrawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm) {
   int width = hm.width, height = hm.height;
   int pitch = width;
   int* mem = &hm.map[0];
 
   std::map<int, int> counts;
   int* p = mem;
-  int totalPixels = 0;
+  int total_pixels = 0;
   while (p != mem + width * height) {
     if (*p != 0) {
       ++counts[*p];
-      ++totalPixels;
+      ++total_pixels;
     }
     ++p;
   }
 
   std::map<int, int> mapping;
   int cum = 0;
-  int maxIdx = 119 - 104 + 1;
+  int max_idx = 119 - 104 + 1;
 
   mapping[0] = 0;
 
   for (auto& v : counts) {
-    mapping[v.first] = int(104 + int64_t(cum) * maxIdx / totalPixels);
+    mapping[v.first] = int(104 + int64_t(cum) * max_idx / total_pixels);
     cum += v.second;
   }
 
@@ -623,23 +623,23 @@ void drawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm) {
   });
 }
 
-void scaleDraw(PalIdx* src, int w, int h, std::size_t srcPitch, uint8_t* dest,
-               std::size_t destPitch, int mag, uint32_t* pal32) {
+void ScaleDraw(PalIdx* src, int w, int h, std::size_t src_pitch, uint8_t* dest,
+               std::size_t dest_pitch, int mag, uint32_t* pal32) {
   if (mag == 1) {
     for (int y = 0; y < h; ++y) {
-      PalIdx* line = src + y * srcPitch;
-      uint32_t* destLine = reinterpret_cast<uint32_t*>(dest + y * destPitch);
+      PalIdx* line = src + y * src_pitch;
+      uint32_t* dest_line = reinterpret_cast<uint32_t*>(dest + y * dest_pitch);
 
       for (int x = 0; x < w; ++x) {
         PalIdx pix = *line++;
-        *destLine++ = pal32[pix];
+        *dest_line++ = pal32[pix];
       }
     }
   } else if (mag > 1) {
     for (int y = 0; y < h; ++y) {
-      PalIdx* line = src + y * srcPitch;
-      int destMagPitch = mag * (int)destPitch;
-      uint8_t* destLine = dest + y * destMagPitch;
+      PalIdx* line = src + y * src_pitch;
+      int dest_mag_pitch = mag * (int)dest_pitch;
+      uint8_t* dest_line = dest + y * dest_mag_pitch;
 
       for (int x = 0; x < w / 4; ++x) {
         uint32_t pix = *reinterpret_cast<uint32_t*>(line);
@@ -651,52 +651,52 @@ void scaleDraw(PalIdx* src, int w, int h, std::size_t srcPitch, uint8_t* dest,
         uint32_t d = pal32[pix & 0x000000ff];
 
         for (int dx = 0; dx < mag; ++dx) {
-          for (int dy = 0; dy < destMagPitch; dy += (int)destPitch) {
-            *reinterpret_cast<uint32_t*>(destLine + dy) = d;
+          for (int dy = 0; dy < dest_mag_pitch; dy += (int)dest_pitch) {
+            *reinterpret_cast<uint32_t*>(dest_line + dy) = d;
           }
-          destLine += 4;
+          dest_line += 4;
         }
         for (int dx = 0; dx < mag; ++dx) {
-          for (int dy = 0; dy < destMagPitch; dy += (int)destPitch) {
-            *reinterpret_cast<uint32_t*>(destLine + dy) = c;
+          for (int dy = 0; dy < dest_mag_pitch; dy += (int)dest_pitch) {
+            *reinterpret_cast<uint32_t*>(dest_line + dy) = c;
           }
-          destLine += 4;
+          dest_line += 4;
         }
         for (int dx = 0; dx < mag; ++dx) {
-          for (int dy = 0; dy < destMagPitch; dy += (int)destPitch) {
-            *reinterpret_cast<uint32_t*>(destLine + dy) = b;
+          for (int dy = 0; dy < dest_mag_pitch; dy += (int)dest_pitch) {
+            *reinterpret_cast<uint32_t*>(dest_line + dy) = b;
           }
-          destLine += 4;
+          dest_line += 4;
         }
         for (int dx = 0; dx < mag; ++dx) {
-          for (int dy = 0; dy < destMagPitch; dy += (int)destPitch) {
-            *reinterpret_cast<uint32_t*>(destLine + dy) = a;
+          for (int dy = 0; dy < dest_mag_pitch; dy += (int)dest_pitch) {
+            *reinterpret_cast<uint32_t*>(dest_line + dy) = a;
           }
-          destLine += 4;
+          dest_line += 4;
         }
       }
     }
   }
 }
 
-void preparePaletteBgra(Color realPal[256], uint32_t (&pal32)[256]) {
+void PreparePaletteBgra(Color real_pal[256], uint32_t (&pal32)[256]) {
   for (int i = 0; i < 256; ++i) {
-    pal32[i] = (realPal[i].r << 16) | (realPal[i].g << 8) | realPal[i].b;
+    pal32[i] = (real_pal[i].r << 16) | (real_pal[i].g << 8) | real_pal[i].b;
   }
 }
 
-int fitScreen(int backW, int backH, int scrW, int scrH, int& offsetX, int& offsetY) {
+int FitScreen(int back_w, int back_h, int scr_w, int scr_h, int& offset_x, int& offset_y) {
   int mag = 1;
 
-  while (scrW * mag <= backW && scrH * mag <= backH) ++mag;
+  while (scr_w * mag <= back_w && scr_h * mag <= back_h) ++mag;
 
   --mag;  // mag was the first that didn't fit
 
-  scrW *= mag;
-  scrH *= mag;
+  scr_w *= mag;
+  scr_h *= mag;
 
-  offsetX = backW / 2 - scrW / 2;
-  offsetY = backH / 2 - scrH / 2;
+  offset_x = back_w / 2 - scr_w / 2;
+  offset_y = back_h / 2 - scr_h / 2;
 
   return mag;
 }

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -11,66 +11,66 @@ struct Common;
 struct Rand;
 struct Bitmap;
 
-void vline(Bitmap& scr, int x, int y1, int y2, int color);
+void Vline(Bitmap& scr, int x, int y1, int y2, int color);
 
-void fillRect(Bitmap& scr, int x, int y, int w, int h, int color);
-void fill(Bitmap& scr, int color);
-void drawBar(Bitmap& scr, int x, int y, int width, int color);
-void drawBar(Bitmap& scr, int x, int y, int width, int height, int color);
-void drawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width);
-void drawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int height);
-void blitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height, int pitch);
+void FillRect(Bitmap& scr, int x, int y, int w, int h, int color);
+void Fill(Bitmap& scr, int color);
+void DrawBar(Bitmap& scr, int x, int y, int width, int color);
+void DrawBar(Bitmap& scr, int x, int y, int width, int height, int color);
+void DrawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width);
+void DrawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int height);
+void BlitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height, int pitch);
 // void blitImage(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height);
-void blitImage(Bitmap& scr, Sprite spr, int x, int y);
-void blitImageR(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height);
-void blitImageTrans(Bitmap& scr, Sprite spr, int x, int y, int phase);
-void blitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int width, int height);
-void blitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y);
-void blitFireCone(Bitmap& scr, int fc, PalIdx* mem, int x, int y);
-void drawDirtEffect(Common& common, Rand& rand, Level& level, int dirtEffect, int x, int y);
-void blitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int width, int height);
-void correctShadow(Common& common, Level& level, Rect rect);
-void drawDashedLineBox(Bitmap& scr, int x, int y, int color, int color2, int num, int den,
+void BlitImage(Bitmap& scr, Sprite spr, int x, int y);
+void BlitImageR(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height);
+void BlitImageTrans(Bitmap& scr, Sprite spr, int x, int y, int phase);
+void BlitShadowImage(Common& common, Bitmap& scr, PalIdx* mem, int x, int y, int width, int height);
+void BlitStone(Common& common, Level& level, bool p1, PalIdx* mem, int x, int y);
+void BlitFireCone(Bitmap& scr, int fc, PalIdx* mem, int x, int y);
+void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, int x, int y);
+void BlitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int width, int height);
+void CorrectShadow(Common& common, Level& level, Rect rect);
+void DrawDashedLineBox(Bitmap& scr, int x, int y, int color, int color2, int num, int den,
                        int width, int height, int phase);
 
-void drawNinjarope(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY);
-void drawLaserSight(Bitmap& scr, Rand& rand, int fromX, int fromY, int toX, int toY);
-void drawShadowLine(Common& common, Bitmap& scr, int fromX, int fromY, int toX, int toY);
-void drawLine(Bitmap& scr, int fromX, int fromY, int toX, int toY, int color);
+void DrawNinjarope(Common& common, Bitmap& scr, int from_x, int from_y, int to_x, int to_y);
+void DrawLaserSight(Bitmap& scr, Rand& rand, int from_x, int from_y, int to_x, int to_y);
+void DrawShadowLine(Common& common, Bitmap& scr, int from_x, int from_y, int to_x, int to_y);
+void DrawLine(Bitmap& scr, int from_x, int from_y, int to_x, int to_y, int color);
 
-void drawGraph(Bitmap& scr, std::vector<double> const& data, int height, int startX, int startY,
-               int color, int negColor, bool balanced);
+void DrawGraph(Bitmap& scr, std::vector<double> const& data, int height, int start_x, int start_y,
+               int color, int neg_color, bool balanced);
 
-void scaleDraw(PalIdx* src, int w, int h, std::size_t srcPitch, uint8_t* dest,
-               std::size_t destPitch, int mag, uint32_t* pal32);
+void ScaleDraw(PalIdx* src, int w, int h, std::size_t src_pitch, uint8_t* dest,
+               std::size_t dest_pitch, int mag, uint32_t* pal32);
 
-void preparePaletteBgra(Color realPal[256], uint32_t (&pal32)[256]);
-int fitScreen(int backW, int backH, int scrW, int scrH, int& offsetX, int& offsetY);
+void PreparePaletteBgra(Color real_pal[256], uint32_t (&pal32)[256]);
+int FitScreen(int back_w, int back_h, int scr_w, int scr_h, int& offset_x, int& offset_y);
 
-inline void blitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height) {
-  blitImageNoKeyColour(scr, mem, x, y, width, height, width);
+inline void BlitImageNoKeyColour(Bitmap& scr, PalIdx* mem, int x, int y, int width, int height) {
+  BlitImageNoKeyColour(scr, mem, x, y, width, height, width);
 }
 
 struct Heatmap {
-  Heatmap(int width, int height, int orgWidth, int orgHeight)
+  Heatmap(int width, int height, int org_width, int org_height)
       : width(width),
         height(height),
-        orgWidth(orgWidth),
-        orgHeight(orgHeight),
+        org_width(org_width),
+        org_height(org_height),
         map(width * height) {}
 
-  void inc(int x, int y, int v = 1) {
-    x = (x * width) / orgWidth;
-    y = (y * height) / orgHeight;
+  void Inc(int x, int y, int v = 1) {
+    x = (x * width) / org_width;
+    y = (y * height) / org_height;
     x = std::min(std::max(x, 0), width - 1);
     y = std::min(std::max(y, 0), height - 1);
 
     map[y * width + x] += v;
   }
 
-  void incArea(int x, int y, int v = 1) {
-    x = (x * width) / orgWidth;
-    y = (y * height) / orgHeight;
+  void IncArea(int x, int y, int v = 1) {
+    x = (x * width) / org_width;
+    y = (y * height) / org_height;
     x = std::min(std::max(x, 0), width - 1);
     y = std::min(std::max(y, 0), height - 1);
 
@@ -86,9 +86,9 @@ struct Heatmap {
   }
 
   int width, height;
-  int orgWidth, orgHeight;
+  int org_width, org_height;
 
   std::vector<int> map;
 };
 
-void drawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm);
+void DrawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm);

--- a/src/game/gfx/font.cpp
+++ b/src/game/gfx/font.cpp
@@ -54,8 +54,8 @@ unsigned char CodepointToFontByte(char32_t cp) {
 
 }  // namespace
 
-void Font::DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color,
-                    int size) {
+void Font::DrawString(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color,
+                      int size) {
   int org_x = x;
 
   for (std::size_t i = 0; i < len;) {
@@ -80,7 +80,7 @@ void Font::DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y,
 
 void Font::DrawFramedText(Bitmap& scr, std::string const& text, int x, int y, int color) {
   DrawRoundedBox(scr, x, y, 0, 7, GetDims(text));
-  DrawText(scr, text, x + 2, y + 1, color);
+  DrawString(scr, text, x + 2, y + 1, color);
 }
 
 int Font::GetDims(char const* str, std::size_t len, int* height) {

--- a/src/game/gfx/font.cpp
+++ b/src/game/gfx/font.cpp
@@ -5,7 +5,7 @@
 #include "color.hpp"
 #include "macros.hpp"
 
-void Font::drawChar(Bitmap& scr, unsigned char c, int x, int y, int color, int size) {
+void Font::DrawChar(Bitmap& scr, unsigned char c, int x, int y, int color, int size) {
   if (c >= 2 && c < 252)  // TODO: Is this correct, shouldn't it be c >= 0 && c < 250, since
                           // drawText subtracts 2?
   {
@@ -47,63 +47,63 @@ void Font::drawChar(Bitmap& scr, unsigned char c, int x, int y, int color, int s
 // drawChar already ignores any byte outside [2, 252), so this stays in sync.
 namespace {
 
-unsigned char codepointToFontByte(char32_t cp) {
-  int b = cp437::unicodeToByte(cp);
+unsigned char CodepointToFontByte(char32_t cp) {
+  int b = cp437::UnicodeToByte(cp);
   return b < 0 ? 1 : static_cast<unsigned char>(b);  // 1 = skip-no-draw
 }
 
 }  // namespace
 
-void Font::drawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color,
+void Font::DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color,
                     int size) {
-  int orgX = x;
+  int org_x = x;
 
   for (std::size_t i = 0; i < len;) {
-    char32_t cp = cp437::utf8DecodeNext(str, len, i);
+    char32_t cp = cp437::Utf8DecodeNext(str, len, i);
 
     if (cp == 0) {
-      x = orgX;
+      x = org_x;
       y += 8 * size;
       continue;
     }
 
-    unsigned char c = codepointToFontByte(cp);
+    unsigned char c = CodepointToFontByte(cp);
     if (c >= 2 && c < 252) {
       c -= 2;
 
-      drawChar(scr, c, x, y, color, size);
+      DrawChar(scr, c, x, y, color, size);
 
       x += chars[c].width * size;
     }
   }
 }
 
-void Font::drawFramedText(Bitmap& scr, std::string const& text, int x, int y, int color) {
-  drawRoundedBox(scr, x, y, 0, 7, getDims(text));
-  drawText(scr, text, x + 2, y + 1, color);
+void Font::DrawFramedText(Bitmap& scr, std::string const& text, int x, int y, int color) {
+  DrawRoundedBox(scr, x, y, 0, 7, GetDims(text));
+  DrawText(scr, text, x + 2, y + 1, color);
 }
 
-int Font::getDims(char const* str, std::size_t len, int* height) {
+int Font::GetDims(char const* str, std::size_t len, int* height) {
   int width = 0;
-  int maxHeight = 8;
+  int max_height = 8;
 
-  int maxWidth = 0;
+  int max_width = 0;
 
   for (std::size_t i = 0; i < len;) {
-    char32_t cp = cp437::utf8DecodeNext(str, len, i);
+    char32_t cp = cp437::Utf8DecodeNext(str, len, i);
 
     if (cp == 0) {
-      maxWidth = std::max(maxWidth, width);
+      max_width = std::max(max_width, width);
       width = 0;
-      maxHeight += 8;
+      max_height += 8;
       continue;
     }
 
-    unsigned char c = codepointToFontByte(cp);
+    unsigned char c = CodepointToFontByte(cp);
     if (c >= 2 && c < 252) width += chars[c - 2].width;
   }
 
-  if (height) *height = maxHeight;
+  if (height) *height = max_height;
 
-  return std::max(maxWidth, width);
+  return std::max(max_width, width);
 }

--- a/src/game/gfx/font.hpp
+++ b/src/game/gfx/font.hpp
@@ -15,7 +15,7 @@ struct Font {
 
   Font() : chars(250) {}
 
-  void DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color, int size);
+  void DrawString(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color, int size);
   int GetDims(char const* str, std::size_t len, int* height = 0);
   void DrawChar(Bitmap& scr, unsigned char ch, int x, int y, int color, int size);
 
@@ -25,7 +25,7 @@ struct Font {
 
   void DrawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color, int size) {
     int len = GetDims(str) * size;
-    DrawText(scr, str.data(), str.size(), x - (len / 2), y, color, size);
+    DrawString(scr, str.data(), str.size(), x - (len / 2), y, color, size);
   }
 
   void DrawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color) {
@@ -35,19 +35,19 @@ struct Font {
   // draws text with a simple shadow underneath it, so even text that would blend into the
   // background can be displayed
   void DrawShadowedText(Bitmap& scr, std::string const& str, int x, int y, int color) {
-    DrawText(scr, str, x + 1, y + 1, color / 2);
-    DrawText(scr, str, x, y, color);
+    DrawString(scr, str, x + 1, y + 1, color / 2);
+    DrawString(scr, str, x, y, color);
   }
 
-  void DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color) {
-    DrawText(scr, str, len, x, y, color, 1);
+  void DrawString(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color) {
+    DrawString(scr, str, len, x, y, color, 1);
   }
 
-  void DrawText(Bitmap& scr, std::string const& str, int x, int y, int color) {
-    DrawText(scr, str.data(), str.size(), x, y, color, 1);
+  void DrawString(Bitmap& scr, std::string const& str, int x, int y, int color) {
+    DrawString(scr, str.data(), str.size(), x, y, color, 1);
   }
 
-  void DrawText(Bitmap& scr, TextCell const& str, int x, int y, int color) {
+  void DrawString(Bitmap& scr, TextCell const& str, int x, int y, int color) {
     if (str.buffer.empty()) return;
 
     if (str.placement != TextCell::kLeft) {
@@ -59,7 +59,8 @@ struct Font {
         x -= w;
     }
 
-    DrawText(scr, reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size(), x, y, color, 1);
+    DrawString(scr, reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size(), x, y, color,
+               1);
   }
 
   int GetDims(std::string const& str, int* height = 0) {

--- a/src/game/gfx/font.hpp
+++ b/src/game/gfx/font.hpp
@@ -15,58 +15,58 @@ struct Font {
 
   Font() : chars(250) {}
 
-  void drawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color, int size);
-  int getDims(char const* str, std::size_t len, int* height = 0);
-  void drawChar(Bitmap& scr, unsigned char ch, int x, int y, int color, int size);
+  void DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color, int size);
+  int GetDims(char const* str, std::size_t len, int* height = 0);
+  void DrawChar(Bitmap& scr, unsigned char ch, int x, int y, int color, int size);
 
-  void drawChar(Bitmap& scr, unsigned char ch, int x, int y, int color) {
-    drawChar(scr, ch, x, y, color, 1);
+  void DrawChar(Bitmap& scr, unsigned char ch, int x, int y, int color) {
+    DrawChar(scr, ch, x, y, color, 1);
   }
 
-  void drawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color, int size) {
-    int len = getDims(str) * size;
-    drawText(scr, str.data(), str.size(), x - (len / 2), y, color, size);
+  void DrawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color, int size) {
+    int len = GetDims(str) * size;
+    DrawText(scr, str.data(), str.size(), x - (len / 2), y, color, size);
   }
 
-  void drawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color) {
-    drawCenteredText(scr, str, x, y, color, 1);
+  void DrawCenteredText(Bitmap& scr, std::string const& str, int x, int y, int color) {
+    DrawCenteredText(scr, str, x, y, color, 1);
   }
 
   // draws text with a simple shadow underneath it, so even text that would blend into the
   // background can be displayed
-  void drawShadowedText(Bitmap& scr, std::string const& str, int x, int y, int color) {
-    drawText(scr, str, x + 1, y + 1, color / 2);
-    drawText(scr, str, x, y, color);
+  void DrawShadowedText(Bitmap& scr, std::string const& str, int x, int y, int color) {
+    DrawText(scr, str, x + 1, y + 1, color / 2);
+    DrawText(scr, str, x, y, color);
   }
 
-  void drawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color) {
-    drawText(scr, str, len, x, y, color, 1);
+  void DrawText(Bitmap& scr, char const* str, std::size_t len, int x, int y, int color) {
+    DrawText(scr, str, len, x, y, color, 1);
   }
 
-  void drawText(Bitmap& scr, std::string const& str, int x, int y, int color) {
-    drawText(scr, str.data(), str.size(), x, y, color, 1);
+  void DrawText(Bitmap& scr, std::string const& str, int x, int y, int color) {
+    DrawText(scr, str.data(), str.size(), x, y, color, 1);
   }
 
-  void drawText(Bitmap& scr, TextCell const& str, int x, int y, int color) {
+  void DrawText(Bitmap& scr, TextCell const& str, int x, int y, int color) {
     if (str.buffer.empty()) return;
 
-    if (str.placement != TextCell::Left) {
-      int w = getDims(reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size());
+    if (str.placement != TextCell::kLeft) {
+      int w = GetDims(reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size());
 
-      if (str.placement == TextCell::Center)
+      if (str.placement == TextCell::kCenter)
         x -= w / 2;
-      else if (str.placement == TextCell::Right)
+      else if (str.placement == TextCell::kRight)
         x -= w;
     }
 
-    drawText(scr, reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size(), x, y, color, 1);
+    DrawText(scr, reinterpret_cast<char const*>(&str.buffer[0]), str.buffer.size(), x, y, color, 1);
   }
 
-  int getDims(std::string const& str, int* height = 0) {
-    return getDims(str.data(), str.size(), height);
+  int GetDims(std::string const& str, int* height = 0) {
+    return GetDims(str.data(), str.size(), height);
   }
 
-  void drawFramedText(Bitmap& scr, std::string const& text, int x, int y, int color);
+  void DrawFramedText(Bitmap& scr, std::string const& text, int x, int y, int color);
 
   std::vector<Char> chars;
 };

--- a/src/game/gfx/palette.cpp
+++ b/src/game/gfx/palette.cpp
@@ -5,46 +5,46 @@
 #include "../settings.hpp"
 #include "io/stream.hpp"
 
-void Palette::activate(Color realPal[256]) {
+void Palette::Activate(Color real_pal[256]) {
   for (int i = 0; i < 256; ++i) {
-    realPal[i].r = entries[i].r << 2;
-    realPal[i].g = entries[i].g << 2;
-    realPal[i].b = entries[i].b << 2;
+    real_pal[i].r = entries[i].r << 2;
+    real_pal[i].g = entries[i].g << 2;
+    real_pal[i].b = entries[i].b << 2;
   }
 }
 
-int fadeValue(int v, int amount) {
+int FadeValue(int v, int amount) {
   assert(v < 64);
   v = (v * amount) >> 5;
   if (v < 0) v = 0;
   return v;
 }
 
-int lightUpValue(int v, int amount) {
+int LightUpValue(int v, int amount) {
   v = (v * (32 - amount) + amount * 63) >> 5;
   if (v > 63) v = 63;
   return v;
 }
 
-void Palette::fade(int amount) {
+void Palette::Fade(int amount) {
   if (amount >= 32) return;
 
   for (int i = 0; i < 256; ++i) {
-    entries[i].r = fadeValue(entries[i].r, amount);
-    entries[i].g = fadeValue(entries[i].g, amount);
-    entries[i].b = fadeValue(entries[i].b, amount);
+    entries[i].r = FadeValue(entries[i].r, amount);
+    entries[i].g = FadeValue(entries[i].g, amount);
+    entries[i].b = FadeValue(entries[i].b, amount);
   }
 }
 
-void Palette::lightUp(int amount) {
+void Palette::LightUp(int amount) {
   for (int i = 0; i < 256; ++i) {
-    entries[i].r = lightUpValue(entries[i].r, amount);
-    entries[i].g = lightUpValue(entries[i].g, amount);
-    entries[i].b = lightUpValue(entries[i].b, amount);
+    entries[i].r = LightUpValue(entries[i].r, amount);
+    entries[i].g = LightUpValue(entries[i].g, amount);
+    entries[i].b = LightUpValue(entries[i].b, amount);
   }
 }
 
-void Palette::rotateFrom(Palette& source, int from, int to, unsigned dist) {
+void Palette::RotateFrom(Palette& source, int from, int to, unsigned dist) {
   int count = (to - from + 1);
   dist %= count;
 
@@ -53,12 +53,12 @@ void Palette::rotateFrom(Palette& source, int from, int to, unsigned dist) {
   }
 }
 
-void Palette::clear() { std::memset(entries, 0, sizeof(entries)); }
+void Palette::Clear() { std::memset(entries, 0, sizeof(entries)); }
 
-void Palette::read(io::Reader& r) {
+void Palette::Read(io::Reader& r) {
   for (int i = 0; i < 256; ++i) {
     uint8_t rgb[3];
-    r.get(rgb, 3);
+    r.Get(rgb, 3);
 
     entries[i].r = rgb[0] & 63;
     entries[i].g = rgb[1] & 63;
@@ -66,20 +66,20 @@ void Palette::read(io::Reader& r) {
   }
 }
 
-int const Palette::wormColourIndexes[2] = {0x58, 0x78};  // TODO: Read from EXE?
+int const Palette::kWormColourIndexes[2] = {0x58, 0x78};  // TODO: Read from EXE?
 
 // Sprite palette bases per worm index (hardcoded in worm sprite precomputation)
-int const Palette::wormSpriteColorBase[2] = {32, 41};
+int const Palette::kWormSpriteColorBase[2] = {32, 41};
 
-void Palette::setWormColour(int i, WormSettings const& settings) {
+void Palette::SetWormColour(int i, WormSettings const& settings) {
   // Always write to the sprite-referenced palette positions for this worm index.
   // Worm sprites have hardcoded pixel values: 30-34 for worm 0, 39-43 for worm 1.
-  int idx = wormSpriteColorBase[i];
+  int idx = kWormSpriteColorBase[i];
 
-  setWormColoursSpan(idx, settings.rgb);
+  SetWormColoursSpan(idx, settings.rgb);
 
   for (int j = 0; j < 6; ++j) {
-    entries[wormColourIndexes[i] + j] = entries[idx + (j % 3) - 1];
+    entries[kWormColourIndexes[i] + j] = entries[idx + (j % 3) - 1];
   }
 
   for (int j = 0; j < 3; ++j) {
@@ -87,8 +87,8 @@ void Palette::setWormColour(int i, WormSettings const& settings) {
   }
 }
 
-void Palette::setWormColours(Settings const& settings) {
+void Palette::SetWormColours(Settings const& settings) {
   for (int i = 0; i < 2; ++i) {
-    setWormColour(i, *settings.wormSettings[i]);
+    SetWormColour(i, *settings.worm_settings[i]);
   }
 }

--- a/src/game/gfx/palette.hpp
+++ b/src/game/gfx/palette.hpp
@@ -12,18 +12,18 @@ struct Reader;
 }
 
 struct Palette {
-  static int const wormColourIndexes[2];
-  static int const wormSpriteColorBase[2];
+  static int const kWormColourIndexes[2];
+  static int const kWormSpriteColorBase[2];
 
   Color entries[256];
 
-  void activate(Color realPal[256]);
-  void fade(int amount);
-  void lightUp(int amount);
-  void rotateFrom(Palette& source, int from, int to, unsigned dist);
-  void read(io::Reader& r);
+  void Activate(Color real_pal[256]);
+  void Fade(int amount);
+  void LightUp(int amount);
+  void RotateFrom(Palette& source, int from, int to, unsigned dist);
+  void Read(io::Reader& r);
 
-  void scaleAdd(int dest, int const (&c)[3], int scale, int add) {
+  void ScaleAdd(int dest, int const (&c)[3], int scale, int add) {
     entries[dest].r = (add + c[0] * scale) / 64;
     entries[dest].g = (add + c[1] * scale) / 64;
     entries[dest].b = (add + c[2] * scale) / 64;
@@ -33,21 +33,21 @@ struct Palette {
     assert(entries[dest].b < 64);
   }
 
-  void setWormColoursSpan(int base, int const (&c)[3]) {
-    scaleAdd(base - 2, c, 38, 0);
-    scaleAdd(base - 1, c, 50, 0);
-    scaleAdd(base, c, 64, 0);
-    scaleAdd(base + 1, c, 47, 1008);
-    scaleAdd(base + 2, c, 28, 2205);
+  void SetWormColoursSpan(int base, int const (&c)[3]) {
+    ScaleAdd(base - 2, c, 38, 0);
+    ScaleAdd(base - 1, c, 50, 0);
+    ScaleAdd(base, c, 64, 0);
+    ScaleAdd(base + 1, c, 47, 1008);
+    ScaleAdd(base + 2, c, 28, 2205);
   }
 
-  void resetPalette(Palette const& newPal, Settings const& settings) {
-    *this = newPal;
+  void ResetPalette(Palette const& new_pal, Settings const& settings) {
+    *this = new_pal;
     // setWormColours(settings);
   }
 
-  void setWormColour(int i, WormSettings const& settings);
-  void setWormColours(Settings const& settings);
+  void SetWormColour(int i, WormSettings const& settings);
+  void SetWormColours(Settings const& settings);
 
-  void clear();
+  void Clear();
 };

--- a/src/game/gfx/renderer.cpp
+++ b/src/game/gfx/renderer.cpp
@@ -2,17 +2,17 @@
 #include "../common.hpp"
 #include "blit.hpp"
 
-void Renderer::init(int x, int y) { this->setRenderResolution(x, y); }
+void Renderer::Init(int x, int y) { this->SetRenderResolution(x, y); }
 
-void Renderer::setRenderResolution(int x, int y) {
-  renderResX = x;
-  renderResY = y;
-  bmp.alloc(renderResX, renderResY);
+void Renderer::SetRenderResolution(int x, int y) {
+  render_res_x = x;
+  render_res_y = y;
+  bmp.Alloc(render_res_x, render_res_y);
 }
 
-void Renderer::loadPalette(Common const& common) {
+void Renderer::LoadPalette(Common const& common) {
   origpal = common.exepal;
   pal = origpal;
 }
 
-void Renderer::clear() { fill(bmp, 0); }
+void Renderer::Clear() { Fill(bmp, 0); }

--- a/src/game/gfx/renderer.hpp
+++ b/src/game/gfx/renderer.hpp
@@ -5,19 +5,19 @@
 #include "bitmap.hpp"
 
 struct Renderer {
-  Renderer() : fadeValue(0) {}
+  Renderer() : fade_value(0) {}
 
-  void init(int x, int y);
-  void clear();
-  void loadPalette(Common const& common);
-  void setRenderResolution(int x, int y);
+  void Init(int x, int y);
+  void Clear();
+  void LoadPalette(Common const& common);
+  void SetRenderResolution(int x, int y);
 
   // the bitmap that is drawn into by this renderer
   Bitmap bmp;
   Palette pal, origpal;
-  int fadeValue;
+  int fade_value;
   // Resolution to render the game at. This should be modified via
   // setRenderResolution() to ensure that the bitmap is re-allocated
-  int renderResX = 320;
-  int renderResY = 200;
+  int render_res_x = 320;
+  int render_res_y = 200;
 };

--- a/src/game/gfx/sprite.cpp
+++ b/src/game/gfx/sprite.cpp
@@ -5,12 +5,12 @@
 #include <cassert>
 #include <vector>
 
-void SpriteSet::allocate(int width, int height, int count) {
+void SpriteSet::Allocate(int width, int height, int count) {
   this->width = width;
   this->height = height;
-  this->spriteSize = width * height;
+  this->sprite_size = width * height;
   this->count = count;
 
-  int amount = spriteSize * count;
+  int amount = sprite_size * count;
   data.resize(amount);
 }

--- a/src/game/gfx/sprite.hpp
+++ b/src/game/gfx/sprite.hpp
@@ -11,24 +11,24 @@ struct Sprite {
 };
 
 struct SpriteSet {
-  SpriteSet() : width(0), height(0), spriteSize(0), count(0) {}
+  SpriteSet() : width(0), height(0), sprite_size(0), count(0) {}
 
   std::vector<PalIdx> data;
   int width;
   int height;
-  int spriteSize;
+  int sprite_size;
   int count;
 
-  PalIdx* spritePtr(int frame) {
+  PalIdx* SpritePtr(int frame) {
     assert(frame >= 0 && frame < count);
-    return &data[frame * spriteSize];
+    return &data[frame * sprite_size];
   }
 
   Sprite operator[](int frame) {
     assert(frame >= 0 && frame < count);
-    Sprite s = {&data[frame * spriteSize], width, height, width};
+    Sprite s = {&data[frame * sprite_size], width, height, width};
     return s;
   }
 
-  void allocate(int width, int height, int count);
+  void Allocate(int width, int height, int count);
 };

--- a/src/game/gfx/text_cell.hpp
+++ b/src/game/gfx/text_cell.hpp
@@ -9,7 +9,7 @@
 // with left / center / right placement.
 
 struct TextCell {
-  enum Placement { Left, Center, Right };
+  enum Placement { kLeft, kCenter, kRight };
 
   TextCell() = default;
   explicit TextCell(Placement p) : placement(p) {}
@@ -26,8 +26,8 @@ struct TextCell {
   }
 
   // Convenience for the `cell().ref() << ...` pattern.
-  TextCell& ref() { return *this; }
+  TextCell& Ref() { return *this; }
 
   std::vector<uint8_t> buffer;
-  Placement placement = Left;
+  Placement placement = kLeft;
 };

--- a/src/game/inputState.cpp
+++ b/src/game/inputState.cpp
@@ -90,7 +90,7 @@ void InputStringState::Draw() {
                        clr_x + 10 + width, 8, gfx->frozen_screen.pitch);
 
   DrawRoundedBox(gfx->play_renderer.bmp, x_ - 2 - adjust, y_, 0, 7, width);
-  font.DrawText(gfx->play_renderer.bmp, str, x_ - adjust, y_ + 1, 50);
+  font.DrawString(gfx->play_renderer.bmp, str, x_ - adjust, y_ + 1, 50);
 }
 
 // --- WaitForKeyState ---
@@ -154,7 +154,7 @@ void WaitForKeyState::Draw() {
   int cy = 100 - height / 2 - 2;
 
   DrawRoundedBox(gfx->play_renderer.bmp, cx, cy, 0, height + 1, width + 1);
-  gfx->common->font.DrawText(gfx->play_renderer.bmp, text, cx + 2, cy + 2, 50);
+  gfx->common->font.DrawString(gfx->play_renderer.bmp, text, cx + 2, cy + 2, 50);
 }
 
 // --- InfoBoxState ---
@@ -202,5 +202,5 @@ void InfoBoxState::Draw() {
   int cy = y_ - height / 2 - 2;
 
   DrawRoundedBox(gfx->play_renderer.bmp, cx, cy, 0, height + 1, width + 1);
-  gfx->common->font.DrawText(gfx->play_renderer.bmp, text_, cx + 2, cy + 2, 6);
+  gfx->common->font.DrawString(gfx->play_renderer.bmp, text_, cx + 2, cy + 2, 6);
 }

--- a/src/game/inputState.cpp
+++ b/src/game/inputState.cpp
@@ -10,11 +10,11 @@
 
 // --- InputStringState ---
 
-InputStringState::InputStringState(std::string initial, std::size_t maxLen, int x, int y,
+InputStringState::InputStringState(std::string initial, std::size_t max_len, int x, int y,
                                    int (*filter)(int), std::string prefix, bool centered,
                                    Callback callback)
     : buffer_(std::move(initial)),
-      maxLen_(maxLen),
+      maxLen_(max_len),
       x_(x),
       y_(y),
       filter_(filter),
@@ -22,10 +22,10 @@ InputStringState::InputStringState(std::string initial, std::size_t maxLen, int 
       centered_(centered),
       callback_(std::move(callback)) {}
 
-void InputStringState::enter() { SDL_StartTextInput(gfx->sdlWindow); }
+void InputStringState::Enter() { SDL_StartTextInput(gfx->sdl_window); }
 
-void InputStringState::handleEvent(SDL_Event& ev) {
-  gfx->processEvent(ev);
+void InputStringState::HandleEvent(SDL_Event& ev) {
+  gfx->ProcessEvent(ev);
 
   switch (ev.type) {
     case SDL_EVENT_KEY_DOWN:
@@ -51,7 +51,7 @@ void InputStringState::handleEvent(SDL_Event& ev) {
       break;
 
     case SDL_EVENT_TEXT_INPUT: {
-      int k = utf8ToDOS(ev.text.text);
+      int k = Utf8ToDos(ev.text.text);
       if (k && buffer_.size() < maxLen_ && (!filter_ || (k = filter_(k)))) {
         buffer_ += char(k);
       }
@@ -67,30 +67,30 @@ void InputStringState::handleEvent(SDL_Event& ev) {
   }
 }
 
-bool InputStringState::update() {
+bool InputStringState::Update() {
   if (done_) {
-    SDL_StopTextInput(gfx->sdlWindow);
-    g_soundPlayer->play(gfx->common->soundHook[SoundMenuSelect]);
-    gfx->clearKeys();
+    SDL_StopTextInput(gfx->sdl_window);
+    g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
+    gfx->ClearKeys();
     callback_(accepted_, buffer_);
     return false;
   }
   return true;
 }
 
-void InputStringState::draw() {
+void InputStringState::Draw() {
   std::string str = prefix_ + buffer_ + '_';
 
   Font& font = gfx->common->font;
-  int width = font.getDims(str);
+  int width = font.GetDims(str);
   int adjust = centered_ ? width / 2 : 0;
-  int clrX = x_ - 10 - adjust;
+  int clr_x = x_ - 10 - adjust;
 
-  blitImageNoKeyColour(gfx->playRenderer.bmp, &gfx->frozenScreen.getPixel(clrX, y_), clrX, y_,
-                       clrX + 10 + width, 8, gfx->frozenScreen.pitch);
+  BlitImageNoKeyColour(gfx->play_renderer.bmp, &gfx->frozen_screen.GetPixel(clr_x, y_), clr_x, y_,
+                       clr_x + 10 + width, 8, gfx->frozen_screen.pitch);
 
-  drawRoundedBox(gfx->playRenderer.bmp, x_ - 2 - adjust, y_, 0, 7, width);
-  font.drawText(gfx->playRenderer.bmp, str, x_ - adjust, y_ + 1, 50);
+  DrawRoundedBox(gfx->play_renderer.bmp, x_ - 2 - adjust, y_, 0, 7, width);
+  font.DrawText(gfx->play_renderer.bmp, str, x_ - adjust, y_ + 1, 50);
 }
 
 // --- WaitForKeyState ---
@@ -98,15 +98,15 @@ void InputStringState::draw() {
 WaitForKeyState::WaitForKeyState(bool extended, Callback callback)
     : extended_(extended), callback_(std::move(callback)) {}
 
-void WaitForKeyState::enter() {}
+void WaitForKeyState::Enter() {}
 
-void WaitForKeyState::handleEvent(SDL_Event& ev) {
-  gfx->processEvent(ev);
+void WaitForKeyState::HandleEvent(SDL_Event& ev) {
+  gfx->ProcessEvent(ev);
 
   switch (ev.type) {
     case SDL_EVENT_KEY_DOWN: {
       uint32_t k = SDLToDOSKey(ev.key.scancode);
-      if (extended_ || !isExtendedKey(k)) {
+      if (extended_ || !IsExtendedKey(k)) {
         result_ = k;
         done_ = true;
       }
@@ -114,12 +114,12 @@ void WaitForKeyState::handleEvent(SDL_Event& ev) {
     }
 
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
-      if (ev.gaxis.value > JoyAxisThreshold) {
-        result_ = WormSettingsExtensions::gamepadAxisPositive(ev.gaxis.axis);
+      if (ev.gaxis.value > kJoyAxisThreshold) {
+        result_ = WormSettingsExtensions::GamepadAxisPositive(ev.gaxis.axis);
         isGamepadResult_ = true;
         done_ = true;
-      } else if (ev.gaxis.value < -JoyAxisThreshold) {
-        result_ = WormSettingsExtensions::gamepadAxisNegative(ev.gaxis.axis);
+      } else if (ev.gaxis.value < -kJoyAxisThreshold) {
+        result_ = WormSettingsExtensions::GamepadAxisNegative(ev.gaxis.axis);
         isGamepadResult_ = true;
         done_ = true;
       }
@@ -136,49 +136,49 @@ void WaitForKeyState::handleEvent(SDL_Event& ev) {
   }
 }
 
-bool WaitForKeyState::update() {
+bool WaitForKeyState::Update() {
   if (done_) {
-    gfx->clearKeys();
+    gfx->ClearKeys();
     callback_(result_, isGamepadResult_);
     return false;
   }
   return true;
 }
 
-void WaitForKeyState::draw() {
+void WaitForKeyState::Draw() {
   std::string text = "PRESS A KEY";
   int height;
-  int width = gfx->common->font.getDims(text, &height);
+  int width = gfx->common->font.GetDims(text, &height);
 
   int cx = 160 - width / 2 - 2;
   int cy = 100 - height / 2 - 2;
 
-  drawRoundedBox(gfx->playRenderer.bmp, cx, cy, 0, height + 1, width + 1);
-  gfx->common->font.drawText(gfx->playRenderer.bmp, text, cx + 2, cy + 2, 50);
+  DrawRoundedBox(gfx->play_renderer.bmp, cx, cy, 0, height + 1, width + 1);
+  gfx->common->font.DrawText(gfx->play_renderer.bmp, text, cx + 2, cy + 2, 50);
 }
 
 // --- InfoBoxState ---
 
-InfoBoxState::InfoBoxState(std::string text, int x, int y, bool clearScreen,
-                           DismissCallback onDismiss)
+InfoBoxState::InfoBoxState(std::string text, int x, int y, bool clear_screen,
+                           DismissCallback on_dismiss)
     : text_(std::move(text)),
       x_(x),
       y_(y),
-      clearScreen_(clearScreen),
-      onDismiss_(std::move(onDismiss)) {}
+      clearScreen_(clear_screen),
+      onDismiss_(std::move(on_dismiss)) {}
 
-void InfoBoxState::enter() {}
+void InfoBoxState::Enter() {}
 
-void InfoBoxState::handleEvent(SDL_Event& ev) {
-  gfx->processEvent(ev);
+void InfoBoxState::HandleEvent(SDL_Event& ev) {
+  gfx->ProcessEvent(ev);
 
   if (ev.type == SDL_EVENT_KEY_DOWN || ev.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) done_ = true;
 }
 
-bool InfoBoxState::update() {
+bool InfoBoxState::Update() {
   if (done_) {
-    gfx->clearKeys();
-    if (clearScreen_) fill(gfx->playRenderer.bmp, 0);
+    gfx->ClearKeys();
+    if (clearScreen_) Fill(gfx->play_renderer.bmp, 0);
     // onDismiss_ runs before this state is popped. It may call
     // scheduleReplaceTop() on the StateStack to chain into another
     // state; that takes precedence over the normal pop because the
@@ -189,18 +189,18 @@ bool InfoBoxState::update() {
   return true;
 }
 
-void InfoBoxState::draw() {
+void InfoBoxState::Draw() {
   if (clearScreen_) {
-    gfx->playRenderer.pal = gfx->common->exepal;
-    fill(gfx->playRenderer.bmp, 0);
+    gfx->play_renderer.pal = gfx->common->exepal;
+    Fill(gfx->play_renderer.bmp, 0);
   }
 
   int height;
-  int width = gfx->common->font.getDims(text_, &height);
+  int width = gfx->common->font.GetDims(text_, &height);
 
   int cx = x_ - width / 2 - 2;
   int cy = y_ - height / 2 - 2;
 
-  drawRoundedBox(gfx->playRenderer.bmp, cx, cy, 0, height + 1, width + 1);
-  gfx->common->font.drawText(gfx->playRenderer.bmp, text_, cx + 2, cy + 2, 6);
+  DrawRoundedBox(gfx->play_renderer.bmp, cx, cy, 0, height + 1, width + 1);
+  gfx->common->font.DrawText(gfx->play_renderer.bmp, text_, cx + 2, cy + 2, 6);
 }

--- a/src/game/inputState.hpp
+++ b/src/game/inputState.hpp
@@ -11,16 +11,16 @@
 struct InputStringState : AppState {
   using Callback = std::function<void(bool accepted, std::string const& result)>;
 
-  InputStringState(std::string initial, std::size_t maxLen, int x, int y, int (*filter)(int),
+  InputStringState(std::string initial, std::size_t max_len, int x, int y, int (*filter)(int),
                    std::string prefix, bool centered, Callback callback);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
   // Overlay so the menu beneath repaints each frame; frozenScreen
   // only captures the background, not the live menu items.
-  bool isOverlay() const override { return true; }
+  bool IsOverlay() const override { return true; }
 
  private:
   std::string buffer_;
@@ -36,15 +36,15 @@ struct InputStringState : AppState {
 
 // Key binding state. Waits for a key/joystick press and returns via callback.
 struct WaitForKeyState : AppState {
-  using Callback = std::function<void(uint32_t key, bool isGamepad)>;
+  using Callback = std::function<void(uint32_t key, bool is_gamepad)>;
 
   // If extended is false, only non-extended (DOS) keys are accepted.
   WaitForKeyState(bool extended, Callback callback);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
  private:
   bool extended_;
@@ -58,13 +58,13 @@ struct WaitForKeyState : AppState {
 struct InfoBoxState : AppState {
   using DismissCallback = std::function<void()>;
 
-  InfoBoxState(std::string text, int x, int y, bool clearScreen,
-               DismissCallback onDismiss = nullptr);
+  InfoBoxState(std::string text, int x, int y, bool clear_screen,
+               DismissCallback on_dismiss = nullptr);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
  private:
   std::string text_;

--- a/src/game/io/coding.hpp
+++ b/src/game/io/coding.hpp
@@ -15,19 +15,19 @@ namespace io {
 namespace detail {
 
 template <typename T, typename Reader>
-inline T read_n(Reader& r) {
+inline T ReadN(Reader& r) {
   uint8_t buf[sizeof(T)];
-  for (auto& b : buf) b = r.get();
+  for (auto& b : buf) b = r.Get();
   T v;
   std::memcpy(&v, buf, sizeof(T));
   return v;
 }
 
 template <typename T, typename Writer>
-inline void write_n(Writer& w, T v) {
+inline void WriteN(Writer& w, T v) {
   uint8_t buf[sizeof(T)];
   std::memcpy(buf, &v, sizeof(T));
-  for (auto b : buf) w.put(b);
+  for (auto b : buf) w.Put(b);
 }
 
 }  // namespace detail
@@ -35,59 +35,59 @@ inline void write_n(Writer& w, T v) {
 // --- Big-endian (network byte order) readers/writers ---
 
 template <typename Reader>
-inline uint16_t read_uint16(Reader& r) {
-  uint16_t v = detail::read_n<uint16_t>(r);
+inline uint16_t ReadUint16(Reader& r) {
+  uint16_t v = detail::ReadN<uint16_t>(r);
   if constexpr (std::endian::native == std::endian::little) v = std::byteswap(v);
   return v;
 }
 
 template <typename Reader>
-inline uint32_t read_uint32(Reader& r) {
-  uint32_t v = detail::read_n<uint32_t>(r);
+inline uint32_t ReadUint32(Reader& r) {
+  uint32_t v = detail::ReadN<uint32_t>(r);
   if constexpr (std::endian::native == std::endian::little) v = std::byteswap(v);
   return v;
 }
 
 template <typename Writer>
-inline void write_uint16(Writer& w, uint16_t v) {
+inline void WriteUint16(Writer& w, uint16_t v) {
   if constexpr (std::endian::native == std::endian::little) v = std::byteswap(v);
-  detail::write_n(w, v);
+  detail::WriteN(w, v);
 }
 
 template <typename Writer>
-inline void write_uint32(Writer& w, uint32_t v) {
+inline void WriteUint32(Writer& w, uint32_t v) {
   if constexpr (std::endian::native == std::endian::little) v = std::byteswap(v);
-  detail::write_n(w, v);
+  detail::WriteN(w, v);
 }
 
 // --- Little-endian readers/writers ---
 
 template <typename Reader>
-inline uint16_t read_uint16_le(Reader& r) {
-  uint16_t v = detail::read_n<uint16_t>(r);
+inline uint16_t ReadUint16Le(Reader& r) {
+  uint16_t v = detail::ReadN<uint16_t>(r);
   if constexpr (std::endian::native == std::endian::big) v = std::byteswap(v);
   return v;
 }
 
 template <typename Reader>
-inline uint32_t read_uint32_le(Reader& r) {
-  uint32_t v = detail::read_n<uint32_t>(r);
+inline uint32_t ReadUint32Le(Reader& r) {
+  uint32_t v = detail::ReadN<uint32_t>(r);
   if constexpr (std::endian::native == std::endian::big) v = std::byteswap(v);
   return v;
 }
 
 template <typename Writer>
-inline void write_uint16_le(Writer& w, uint16_t v) {
+inline void WriteUint16Le(Writer& w, uint16_t v) {
   if constexpr (std::endian::native == std::endian::big) v = std::byteswap(v);
-  detail::write_n(w, v);
+  detail::WriteN(w, v);
 }
 
 template <typename Writer>
-inline void write_uint32_le(Writer& w, uint32_t v) {
+inline void WriteUint32Le(Writer& w, uint32_t v) {
   if constexpr (std::endian::native == std::endian::big) v = std::byteswap(v);
-  detail::write_n(w, v);
+  detail::WriteN(w, v);
 }
 
-inline int32_t uint32_as_int32(uint32_t v) { return static_cast<int32_t>(v); }
+inline int32_t Uint32AsInt32(uint32_t v) { return static_cast<int32_t>(v); }
 
 }  // namespace io

--- a/src/game/io/deflate.hpp
+++ b/src/game/io/deflate.hpp
@@ -35,19 +35,19 @@ struct InflateReader : Reader {
   InflateReader(InflateReader const&) = delete;
   InflateReader& operator=(InflateReader const&) = delete;
 
-  uint8_t get() override {
+  uint8_t Get() override {
     if (out_pos_ >= out_len_) {
-      refill();
+      Refill();
       if (out_len_ == 0) throw EndOfStream{};
     }
     return outbuf_[out_pos_++];
   }
 
-  std::size_t try_get(uint8_t* dst, std::size_t n) override {
+  std::size_t TryGet(uint8_t* dst, std::size_t n) override {
     std::size_t total = 0;
     while (total < n) {
       if (out_pos_ >= out_len_) {
-        refill();
+        Refill();
         if (out_len_ == 0) break;
       }
       std::size_t take = std::min(n - total, out_len_ - out_pos_);
@@ -59,7 +59,7 @@ struct InflateReader : Reader {
   }
 
  private:
-  void refill() {
+  void Refill() {
     out_pos_ = 0;
     out_len_ = 0;
     if (eos_) return;
@@ -69,7 +69,7 @@ struct InflateReader : Reader {
 
     while (stream_.avail_out > 0) {
       if (stream_.avail_in == 0 && !input_done_) {
-        std::size_t got = source_->try_get(inbuf_.data(), inbuf_.size());
+        std::size_t got = source_->TryGet(inbuf_.data(), inbuf_.size());
         if (got == 0) {
           input_done_ = true;
         } else {
@@ -127,7 +127,7 @@ struct DeflateWriter : Writer {
 
   ~DeflateWriter() override {
     try {
-      finish();
+      Finish();
     } catch (...) {
       // Best-effort during stack unwind.
     }
@@ -137,38 +137,38 @@ struct DeflateWriter : Writer {
   DeflateWriter(DeflateWriter const&) = delete;
   DeflateWriter& operator=(DeflateWriter const&) = delete;
 
-  void put(uint8_t b) override { put(&b, 1); }
+  void Put(uint8_t b) override { Put(&b, 1); }
 
-  void put(uint8_t const* src, std::size_t n) override {
+  void Put(uint8_t const* src, std::size_t n) override {
     if (finished_) throw StreamError("write after finish");
 
     stream_.next_in = const_cast<unsigned char*>(src);
     stream_.avail_in = static_cast<unsigned int>(n);
 
     while (stream_.avail_in > 0) {
-      if (stream_.avail_out == 0) drain_out();
+      if (stream_.avail_out == 0) DrainOut();
       int rc = mz_deflate(&stream_, MZ_NO_FLUSH);
       if (rc != MZ_OK) throw StreamError("mz_deflate failed");
     }
   }
 
-  void flush() override {
+  void Flush() override {
     // Pre-emptive drain — full flush happens on destruction via finish().
-    drain_out();
-    sink_->flush();
+    DrainOut();
+    sink_->Flush();
   }
 
  private:
-  void drain_out() {
+  void DrainOut() {
     std::size_t produced = outbuf_.size() - stream_.avail_out;
     if (produced > 0) {
-      sink_->put(outbuf_.data(), produced);
+      sink_->Put(outbuf_.data(), produced);
     }
     stream_.next_out = outbuf_.data();
     stream_.avail_out = static_cast<unsigned int>(outbuf_.size());
   }
 
-  void finish() {
+  void Finish() {
     if (finished_) return;
     finished_ = true;
 
@@ -177,11 +177,11 @@ struct DeflateWriter : Writer {
 
     for (;;) {
       int rc = mz_deflate(&stream_, MZ_FINISH);
-      drain_out();
+      DrainOut();
       if (rc == MZ_STREAM_END) break;
       if (rc != MZ_OK) throw StreamError("mz_deflate(MZ_FINISH) failed");
     }
-    sink_->flush();
+    sink_->Flush();
   }
 
   std::unique_ptr<Writer> sink_;

--- a/src/game/io/stream.hpp
+++ b/src/game/io/stream.hpp
@@ -32,24 +32,24 @@ struct Reader {
   virtual ~Reader() = default;
 
   // Read one byte; throw EndOfStream on EOF.
-  virtual uint8_t get() = 0;
+  virtual uint8_t Get() = 0;
 
   // Read up to `n` bytes; return number actually read.
-  virtual std::size_t try_get(uint8_t* dst, std::size_t n) = 0;
+  virtual std::size_t TryGet(uint8_t* dst, std::size_t n) = 0;
 
   // Read exactly `n` bytes or throw EndOfStream.
-  void get(uint8_t* dst, std::size_t n) {
-    std::size_t got = try_get(dst, n);
+  void Get(uint8_t* dst, std::size_t n) {
+    std::size_t got = TryGet(dst, n);
     if (got != n) throw EndOfStream{};
   }
 
   // Discard up to `n` bytes; return number actually discarded.
-  virtual std::size_t try_skip(std::size_t n) {
+  virtual std::size_t TrySkip(std::size_t n) {
     uint8_t buf[1024];
     std::size_t total = 0;
     while (total < n) {
       std::size_t take = std::min(sizeof(buf), n - total);
-      std::size_t got = try_get(buf, take);
+      std::size_t got = TryGet(buf, take);
       total += got;
       if (got < take) break;
     }
@@ -60,9 +60,9 @@ struct Reader {
 struct Writer {
   virtual ~Writer() = default;
 
-  virtual void put(uint8_t b) = 0;
-  virtual void put(uint8_t const* src, std::size_t n) = 0;
-  virtual void flush() {}
+  virtual void Put(uint8_t b) = 0;
+  virtual void Put(uint8_t const* src, std::size_t n) = 0;
+  virtual void Flush() {}
 };
 
 // ---- File-backed ----
@@ -87,13 +87,13 @@ struct FileReader : Reader {
   FileReader(FileReader const&) = delete;
   FileReader& operator=(FileReader const&) = delete;
 
-  uint8_t get() override {
+  uint8_t Get() override {
     int c = std::fgetc(f_);
     if (c == EOF) throw EndOfStream{};
     return static_cast<uint8_t>(c);
   }
 
-  std::size_t try_get(uint8_t* dst, std::size_t n) override { return std::fread(dst, 1, n, f_); }
+  std::size_t TryGet(uint8_t* dst, std::size_t n) override { return std::fread(dst, 1, n, f_); }
 
  private:
   std::FILE* f_;
@@ -120,13 +120,13 @@ struct FileWriter : Writer {
   FileWriter(FileWriter const&) = delete;
   FileWriter& operator=(FileWriter const&) = delete;
 
-  void put(uint8_t b) override {
+  void Put(uint8_t b) override {
     if (std::fputc(b, f_) == EOF) throw StreamError("write failed");
   }
-  void put(uint8_t const* src, std::size_t n) override {
+  void Put(uint8_t const* src, std::size_t n) override {
     if (std::fwrite(src, 1, n, f_) != n) throw StreamError("write failed");
   }
-  void flush() override { std::fflush(f_); }
+  void Flush() override { std::fflush(f_); }
 
  private:
   std::FILE* f_;
@@ -144,24 +144,24 @@ struct MemReader : Reader {
 
   // Point at a different buffer (e.g. once it has been filled by an
   // owning container).
-  void reset(uint8_t const* data, std::size_t size) {
+  void Reset(uint8_t const* data, std::size_t size) {
     data_ = data;
     size_ = size;
     pos_ = 0;
   }
 
-  std::size_t tellg() const { return pos_; }
-  void seekg(std::size_t pos) {
+  std::size_t Tellg() const { return pos_; }
+  void Seekg(std::size_t pos) {
     if (pos > size_) throw EndOfStream("seekg past end");
     pos_ = pos;
   }
 
-  uint8_t get() override {
+  uint8_t Get() override {
     if (pos_ >= size_) throw EndOfStream{};
     return data_[pos_++];
   }
 
-  std::size_t try_get(uint8_t* dst, std::size_t n) override {
+  std::size_t TryGet(uint8_t* dst, std::size_t n) override {
     std::size_t avail = size_ - pos_;
     std::size_t take = std::min(n, avail);
     std::memcpy(dst, data_ + pos_, take);
@@ -179,16 +179,16 @@ struct VectorWriter : Writer {
   std::vector<uint8_t>& buf;
   explicit VectorWriter(std::vector<uint8_t>& b) : buf(b) {}
 
-  void put(uint8_t b) override { buf.push_back(b); }
-  void put(uint8_t const* src, std::size_t n) override { buf.insert(buf.end(), src, src + n); }
+  void Put(uint8_t b) override { buf.push_back(b); }
+  void Put(uint8_t const* src, std::size_t n) override { buf.insert(buf.end(), src, src + n); }
 };
 
 struct StringWriter : Writer {
   std::string& buf;
   explicit StringWriter(std::string& b) : buf(b) {}
 
-  void put(uint8_t b) override { buf.push_back(static_cast<char>(b)); }
-  void put(uint8_t const* src, std::size_t n) override {
+  void Put(uint8_t b) override { buf.push_back(static_cast<char>(b)); }
+  void Put(uint8_t const* src, std::size_t n) override {
     buf.append(reinterpret_cast<char const*>(src), n);
   }
 };

--- a/src/game/keys.cpp
+++ b/src/game/keys.cpp
@@ -3,10 +3,10 @@
 #include <cstddef>
 #include <map>
 
-std::map<int, int> SDLToDOSScanCodes;
+std::map<int, int> sdl_to_dos_scan_codes;
 
-SDL_Scancode const Z = SDL_SCANCODE_UNKNOWN;
-SDL_Scancode lieroToSDLKeys[] = {
+SDL_Scancode const kZ = SDL_SCANCODE_UNKNOWN;
+SDL_Scancode liero_to_sdl_keys[] = {
     SDL_SCANCODE_UNKNOWN, SDL_SCANCODE_ESCAPE, SDL_SCANCODE_1, SDL_SCANCODE_2, SDL_SCANCODE_3,
     SDL_SCANCODE_4, SDL_SCANCODE_5, SDL_SCANCODE_6, SDL_SCANCODE_7, SDL_SCANCODE_8, SDL_SCANCODE_9,
     SDL_SCANCODE_0,
@@ -31,44 +31,44 @@ SDL_Scancode lieroToSDLKeys[] = {
     SDL_SCANCODE_KP_3, SDL_SCANCODE_KP_0, SDL_SCANCODE_KP_PERIOD, SDL_SCANCODE_UNKNOWN,
     SDL_SCANCODE_UNKNOWN, SDL_SCANCODE_NONUSBACKSLASH, SDL_SCANCODE_F11, SDL_SCANCODE_F12,
 
-    Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,  // 27 zeroes
+    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,  // 27 zeroes
     SDL_SCANCODE_KP_ENTER,                                                            // Enter (Pad)
     SDL_SCANCODE_RCTRL,                                                               // Right Ctrl
-    Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,                                               // 12 zeroes
-    SDL_SCANCODE_PRINTSCREEN, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,                           // 10 zeroes
+    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,                                               // 12 zeroes
+    SDL_SCANCODE_PRINTSCREEN, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,                           // 10 zeroes
     SDL_SCANCODE_KP_DIVIDE,                                                           // / (Pad)
-    Z, SDL_SCANCODE_PRINTSCREEN,
+    kZ, SDL_SCANCODE_PRINTSCREEN,
     SDL_SCANCODE_RALT,                         // Right Alt
-    Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,  // 14 zeroes
+    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,  // 14 zeroes
     SDL_SCANCODE_HOME,                         // Home
     SDL_SCANCODE_UP,                           // Up
     SDL_SCANCODE_PAGEUP,                       // Page Up
-    Z,
+    kZ,
     SDL_SCANCODE_LEFT,  // Left
-    Z,
+    kZ,
     SDL_SCANCODE_RIGHT,  // Right
-    Z,
+    kZ,
     SDL_SCANCODE_END,       // End
     SDL_SCANCODE_DOWN,      // Down
     SDL_SCANCODE_PAGEDOWN,  // Page Down
     SDL_SCANCODE_INSERT,    // Insert
     SDL_SCANCODE_DELETE,    // Delete
-    Z, Z, Z, Z, Z           // 5 zeroes
+    kZ, kZ, kZ, kZ, kZ           // 5 zeroes
 };
 
-uint32_t const maxScanCodes = sizeof(lieroToSDLKeys) / sizeof(*lieroToSDLKeys);
+uint32_t const kMaxScanCodes = sizeof(liero_to_sdl_keys) / sizeof(*liero_to_sdl_keys);
 
-void initKeys() {
-  for (std::size_t i = 0; i < maxScanCodes; ++i) {
-    if (lieroToSDLKeys[i] != SDL_SCANCODE_UNKNOWN) {
-      SDLToDOSScanCodes[lieroToSDLKeys[i]] = int(i);
+void InitKeys() {
+  for (std::size_t i = 0; i < kMaxScanCodes; ++i) {
+    if (liero_to_sdl_keys[i] != SDL_SCANCODE_UNKNOWN) {
+      sdl_to_dos_scan_codes[liero_to_sdl_keys[i]] = int(i);
     }
   }
 }
 
 uint32_t SDLToDOSKey(SDL_Scancode scancode) {
-  std::map<int, int>::iterator i = SDLToDOSScanCodes.find(uint32_t(scancode));
-  if (i != SDLToDOSScanCodes.end()) return i->second;
+  std::map<int, int>::iterator i = sdl_to_dos_scan_codes.find(uint32_t(scancode));
+  if (i != sdl_to_dos_scan_codes.end()) return i->second;
   return 89;
 }
 

--- a/src/game/keys.cpp
+++ b/src/game/keys.cpp
@@ -31,18 +31,19 @@ SDL_Scancode liero_to_sdl_keys[] = {
     SDL_SCANCODE_KP_3, SDL_SCANCODE_KP_0, SDL_SCANCODE_KP_PERIOD, SDL_SCANCODE_UNKNOWN,
     SDL_SCANCODE_UNKNOWN, SDL_SCANCODE_NONUSBACKSLASH, SDL_SCANCODE_F11, SDL_SCANCODE_F12,
 
-    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,  // 27 zeroes
-    SDL_SCANCODE_KP_ENTER,                                                            // Enter (Pad)
-    SDL_SCANCODE_RCTRL,                                                               // Right Ctrl
-    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,                                               // 12 zeroes
-    SDL_SCANCODE_PRINTSCREEN, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,                           // 10 zeroes
-    SDL_SCANCODE_KP_DIVIDE,                                                           // / (Pad)
+    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,
+    kZ, kZ, kZ,                                                        // 27 zeroes
+    SDL_SCANCODE_KP_ENTER,                                             // Enter (Pad)
+    SDL_SCANCODE_RCTRL,                                                // Right Ctrl
+    kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,                    // 12 zeroes
+    SDL_SCANCODE_PRINTSCREEN, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,  // 10 zeroes
+    SDL_SCANCODE_KP_DIVIDE,                                            // / (Pad)
     kZ, SDL_SCANCODE_PRINTSCREEN,
-    SDL_SCANCODE_RALT,                         // Right Alt
+    SDL_SCANCODE_RALT,                                       // Right Alt
     kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ, kZ,  // 14 zeroes
-    SDL_SCANCODE_HOME,                         // Home
-    SDL_SCANCODE_UP,                           // Up
-    SDL_SCANCODE_PAGEUP,                       // Page Up
+    SDL_SCANCODE_HOME,                                       // Home
+    SDL_SCANCODE_UP,                                         // Up
+    SDL_SCANCODE_PAGEUP,                                     // Page Up
     kZ,
     SDL_SCANCODE_LEFT,  // Left
     kZ,
@@ -53,7 +54,7 @@ SDL_Scancode liero_to_sdl_keys[] = {
     SDL_SCANCODE_PAGEDOWN,  // Page Down
     SDL_SCANCODE_INSERT,    // Insert
     SDL_SCANCODE_DELETE,    // Delete
-    kZ, kZ, kZ, kZ, kZ           // 5 zeroes
+    kZ, kZ, kZ, kZ, kZ      // 5 zeroes
 };
 
 uint32_t const kMaxScanCodes = sizeof(liero_to_sdl_keys) / sizeof(*liero_to_sdl_keys);

--- a/src/game/keys.hpp
+++ b/src/game/keys.hpp
@@ -5,30 +5,30 @@
 // extern int SDLToLieroKeys[SDL_SCANCODE_LAST];
 // extern int lieroToSDLKeys[177];
 
-void initKeys();
+void InitKeys();
 
 uint32_t SDLToDOSKey(SDL_Scancode scancode, SDL_Keymod mod);
 uint32_t SDLToDOSKey(SDL_Scancode scancode);
 
-int const DkEscape = 1;
+int const kDkEscape = 1;
 
-int const MaxJoyButtons = 32;
+int const kMaxJoyButtons = 32;
 
-uint32_t const MaxDOSKey = 177;
-uint32_t const JoyKeysStart = 512;
+uint32_t const kMaxDosKey = 177;
+uint32_t const kJoyKeysStart = 512;
 // Gamepad control keys start after joystick keys: encode as (player index, control)
-uint32_t const GamepadControlKeysStart = 1024;
+uint32_t const kGamepadControlKeysStart = 1024;
 
-inline uint32_t joyButtonToExKey(int joyNum, int joyButton) {
-  return JoyKeysStart + MaxJoyButtons * joyNum + joyButton;
+inline uint32_t JoyButtonToExKey(int joy_num, int joy_button) {
+  return kJoyKeysStart + kMaxJoyButtons * joy_num + joy_button;
 }
 
-inline uint32_t gamepadControlToExKey(int playerIdx, int control) {
-  return GamepadControlKeysStart + playerIdx * 8 + control;
+inline uint32_t GamepadControlToExKey(int player_idx, int control) {
+  return kGamepadControlKeysStart + player_idx * 8 + control;
 }
 
-inline bool isGamepadControlKey(uint32_t k) { return k >= GamepadControlKeysStart; }
+inline bool IsGamepadControlKey(uint32_t k) { return k >= kGamepadControlKeysStart; }
 
-inline bool isExtendedKey(uint32_t k) { return k >= MaxDOSKey; }
+inline bool IsExtendedKey(uint32_t k) { return k >= kMaxDosKey; }
 
-const int JoyAxisThreshold = 10000;
+const int kJoyAxisThreshold = 10000;

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -8,18 +8,18 @@
 
 #include <cstring>
 
-void Level::generateDirtPattern(Common& common, Rand& rand) {
-  resize(504, 350);
+void Level::GenerateDirtPattern(Common& common, Rand& rand) {
+  Resize(504, 350);
 
-  setPixel(0, 0, rand(7) + 12, common);
+  SetPixel(0, 0, rand(7) + 12, common);
 
-  for (int y = 1; y < height; ++y) setPixel(0, y, ((rand(7) + 12) + pixel(0, y - 1)) >> 1, common);
+  for (int y = 1; y < height; ++y) SetPixel(0, y, ((rand(7) + 12) + Pixel(0, y - 1)) >> 1, common);
 
-  for (int x = 1; x < width; ++x) setPixel(x, 0, ((rand(7) + 12) + pixel(x - 1, 0)) >> 1, common);
+  for (int x = 1; x < width; ++x) SetPixel(x, 0, ((rand(7) + 12) + Pixel(x - 1, 0)) >> 1, common);
 
   for (int y = 1; y < height; ++y)
     for (int x = 1; x < width; ++x) {
-      setPixel(x, y, (pixel(x - 1, y) + pixel(x, y - 1) + rand(8) + 12) / 3, common);
+      SetPixel(x, y, (Pixel(x - 1, y) + Pixel(x, y - 1) + rand(8) + 12) / 3, common);
     }
 
   // TODO: Optimize the following
@@ -32,7 +32,7 @@ void Level::generateDirtPattern(Common& common, Rand& rand) {
 
     int temp = rand(4) + 69;
 
-    PalIdx* image = common.largeSprites.spritePtr(temp);
+    PalIdx* image = common.large_sprites.SpritePtr(temp);
 
     for (int cy = 0; cy < 16; ++cy) {
       int my = cy + y;
@@ -46,13 +46,13 @@ void Level::generateDirtPattern(Common& common, Rand& rand) {
 
         if (mx < 0) continue;
 
-        PalIdx srcPix = image[(cy << 4) + cx];
-        if (srcPix > 0) {
-          PalIdx pix = pixel(mx, my);
+        PalIdx src_pix = image[(cy << 4) + cx];
+        if (src_pix > 0) {
+          PalIdx pix = Pixel(mx, my);
           if (pix > 176 && pix < 180)
-            setPixel(mx, my, (srcPix + pix) / 2, common);
+            SetPixel(mx, my, (src_pix + pix) / 2, common);
           else
-            setPixel(mx, my, srcPix, common);
+            SetPixel(mx, my, src_pix, common);
         }
       }
     }
@@ -66,27 +66,27 @@ void Level::generateDirtPattern(Common& common, Rand& rand) {
 
     int which = rand(4) + 56;
 
-    blitStone(common, *this, false, common.largeSprites.spritePtr(which), x, y);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(which), x, y);
   }
 }
 
-bool isNoRock(Common& common, Level& level, int size, int x, int y) {
+bool IsNoRock(Common& common, Level& level, int size, int x, int y) {
   Rect rect(x, y, x + size + 1, y + size + 1);
 
-  rect.intersect(Rect(0, 0, level.width, level.height));
+  rect.Intersect(Rect(0, 0, level.width, level.height));
 
   for (int y = rect.y1; y < rect.y2; ++y)
     for (int x = rect.x1; x < rect.x2; ++x) {
-      if (level.mat(x, y).rock()) return false;
+      if (level.Mat(x, y).Rock()) return false;
     }
 
   return true;
 }
 
-void Level::generateRandom(Common& common, Settings const& settings, Rand& rand) {
-  origpal.resetPalette(common.exepal, settings);
+void Level::GenerateRandom(Common& common, Settings const& settings, Rand& rand) {
+  origpal.ResetPalette(common.exepal, settings);
 
-  generateDirtPattern(common, rand);
+  GenerateDirtPattern(common, rand);
 
   int count = rand(50) + 5;
 
@@ -105,7 +105,7 @@ void Level::generateRandom(Common& common, Settings const& settings, Rand& rand)
       for (int k = 0; k < count3; ++k) {
         cx += dx;
         cy += dy;
-        drawDirtEffect(common, rand, *this, 1, cx,
+        DrawDirtEffect(common, rand, *this, 1, cx,
                        cy);  // TODO: Check if it really should be dirt effect 1
       }
 
@@ -127,14 +127,14 @@ void Level::generateRandom(Common& common, Settings const& settings, Rand& rand)
         cy = height - 1 - rand(20);
       else
         cy = rand(height) - 16;
-    } while (!isNoRock(common, *this, 32, cx, cy));
+    } while (!IsNoRock(common, *this, 32, cx, cy));
 
     int rock = rand(3);
 
-    blitStone(common, *this, false, common.largeSprites.spritePtr(stoneTab[rock][0]), cx, cy);
-    blitStone(common, *this, false, common.largeSprites.spritePtr(stoneTab[rock][1]), cx + 16, cy);
-    blitStone(common, *this, false, common.largeSprites.spritePtr(stoneTab[rock][2]), cx, cy + 16);
-    blitStone(common, *this, false, common.largeSprites.spritePtr(stoneTab[rock][3]), cx + 16,
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][0]), cx, cy);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][1]), cx + 16, cy);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][2]), cx, cy + 16);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][3]), cx + 16,
               cy + 16);
   }
 
@@ -149,33 +149,33 @@ void Level::generateRandom(Common& common, Settings const& settings, Rand& rand)
         cy = height - 1 - rand(13);
       else
         cy = rand(height) - 8;
-    } while (!isNoRock(common, *this, 15, cx, cy));
+    } while (!IsNoRock(common, *this, 15, cx, cy));
 
-    blitStone(common, *this, false, common.largeSprites.spritePtr(rand(6) + 3), cx, cy);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(rand(6) + 3), cx, cy);
   }
 }
 
-void Level::makeShadow(Common& common) {
+void Level::MakeShadow(Common& common) {
   for (int x = 0; x < width - 3; ++x)
     for (int y = 3; y < height; ++y) {
-      if (mat(x, y).seeShadow() && mat(x + 3, y - 3).dirtRock()) {
-        setPixel(x, y, pixel(x, y) + 4, common);
+      if (Mat(x, y).SeeShadow() && Mat(x + 3, y - 3).DirtRock()) {
+        SetPixel(x, y, Pixel(x, y) + 4, common);
       }
 
-      if (pixel(x, y) >= 12 && pixel(x, y) <= 18 && mat(x + 3, y - 3).rock()) {
-        setPixel(x, y, pixel(x, y) - 2, common);
-        if (pixel(x, y) < 12) setPixel(x, y, 12, common);
+      if (Pixel(x, y) >= 12 && Pixel(x, y) <= 18 && Mat(x + 3, y - 3).Rock()) {
+        SetPixel(x, y, Pixel(x, y) - 2, common);
+        if (Pixel(x, y) < 12) SetPixel(x, y, 12, common);
       }
     }
 
   for (int x = 0; x < width; ++x) {
-    if (mat(x, height - 1).background()) {
-      setPixel(x, height - 1, 13, common);
+    if (Mat(x, height - 1).Background()) {
+      SetPixel(x, height - 1, 13, common);
     }
   }
 }
 
-void Level::resize(int width_new, int height_new) {
+void Level::Resize(int width_new, int height_new) {
   width = width_new;
   height = height_new;
   data.resize(width * height);
@@ -183,67 +183,67 @@ void Level::resize(int width_new, int height_new) {
 }
 
 bool Level::load(Common& common, Settings const& settings, io::Reader& r) {
-  resize(504, 350);
+  Resize(504, 350);
 
   // std::size_t len = f.len;
-  bool resetPalette = true;
+  bool reset_palette = true;
 
-  r.get(reinterpret_cast<uint8_t*>(&data[0]), width * height);
+  r.Get(reinterpret_cast<uint8_t*>(&data[0]), width * height);
 
   if (/*len >= 504*350 + 10 + 256*3
    &&*/
-      (settings.extensions && settings.loadPowerlevelPalette)) {
+      (settings.kExtensions && settings.load_powerlevel_palette)) {
     uint8_t buf[10] = {};
-    if (r.try_get(buf, 10)) {
+    if (r.TryGet(buf, 10)) {
       if (!std::memcmp("POWERLEVEL", buf, 10)) {
         Palette pal;
-        pal.read(r);
-        origpal.resetPalette(pal, settings);
+        pal.Read(r);
+        origpal.ResetPalette(pal, settings);
 
-        resetPalette = false;
+        reset_palette = false;
       }
     }
   }
 
   for (std::size_t i = 0; i < data.size(); ++i) materials[i] = common.materials[data[i]];
 
-  if (resetPalette) origpal.resetPalette(common.exepal, settings);
+  if (reset_palette) origpal.ResetPalette(common.exepal, settings);
 
   return true;
 }
 
-void Level::generateFromSettings(Common& common, Settings const& settings, Rand& rand) {
-  if (settings.randomLevel) {
-    generateRandom(common, settings, rand);
+void Level::GenerateFromSettings(Common& common, Settings const& settings, Rand& rand) {
+  if (settings.random_level) {
+    GenerateRandom(common, settings, rand);
   } else {
-    std::string path = settings.levelFile;
+    std::string path = settings.level_file;
     if (path.find('.', 0) == std::string::npos) path += ".LEV";
 
     bool loaded = false;
     try {
-      auto r_ptr = FsNode(path).toReader();
+      auto r_ptr = FsNode(path).ToReader();
       io::Reader& r = *r_ptr;
       loaded = load(common, settings, r);
     } catch (std::runtime_error&) {
       // Ignore
     }
 
-    if (!loaded) generateRandom(common, settings, rand);
+    if (!loaded) GenerateRandom(common, settings, rand);
   }
 
-  oldRandomLevel = settings.randomLevel;
-  oldLevelFile = settings.levelFile;
+  old_random_level = settings.random_level;
+  old_level_file = settings.level_file;
 
   if (settings.shadow) {
-    makeShadow(common);
+    MakeShadow(common);
   }
 }
 
 using std::vector;
 
-inline bool free(Material m) { return m.background() || m.anyDirt(); }
+inline bool Free(Material m) { return m.Background() || m.AnyDirt(); }
 
-bool Level::selectSpawn(Rand& rand, int w, int h, IVec2& selected) {
+bool Level::SelectSpawn(Rand& rand, int w, int h, IVec2& selected) {
   vector<int> vruns(width - w + 1);
   vector<int> vdists(width - w + 1);
 
@@ -256,7 +256,7 @@ bool Level::selectSpawn(Rand& rand, int w, int h, IVec2& selected) {
     int filled = 0;
 
     for (int x = 0; x < width; ++x) {
-      if (free(*m)) {
+      if (Free(*m)) {
         ++hrun;
       } else {
         hrun = 0;
@@ -288,23 +288,23 @@ bool Level::selectSpawn(Rand& rand, int w, int h, IVec2& selected) {
         ++vdist;
       }
 
-      filled -= !free(m[-w]);
+      filled -= !Free(m[-w]);
     }
   }
 
   return i > 0;
 }
 
-void Level::drawMiniature(Bitmap& dest, int mapX, int mapY, int step) {
+void Level::DrawMiniature(Bitmap& dest, int map_x, int map_y, int step) {
   int my = step / 2;
 
-  int mapEndY = mapY + ((height + step / 2) / step);
-  int mapEndX = mapX + ((width + step / 2) / step);
+  int map_end_y = map_y + ((height + step / 2) / step);
+  int map_end_x = map_x + ((width + step / 2) / step);
 
-  for (int y = mapY; y < mapEndY; ++y) {
+  for (int y = map_y; y < map_end_y; ++y) {
     int mx = step / 2;
-    for (int x = mapX; x < mapEndX; ++x) {
-      dest.getPixel(x, y) = checkedPixelWrap(mx, my);
+    for (int x = map_x; x < map_end_x; ++x) {
+      dest.GetPixel(x, y) = CheckedPixelWrap(mx, my);
       mx += step;
     }
     my += step;

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -132,8 +132,10 @@ void Level::GenerateRandom(Common& common, Settings const& settings, Rand& rand)
     int rock = rand(3);
 
     BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][0]), cx, cy);
-    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][1]), cx + 16, cy);
-    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][2]), cx, cy + 16);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][1]), cx + 16,
+              cy);
+    BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][2]), cx,
+              cy + 16);
     BlitStone(common, *this, false, common.large_sprites.SpritePtr(stone_tab[rock][3]), cx + 16,
               cy + 16);
   }

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -19,82 +19,82 @@ struct Rand;
 struct Common;
 
 struct Level {
-  Level(Common& common) : width(0), height(0) { zeroMaterial = common.materials[0]; }
+  Level(Common& common) : width(0), height(0) { zero_material = common.materials[0]; }
 
   bool load(Common& common, Settings const& settings, io::Reader& r);
 
-  void generateDirtPattern(Common& common, Rand& rand);
-  void generateRandom(Common& common, Settings const& settings, Rand& rand);
-  void makeShadow(Common& common);
-  void generateFromSettings(Common& common, Settings const& settings, Rand& rand);
-  bool selectSpawn(Rand& rand, int w, int h, IVec2& selected);
-  void drawMiniature(Bitmap& dest, int mapX, int mapY, int step);
+  void GenerateDirtPattern(Common& common, Rand& rand);
+  void GenerateRandom(Common& common, Settings const& settings, Rand& rand);
+  void MakeShadow(Common& common);
+  void GenerateFromSettings(Common& common, Settings const& settings, Rand& rand);
+  bool SelectSpawn(Rand& rand, int w, int h, IVec2& selected);
+  void DrawMiniature(Bitmap& dest, int map_x, int map_y, int step);
 
-  unsigned char pixel(int x, int y) { return data[x + y * width]; }
+  unsigned char Pixel(int x, int y) { return data[x + y * width]; }
 
-  unsigned char pixel(fixedvec pos) { return data[pos.x + pos.y * width]; }
+  unsigned char Pixel(fixedvec pos) { return data[pos.x + pos.y * width]; }
 
-  unsigned char* pixelp(int x, int y) { return &data[x + y * width]; }
+  unsigned char* Pixelp(int x, int y) { return &data[x + y * width]; }
 
-  void setPixel(int x, int y, PalIdx w, Common& common) {
+  void SetPixel(int x, int y, PalIdx w, Common& common) {
     data[x + y * width] = w;
     materials[x + y * width] = common.materials[w];
   }
 
-  void setPixel(fixedvec pos, PalIdx w, Common& common) {
+  void SetPixel(fixedvec pos, PalIdx w, Common& common) {
     data[pos.x + pos.y * width] = w;
     materials[pos.x + pos.y * width] = common.materials[w];
   }
 
-  Material& mat(int x, int y) { return materials[x + y * width]; }
+  Material& Mat(int x, int y) { return materials[x + y * width]; }
 
-  Material& mat(fixedvec pos) { return materials[pos.x + pos.y * width]; }
+  Material& Mat(fixedvec pos) { return materials[pos.x + pos.y * width]; }
 
-  Material* matp(int x, int y) { return &materials[x + y * width]; }
+  Material* Matp(int x, int y) { return &materials[x + y * width]; }
 
-  unsigned char checkedPixelWrap(int x, int y) {
+  unsigned char CheckedPixelWrap(int x, int y) {
     unsigned int idx = static_cast<unsigned int>(x + y * width);
     if (idx < data.size()) return data[idx];
     return 0;
   }
 
-  Material checkedMatWrap(int x, int y) {
+  Material CheckedMatWrap(int x, int y) {
     unsigned int idx = static_cast<unsigned int>(x + y * width);
     if (idx < materials.size()) return materials[idx];
-    return zeroMaterial;
+    return zero_material;
   }
 
-  bool inside(int x, int y) {
+  bool Inside(int x, int y) {
     return static_cast<unsigned int>(x) < static_cast<unsigned int>(width) &&
            static_cast<unsigned int>(y) < static_cast<unsigned int>(height);
   }
 
-  bool inside(fixedvec pos) {
+  bool Inside(fixedvec pos) {
     return static_cast<unsigned int>(pos.x) < static_cast<unsigned int>(width) &&
            static_cast<unsigned int>(pos.y) < static_cast<unsigned int>(height);
   }
 
-  void swap(Level& other) {
+  void Swap(Level& other) {
     data.swap(other.data);
     materials.swap(other.materials);
     std::swap(width, other.width);
     std::swap(height, other.height);
     std::swap(origpal, other.origpal);
-    std::swap(oldRandomLevel, other.oldRandomLevel);
-    std::swap(oldLevelFile, other.oldLevelFile);
-    std::swap(zeroMaterial, other.zeroMaterial);
+    std::swap(old_random_level, other.old_random_level);
+    std::swap(old_level_file, other.old_level_file);
+    std::swap(zero_material, other.zero_material);
   }
 
-  Rect rect() { return Rect(0, 0, width, height); }
+  Rect Bounds() { return Rect(0, 0, width, height); }
 
-  void resize(int width_new, int height_new);
+  void Resize(int width_new, int height_new);
 
   std::vector<unsigned char> data;
   std::vector<Material> materials;
 
-  bool oldRandomLevel;
-  std::string oldLevelFile;
+  bool old_random_level;
+  std::string old_level_file;
   int width, height;
   Palette origpal;
-  Material zeroMaterial;
+  Material zero_material;
 };

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -5,11 +5,11 @@
 #include <windows.h>
 #endif
 
-int gameEntry(int argc, char* argv[]);
+int GameEntry(int argc, char* argv[]);
 
 int main(int argc, char* argv[]) {
   try {
-    return gameEntry(argc, argv);
+    return GameEntry(argc, argv);
   } catch (std::exception& ex) {
 #if _WIN32
     MessageBoxA(NULL, (std::string("Sorry, something went wrong :(\r\n\r\n") + ex.what()).c_str(),

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -25,7 +25,7 @@ using std::vector;
 
 #define MIN3(a, b, c) ((a) < (b) ? ((a) < (c) ? (a) : (c)) : ((b) < (c) ? (b) : (c)))
 
-static int levenshtein(char const* s1, char const* s2) {
+static int Levenshtein(char const* s1, char const* s2) {
   std::size_t x, y, s1len, s2len;
   s1len = strlen(s1);
   s2len = strlen(s2);
@@ -45,11 +45,11 @@ static int levenshtein(char const* s1, char const* s2) {
 
 #undef MIN3
 
-static void resetLeftRight() {
-  gfx.releaseSDLKey(SDL_SCANCODE_LEFT);
-  gfx.releaseSDLKey(SDL_SCANCODE_RIGHT);
-  gfx.releaseControl(WormSettingsExtensions::Left);
-  gfx.releaseControl(WormSettingsExtensions::Right);
+static void ResetLeftRight() {
+  gfx.ReleaseSdlKey(SDL_SCANCODE_LEFT);
+  gfx.ReleaseSdlKey(SDL_SCANCODE_RIGHT);
+  gfx.ReleaseControl(WormSettingsExtensions::kLeft);
+  gfx.ReleaseControl(WormSettingsExtensions::kRight);
 }
 
 // Builds an InputStringState for a Save As dialog with name-collision
@@ -58,25 +58,25 @@ static void resetLeftRight() {
 // preserving what the user typed. `onComplete` is called once at the
 // end of the dialog flow — with the validated name on success, or an
 // empty string on cancel.
-static std::unique_ptr<AppState> makeSaveAsState(
+static std::unique_ptr<AppState> MakeSaveAsState(
     std::string subdir, std::string ext, std::string initial, int x, int y,
-    std::function<void(std::string const& result)> onComplete) {
-  auto cb = [subdir, ext, x, y, onComplete](bool accepted, std::string const& result) {
+    std::function<void(std::string const& result)> on_complete) {
+  auto cb = [subdir, ext, x, y, on_complete](bool accepted, std::string const& result) {
     if (!accepted || result.empty()) {
-      onComplete(std::string());
+      on_complete(std::string());
       return;
     }
     std::string leaf = result + ext;
-    if (paths::shadowsSystem(gfx.getUserConfigNode(), subdir, leaf)) {
+    if (paths::ShadowsSystem(gfx.GetUserConfigNode(), subdir, leaf)) {
       std::string msg = "NAME '" + leaf + "' IS RESERVED";
-      gfx.stateStack.scheduleReplaceTop(std::make_unique<InfoBoxState>(
-          msg, 160, 100, true, [subdir, ext, result, x, y, onComplete]() {
-            gfx.stateStack.scheduleReplaceTop(
-                makeSaveAsState(subdir, ext, result, x, y, onComplete));
+      gfx.state_stack.ScheduleReplaceTop(std::make_unique<InfoBoxState>(
+          msg, 160, 100, true, [subdir, ext, result, x, y, on_complete]() {
+            gfx.state_stack.ScheduleReplaceTop(
+                MakeSaveAsState(subdir, ext, result, x, y, on_complete));
           }));
       return;
     }
-    onComplete(result);
+    on_complete(result);
   };
   return std::make_unique<InputStringState>(std::move(initial), 30, x, y, nullptr, "", false,
                                             std::move(cb));
@@ -84,163 +84,163 @@ static std::unique_ptr<AppState> makeSaveAsState(
 
 MainMenuState::MainMenuState() {}
 
-void MainMenuState::enter() {
+void MainMenuState::Enter() {
   Common& common = *gfx->common;
-  int centerX = gfx->singleScreenRenderer.renderResX / 2;
+  int center_x = gfx->single_screen_renderer.render_res_x / 2;
 
-  std::memset(gfx->playRenderer.pal.entries, 0, sizeof(gfx->playRenderer.pal.entries));
-  std::memset(gfx->singleScreenRenderer.pal.entries, 0,
-              sizeof(gfx->singleScreenRenderer.pal.entries));
-  gfx->flip();
-  gfx->process();
+  std::memset(gfx->play_renderer.pal.entries, 0, sizeof(gfx->play_renderer.pal.entries));
+  std::memset(gfx->single_screen_renderer.pal.entries, 0,
+              sizeof(gfx->single_screen_renderer.pal.entries));
+  gfx->Flip();
+  gfx->Process();
 
-  fillRect(gfx->playRenderer.bmp, 0, 151, 160, 7, 0);
-  common.font.drawText(gfx->playRenderer.bmp, LS(Copyright2), 2, 152, 19);
+  FillRect(gfx->play_renderer.bmp, 0, 151, 160, 7, 0);
+  common.font.DrawText(gfx->play_renderer.bmp, LS(Copyright2), 2, 152, 19);
 
-  if (gfx->controller->running()) {
-    gfx->mainMenu.setVisibility(MainMenu::MaResumeGame, true);
-    gfx->mainMenu.itemFromId(MainMenu::MaResumeGame)->string = "RESUME GAME (F1)";
-    gfx->mainMenu.itemFromId(MainMenu::MaNewGame)->string = "NEW GAME";
-    startItemId_ = MainMenu::MaResumeGame;
+  if (gfx->controller->Running()) {
+    gfx->main_menu.SetVisibility(MainMenu::kMaResumeGame, true);
+    gfx->main_menu.ItemFromId(MainMenu::kMaResumeGame)->string = "RESUME GAME (F1)";
+    gfx->main_menu.ItemFromId(MainMenu::kMaNewGame)->string = "NEW GAME";
+    startItemId_ = MainMenu::kMaResumeGame;
   } else {
-    gfx->mainMenu.setVisibility(MainMenu::MaResumeGame, false);
-    gfx->mainMenu.itemFromId(MainMenu::MaNewGame)->string = "NEW GAME (F1)";
-    startItemId_ = MainMenu::MaNewGame;
+    gfx->main_menu.SetVisibility(MainMenu::kMaResumeGame, false);
+    gfx->main_menu.ItemFromId(MainMenu::kMaNewGame)->string = "NEW GAME (F1)";
+    startItemId_ = MainMenu::kMaNewGame;
   }
 
-  gfx->mainMenu.itemFromId(MainMenu::MaTc)->string = "TC (" + gfx->settings->tc + ")";
+  gfx->main_menu.ItemFromId(MainMenu::kMaTc)->string = "TC (" + gfx->settings->tc + ")";
 
-  gfx->mainMenu.moveToFirstVisible();
-  gfx->settingsMenu.moveToFirstVisible();
-  gfx->settingsMenu.updateItems(common);
+  gfx->main_menu.MoveToFirstVisible();
+  gfx->settings_menu.MoveToFirstVisible();
+  gfx->settings_menu.UpdateItems(common);
 
-  gfx->playRenderer.fadeValue = 0;
-  gfx->singleScreenRenderer.fadeValue = 0;
-  gfx->curMenu = &gfx->mainMenu;
+  gfx->play_renderer.fade_value = 0;
+  gfx->single_screen_renderer.fade_value = 0;
+  gfx->cur_menu = &gfx->main_menu;
 
-  gfx->frozenScreen.copy(gfx->playRenderer.bmp);
-  gfx->singleScreenRenderer.clear();
-  if (gfx->controller->currentLevel()) {
-    gfx->controller->currentLevel()->drawMiniature(gfx->singleScreenRenderer.bmp, centerX - 126,
-                                                   gfx->singleScreenRenderer.renderResY - 208, 2);
+  gfx->frozen_screen.Copy(gfx->play_renderer.bmp);
+  gfx->single_screen_renderer.Clear();
+  if (gfx->controller->CurrentLevel()) {
+    gfx->controller->CurrentLevel()->DrawMiniature(gfx->single_screen_renderer.bmp, center_x - 126,
+                                                   gfx->single_screen_renderer.render_res_y - 208, 2);
   }
-  gfx->frozenSpectatorScreen.copy(gfx->singleScreenRenderer.bmp);
+  gfx->frozen_spectator_screen.Copy(gfx->single_screen_renderer.bmp);
 
-  gfx->menuCycles = 0;
+  gfx->menu_cycles = 0;
   selected_ = -1;
-  phase_ = Phase::Active;
+  phase_ = Phase::kActive;
 }
 
-void MainMenuState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void MainMenuState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool MainMenuState::update() {
-  if (phase_ == Phase::FadingOut) {
-    if (gfx->playRenderer.fadeValue > 0) {
-      --gfx->playRenderer.fadeValue;
-      --gfx->singleScreenRenderer.fadeValue;
+bool MainMenuState::Update() {
+  if (phase_ == Phase::kFadingOut) {
+    if (gfx->play_renderer.fade_value > 0) {
+      --gfx->play_renderer.fade_value;
+      --gfx->single_screen_renderer.fade_value;
       return true;
     }
     return false;
   }
 
   // Check if a sub-state left a result for us
-  if (gfx->pendingMenuSelection >= 0) {
-    selected_ = gfx->pendingMenuSelection;
-    gfx->pendingMenuSelection = -1;
+  if (gfx->pending_menu_selection >= 0) {
+    selected_ = gfx->pending_menu_selection;
+    gfx->pending_menu_selection = -1;
   }
 
   // Phase::Active — process input
   Common& common = *gfx->common;
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
-      gfx->testControlOnce(WormSettingsExtensions::Jump) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
-    if (gfx->curMenu == &gfx->mainMenu)
-      gfx->mainMenu.moveToId(MainMenu::MaQuit);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kJump) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
+    if (gfx->cur_menu == &gfx->main_menu)
+      gfx->main_menu.MoveToId(MainMenu::kMaQuit);
     else
-      gfx->curMenu = &gfx->mainMenu;
+      gfx->cur_menu = &gfx->main_menu;
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_UP) || gfx->testControlOnce(WormSettingsExtensions::Up) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-    gfx->curMenu->movement(-1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_UP) || gfx->TestControlOnce(WormSettingsExtensions::kUp) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+    gfx->cur_menu->Movement(-1);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN) ||
-      gfx->testControlOnce(WormSettingsExtensions::Down) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-    gfx->curMenu->movement(1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kDown) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+    gfx->cur_menu->Movement(1);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN) || gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER) ||
-      gfx->testControlOnce(WormSettingsExtensions::Fire) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
-    if (gfx->curMenu == &gfx->mainMenu) {
-      g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RETURN) || gfx->TestSdlKeyOnce(SDL_SCANCODE_KP_ENTER) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kFire) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
+    if (gfx->cur_menu == &gfx->main_menu) {
+      g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
 
-      int s = gfx->mainMenu.selectedId();
+      int s = gfx->main_menu.SelectedId();
       switch (s) {
-        case MainMenu::MaSettings: {
-          gfx->curMenu = &gfx->settingsMenu;
+        case MainMenu::kMaSettings: {
+          gfx->cur_menu = &gfx->settings_menu;
           break;
         }
 
-        case MainMenu::MaPlayer1Settings:
-        case MainMenu::MaPlayer2Settings: {
-          gfx->playerSettings(s - MainMenu::MaPlayer1Settings);
+        case MainMenu::kMaPlayer1Settings:
+        case MainMenu::kMaPlayer2Settings: {
+          gfx->PlayerSettings(s - MainMenu::kMaPlayer1Settings);
           break;
         }
 
-        case MainMenu::MaNetPlayerSettings: {
-          gfx->playerSettings(Settings::NetworkPlayerIdx);
+        case MainMenu::kMaNetPlayerSettings: {
+          gfx->PlayerSettings(Settings::kNetworkPlayerIdx);
           break;
         }
 
-        case MainMenu::MaAdvanced: {
-          gfx->openHiddenMenu();
+        case MainMenu::kMaAdvanced: {
+          gfx->OpenHiddenMenu();
           break;
         }
 
-        case MainMenu::MaReplays: {
-          gfx->stateStack.push(std::make_unique<ReplaySelectorState>(), gfx);
+        case MainMenu::kMaReplays: {
+          gfx->state_stack.Push(std::make_unique<ReplaySelectorState>(), gfx);
           break;
         }
 
-        case MainMenu::MaTc: {
-          gfx->stateStack.push(std::make_unique<TcSelectorState>(), gfx);
+        case MainMenu::kMaTc: {
+          gfx->state_stack.Push(std::make_unique<TcSelectorState>(), gfx);
           break;
         }
 
-        case MainMenu::MaJoinGame: {
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->stateStack.push(std::make_unique<InputStringState>(
+        case MainMenu::kMaJoinGame: {
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->state_stack.Push(std::make_unique<InputStringState>(
                                    "", 40, 10, 80, nullptr, "ADDRESS: ", false,
                                    [this](bool accepted, std::string const& result) {
                                      if (accepted && !result.empty()) {
-                                       gfx->pendingNetAddress = result;
-                                       gfx->pendingMenuSelection = MainMenu::MaJoinGame;
+                                       gfx->pending_net_address = result;
+                                       gfx->pending_menu_selection = MainMenu::kMaJoinGame;
                                      }
                                    }),
                                gfx);
           break;
         }
 
-        case MainMenu::MaHostOnline: {
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->pendingMenuSelection = MainMenu::MaHostOnline;
+        case MainMenu::kMaHostOnline: {
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->pending_menu_selection = MainMenu::kMaHostOnline;
           break;
         }
 
-        case MainMenu::MaJoinOnline: {
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->stateStack.push(std::make_unique<InputStringState>(
+        case MainMenu::kMaJoinOnline: {
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->state_stack.Push(std::make_unique<InputStringState>(
                                    "", 6, 10, 80, ::toupper, "ROOM CODE: ", false,
                                    [this](bool accepted, std::string const& result) {
                                      if (accepted && result.size() == 6) {
-                                       gfx->pendingNetAddress = result;
-                                       gfx->pendingMenuSelection = MainMenu::MaJoinOnline;
+                                       gfx->pending_net_address = result;
+                                       gfx->pending_menu_selection = MainMenu::kMaJoinOnline;
                                      }
                                    }),
                                gfx);
@@ -248,44 +248,44 @@ bool MainMenuState::update() {
         }
 
         default: {
-          gfx->curMenu = &gfx->mainMenu;
+          gfx->cur_menu = &gfx->main_menu;
           selected_ = s;
         }
       }
-    } else if (gfx->curMenu == &gfx->settingsMenu) {
-      int itemId = gfx->settingsMenu.selectedId();
-      switch (itemId) {
-        case SettingsMenu::SiLevel:
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->stateStack.push(std::make_unique<LevelSelectorState>(), gfx);
+    } else if (gfx->cur_menu == &gfx->settings_menu) {
+      int item_id = gfx->settings_menu.SelectedId();
+      switch (item_id) {
+        case SettingsMenu::kSiLevel:
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->state_stack.Push(std::make_unique<LevelSelectorState>(), gfx);
           break;
 
-        case SettingsMenu::SiWeaponOptions:
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->stateStack.push(std::make_unique<WeaponMenuState>(), gfx);
+        case SettingsMenu::kSiWeaponOptions:
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->state_stack.Push(std::make_unique<WeaponMenuState>(), gfx);
           break;
 
-        case SettingsMenu::LoadOptions:
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          gfx->stateStack.push(std::make_unique<OptionsSelectorState>(), gfx);
+        case SettingsMenu::kLoadOptions:
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          gfx->state_stack.Push(std::make_unique<OptionsSelectorState>(), gfx);
           break;
 
-        case SettingsMenu::SaveOptions: {
-          g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+        case SettingsMenu::kSaveOptions: {
+          g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
           int x, y;
-          auto* item = gfx->settingsMenu.itemFromId(SettingsMenu::SaveOptions);
-          if (item && gfx->settingsMenu.itemPosition(*item, x, y)) {
-            x += gfx->settingsMenu.valueOffsetX + 2;
-            std::string name = getBasename(getLeaf(gfx->settingsNode.fullPath()));
-            gfx->stateStack.push(
-                makeSaveAsState("Setups", ".cfg", name, x, y,
+          auto* item = gfx->settings_menu.ItemFromId(SettingsMenu::kSaveOptions);
+          if (item && gfx->settings_menu.ItemPosition(*item, x, y)) {
+            x += gfx->settings_menu.value_offset_x + 2;
+            std::string name = GetBasename(GetLeaf(gfx->settings_node.FullPath()));
+            gfx->state_stack.Push(
+                MakeSaveAsState("Setups", ".cfg", name, x, y,
                                 [this](std::string const& result) {
                                   if (!result.empty()) {
-                                    gfx->saveSettings(gfx->getUserConfigNode() / "Setups" /
+                                    gfx->SaveSettings(gfx->GetUserConfigNode() / "Setups" /
                                                       (result + ".cfg"));
                                   }
-                                  g_soundPlayer->play(gfx->common->soundHook[SoundMenuSelect]);
-                                  gfx->settingsMenu.updateItems(*gfx->common);
+                                  g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
+                                  gfx->settings_menu.UpdateItems(*gfx->common);
                                 }),
                 gfx);
           }
@@ -293,299 +293,299 @@ bool MainMenuState::update() {
         }
 
         default:
-          gfx->settingsMenu.onEnter(common);
+          gfx->settings_menu.OnEnter(common);
           break;
       }
-    } else if (gfx->curMenu == &gfx->playerMenu) {
-      int itemId = gfx->playerMenu.selectedId();
+    } else if (gfx->cur_menu == &gfx->player_menu) {
+      int item_id = gfx->player_menu.SelectedId();
 
-      if (itemId == PlayerMenu::PlLoadProfile) {
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-        gfx->stateStack.push(std::make_unique<ProfileSelectorState>(*gfx->playerMenu.ws), gfx);
-      } else if (itemId == PlayerMenu::PlName) {
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-        auto& ws = *gfx->playerMenu.ws;
+      if (item_id == PlayerMenu::kPlLoadProfile) {
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+        gfx->state_stack.Push(std::make_unique<ProfileSelectorState>(*gfx->player_menu.ws), gfx);
+      } else if (item_id == PlayerMenu::kPlName) {
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+        auto& ws = *gfx->player_menu.ws;
         int x, y;
-        auto* item = gfx->playerMenu.itemFromId(itemId);
-        if (item && gfx->playerMenu.itemPosition(*item, x, y)) {
-          x += gfx->playerMenu.valueOffsetX + 2;
-          gfx->stateStack.push(std::make_unique<InputStringState>(
+        auto* item = gfx->player_menu.ItemFromId(item_id);
+        if (item && gfx->player_menu.ItemPosition(*item, x, y)) {
+          x += gfx->player_menu.value_offset_x + 2;
+          gfx->state_stack.Push(std::make_unique<InputStringState>(
                                    ws.name, 20, x, y, nullptr, "", false,
                                    [this](bool accepted, std::string const& result) {
-                                     auto& ws = *gfx->playerMenu.ws;
+                                     auto& ws = *gfx->player_menu.ws;
                                      if (accepted) ws.name = result;
-                                     if (ws.name.empty()) Settings::generateName(ws, gfx->rand);
-                                     ws.randomName = false;
-                                     g_soundPlayer->play(gfx->common->soundHook[SoundMenuSelect]);
-                                     gfx->playerMenu.updateItems(*gfx->common);
+                                     if (ws.name.empty()) Settings::GenerateName(ws, gfx->rand);
+                                     ws.random_name = false;
+                                     g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
+                                     gfx->player_menu.UpdateItems(*gfx->common);
                                    }),
                                gfx);
         }
-      } else if (itemId == PlayerMenu::PlSaveProfileAs) {
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+      } else if (item_id == PlayerMenu::kPlSaveProfileAs) {
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
         int x, y;
-        auto* item = gfx->playerMenu.itemFromId(itemId);
-        if (item && gfx->playerMenu.itemPosition(*item, x, y)) {
-          x += gfx->playerMenu.valueOffsetX + 2;
-          gfx->stateStack.push(
-              makeSaveAsState("Profiles", ".toml", "", x, y,
+        auto* item = gfx->player_menu.ItemFromId(item_id);
+        if (item && gfx->player_menu.ItemPosition(*item, x, y)) {
+          x += gfx->player_menu.value_offset_x + 2;
+          gfx->state_stack.Push(
+              MakeSaveAsState("Profiles", ".toml", "", x, y,
                               [this](std::string const& result) {
                                 if (!result.empty()) {
-                                  gfx->playerMenu.ws->saveProfile(gfx->getUserConfigNode() /
+                                  gfx->player_menu.ws->SaveProfile(gfx->GetUserConfigNode() /
                                                                   "Profiles" / (result + ".toml"));
                                 }
-                                g_soundPlayer->play(gfx->common->soundHook[SoundMenuSelect]);
-                                gfx->playerMenu.updateItems(*gfx->common);
+                                g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
+                                gfx->player_menu.UpdateItems(*gfx->common);
                               }),
               gfx);
         }
-      } else if ((itemId >= PlayerMenu::PlUp && itemId <= PlayerMenu::PlJump) ||
-                 itemId == PlayerMenu::PlDig) {
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-        bool extended = gfx->settings->extensions;
-        int keyIdx = itemId - PlayerMenu::PlUp;
+      } else if ((item_id >= PlayerMenu::kPlUp && item_id <= PlayerMenu::kPlJump) ||
+                 item_id == PlayerMenu::kPlDig) {
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+        bool extended = gfx->settings->kExtensions;
+        int key_idx = item_id - PlayerMenu::kPlUp;
 
-        gfx->stateStack.push(
+        gfx->state_stack.Push(
             std::make_unique<WaitForKeyState>(extended,
-                                              [this, keyIdx](uint32_t k, bool isGamepad) {
-                                                auto& ws = *gfx->playerMenu.ws;
-                                                if (k != DkEscape) {
-                                                  if (isGamepad) {
-                                                    ws.gamepadControls[keyIdx] = k;
+                                              [this, key_idx](uint32_t k, bool is_gamepad) {
+                                                auto& ws = *gfx->player_menu.ws;
+                                                if (k != kDkEscape) {
+                                                  if (is_gamepad) {
+                                                    ws.gamepad_controls[key_idx] = k;
                                                   } else {
-                                                    if (!isExtendedKey(k)) ws.controls[keyIdx] = k;
-                                                    ws.controlsEx[keyIdx] = k;
+                                                    if (!IsExtendedKey(k)) ws.controls[key_idx] = k;
+                                                    ws.controls_ex[key_idx] = k;
                                                   }
-                                                  gfx->playerMenu.updateItems(*gfx->common);
+                                                  gfx->player_menu.UpdateItems(*gfx->common);
                                                 }
                                               }),
             gfx);
-      } else if (itemId >= PlayerMenu::PlWeap0 && itemId < PlayerMenu::PlWeap0 + 5) {
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+      } else if (item_id >= PlayerMenu::kPlWeap0 && item_id < PlayerMenu::kPlWeap0 + 5) {
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
         int x, y;
-        auto* item = gfx->playerMenu.itemFromId(itemId);
-        if (item && gfx->playerMenu.itemPosition(*item, x, y)) {
-          x += gfx->playerMenu.valueOffsetX + 2;
-          int weapIdx = itemId - PlayerMenu::PlWeap0;
-          gfx->stateStack.push(std::make_unique<InputStringState>(
+        auto* item = gfx->player_menu.ItemFromId(item_id);
+        if (item && gfx->player_menu.ItemPosition(*item, x, y)) {
+          x += gfx->player_menu.value_offset_x + 2;
+          int weap_idx = item_id - PlayerMenu::kPlWeap0;
+          gfx->state_stack.Push(std::make_unique<InputStringState>(
                                    "", 10, x, y, nullptr, "", false,
-                                   [this, weapIdx](bool accepted, std::string const& result) {
+                                   [this, weap_idx](bool accepted, std::string const& result) {
                                      if (accepted && !result.empty()) {
                                        Common& common = *gfx->common;
-                                       auto& ws = *gfx->playerMenu.ws;
-                                       uint32_t numWeapons = (uint32_t)common.weapons.size();
+                                       auto& ws = *gfx->player_menu.ws;
+                                       uint32_t num_weapons = (uint32_t)common.weapons.size();
 
-                                       uint32_t best = ws.weapons[weapIdx];
-                                       double bestDist = std::numeric_limits<double>::max();
-                                       for (uint32_t i = 1; i <= numWeapons; ++i) {
+                                       uint32_t best = ws.weapons[weap_idx];
+                                       double best_dist = std::numeric_limits<double>::max();
+                                       for (uint32_t i = 1; i <= num_weapons; ++i) {
                                          std::string& name =
-                                             common.weapons[common.weapOrder[i - 1]].name;
-                                         double dist = levenshtein(name.c_str(), result.c_str()) /
+                                             common.weapons[common.weap_order[i - 1]].name;
+                                         double dist = Levenshtein(name.c_str(), result.c_str()) /
                                                        (double)name.length();
-                                         if (dist < bestDist) {
+                                         if (dist < best_dist) {
                                            best = i;
-                                           bestDist = dist;
+                                           best_dist = dist;
                                          }
                                        }
-                                       ws.weapons[weapIdx] = best;
-                                       gfx->playerMenu.updateItems(common);
+                                       ws.weapons[weap_idx] = best;
+                                       gfx->player_menu.UpdateItems(common);
                                      }
                                    }),
                                gfx);
         }
       } else {
-        selected_ = gfx->curMenu->onEnter(common);
+        selected_ = gfx->cur_menu->OnEnter(common);
       }
     } else {
-      selected_ = gfx->curMenu->onEnter(common);
+      selected_ = gfx->cur_menu->OnEnter(common);
     }
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F1)) {
-    gfx->curMenu = &gfx->mainMenu;
-    gfx->mainMenu.moveToId(startItemId_);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F1)) {
+    gfx->cur_menu = &gfx->main_menu;
+    gfx->main_menu.MoveToId(startItemId_);
     selected_ = startItemId_;
   }
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F2)) {
-    gfx->mainMenu.moveToId(MainMenu::MaAdvanced);
-    gfx->openHiddenMenu();
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F2)) {
+    gfx->main_menu.MoveToId(MainMenu::kMaAdvanced);
+    gfx->OpenHiddenMenu();
   }
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F3)) {
-    gfx->curMenu = &gfx->mainMenu;
-    gfx->mainMenu.moveToId(MainMenu::MaReplays);
-    gfx->stateStack.push(std::make_unique<ReplaySelectorState>(), gfx);
-  }
-
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F5)) {
-    gfx->mainMenu.moveToId(MainMenu::MaPlayer1Settings);
-    gfx->playerSettings(0);
-  }
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F6)) {
-    gfx->mainMenu.moveToId(MainMenu::MaPlayer2Settings);
-    gfx->playerSettings(1);
-  }
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F7)) {
-    gfx->mainMenu.moveToId(MainMenu::MaSettings);
-    gfx->curMenu = &gfx->settingsMenu;
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F3)) {
+    gfx->cur_menu = &gfx->main_menu;
+    gfx->main_menu.MoveToId(MainMenu::kMaReplays);
+    gfx->state_stack.Push(std::make_unique<ReplaySelectorState>(), gfx);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F9)) {
-    gfx->mainMenu.moveToId(MainMenu::MaNetPlayerSettings);
-    gfx->playerSettings(Settings::NetworkPlayerIdx);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F5)) {
+    gfx->main_menu.MoveToId(MainMenu::kMaPlayer1Settings);
+    gfx->PlayerSettings(0);
+  }
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F6)) {
+    gfx->main_menu.MoveToId(MainMenu::kMaPlayer2Settings);
+    gfx->PlayerSettings(1);
+  }
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F7)) {
+    gfx->main_menu.MoveToId(MainMenu::kMaSettings);
+    gfx->cur_menu = &gfx->settings_menu;
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_F8)) {
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F9)) {
+    gfx->main_menu.MoveToId(MainMenu::kMaNetPlayerSettings);
+    gfx->PlayerSettings(Settings::kNetworkPlayerIdx);
+  }
+
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_F8)) {
     uint32_t s = 14;
 
     Rand r;
-    r.seed(s);
+    r.Seed(s);
 
     Common& common = *gfx->common;
 
-    vector<std::size_t> nobjMap;
+    vector<std::size_t> nobj_map;
 
-    for (std::size_t i = 0; i < common.nobjectTypes.size(); ++i) {
-      nobjMap.push_back(i);
+    for (std::size_t i = 0; i < common.nobject_types.size(); ++i) {
+      nobj_map.push_back(i);
     }
     std::random_device rd;
     std::mt19937 g(rd());
-    std::shuffle(nobjMap.begin(), nobjMap.end(), g);
+    std::shuffle(nobj_map.begin(), nobj_map.end(), g);
 
     for (auto& w : common.weapons) {
-      w.addSpeed = r(30) - 5;
-      w.affectByExplosions = r(2) == 0;
-      w.affectByWorm = r(3) == 0;
+      w.add_speed = r(30) - 5;
+      w.affect_by_explosions = r(2) == 0;
+      w.affect_by_worm = r(3) == 0;
       w.ammo = r(20) + 1;
-      w.bloodOnHit = r(50);
-      w.blowAway = r(10);
+      w.blood_on_hit = r(50);
+      w.blow_away = r(10);
       w.bounce = r(90);
-      w.collideWithObjects = r(10) == 0;
-      w.colorBullets = 3 + r(250);
-      w.createOnExp = r(common.sobjectTypes.size());
+      w.collide_with_objects = r(10) == 0;
+      w.color_bullets = 3 + r(250);
+      w.create_on_exp = r(common.sobject_types.size());
       w.delay = r(70);
-      w.detectDistance = r(20);
-      w.dirtEffect = r(9);
+      w.detect_distance = r(20);
+      w.dirt_effect = r(9);
       w.distribution = r(5000) - 2500;
-      w.explGround = r(2) == 0;
-      w.exploSound = r(common.sounds.size());
-      w.fireCone = r(10);
+      w.expl_ground = r(2) == 0;
+      w.explo_sound = r(common.sounds.size());
+      w.fire_cone = r(10);
       w.gravity = r(2000) - 1000;
-      w.hitDamage = r(20);
-      w.laserSight = r(5) == 0;
-      w.launchSound = r(common.sounds.size());
-      w.leaveShellDelay = r(30);
-      w.leaveShells = r(1) == 0;
-      w.loadingTime = r(70 * 3);
-      w.loopAnim = r(10) == 0;
-      w.loopSound = false;
-      w.multSpeed = r(2) ? 100 : 99 + r(5);
-      w.objTrailDelay = 10 + r(70);
-      w.objTrailType = r(4) == 0 ? r(common.sobjectTypes.size()) : -1;
+      w.hit_damage = r(20);
+      w.laser_sight = r(5) == 0;
+      w.launch_sound = r(common.sounds.size());
+      w.leave_shell_delay = r(30);
+      w.leave_shells = r(1) == 0;
+      w.loading_time = r(70 * 3);
+      w.loop_anim = r(10) == 0;
+      w.loop_sound = false;
+      w.mult_speed = r(2) ? 100 : 99 + r(5);
+      w.obj_trail_delay = 10 + r(70);
+      w.obj_trail_type = r(4) == 0 ? r(common.sobject_types.size()) : -1;
       w.parts = r(2) == 0 ? r(10) : 1;
-      w.partTrailDelay = 10 + r(70);
-      w.partTrailObj = r(4) == 0 ? r(common.nobjectTypes.size()) : -1;
-      w.partTrailType = r(2);
-      w.playReloadSound = r(2) == 0;
+      w.part_trail_delay = 10 + r(70);
+      w.part_trail_obj = r(4) == 0 ? r(common.nobject_types.size()) : -1;
+      w.part_trail_type = r(2);
+      w.play_reload_sound = r(2) == 0;
       w.recoil = r(20);
       w.shadow = r(2) == 0;
-      w.shotType = r(5);
+      w.shot_type = r(5);
       w.speed = r(200);
-      w.splinterAmount = r(5) == 0 ? r(10) : 0;
-      w.splinterColour = r(256);
-      w.splinterScatter = r(2);
-      w.splinterType = r(common.nobjectTypes.size());
-      w.startFrame = r((uint32_t)common.smallSprites.count - 13);
-      w.numFrames = r(5);
-      w.timeToExplo = 50 + r(200);
-      w.timeToExploV = 10 + r(50);
-      w.wormCollide = r(3) > 0;
-      w.wormExplode = r(3) > 0;
+      w.splinter_amount = r(5) == 0 ? r(10) : 0;
+      w.splinter_colour = r(256);
+      w.splinter_scatter = r(2);
+      w.splinter_type = r(common.nobject_types.size());
+      w.start_frame = r((uint32_t)common.small_sprites.count - 13);
+      w.num_frames = r(5);
+      w.time_to_explo = 50 + r(200);
+      w.time_to_explo_v = 10 + r(50);
+      w.worm_collide = r(3) > 0;
+      w.worm_explode = r(3) > 0;
     }
 
-    for (std::size_t idx = 0; idx < common.nobjectTypes.size(); ++idx) {
-      auto& n = common.nobjectTypes[nobjMap[idx]];
-      n.affectByExplosions = r(5) == 0;
-      n.bloodOnHit = r(5);
-      n.bloodTrail = r(10) == 0;
-      n.bloodTrailDelay = r(20) + 3;
-      n.blowAway = r(10);
+    for (std::size_t idx = 0; idx < common.nobject_types.size(); ++idx) {
+      auto& n = common.nobject_types[nobj_map[idx]];
+      n.affect_by_explosions = r(5) == 0;
+      n.blood_on_hit = r(5);
+      n.blood_trail = r(10) == 0;
+      n.blood_trail_delay = r(20) + 3;
+      n.blow_away = r(10);
       n.bounce = r(90);
-      n.colorBullets = 3 + r(250);
-      n.createOnExp = r(3) == 0 ? r(common.sobjectTypes.size()) : -1;
-      n.detectDistance = r(20);
-      n.dirtEffect = r(9);
+      n.color_bullets = 3 + r(250);
+      n.create_on_exp = r(3) == 0 ? r(common.sobject_types.size()) : -1;
+      n.detect_distance = r(20);
+      n.dirt_effect = r(9);
       n.distribution = r(5000) - 2500;
-      n.drawOnMap = r(20) == 0;
-      n.explGround = r(4) > 0;
+      n.draw_on_map = r(20) == 0;
+      n.expl_ground = r(4) > 0;
       n.gravity = r(2000) - 1000;
-      n.hitDamage = r(10);
-      n.leaveObj = r(5) == 0 ? r(common.sobjectTypes.size()) : -1;
-      n.leaveObjDelay = 10 + r(80);
-      n.startFrame = r((uint32_t)common.smallSprites.count - 13);
-      n.numFrames = r(5);
+      n.hit_damage = r(10);
+      n.leave_obj = r(5) == 0 ? r(common.sobject_types.size()) : -1;
+      n.leave_obj_delay = 10 + r(80);
+      n.start_frame = r((uint32_t)common.small_sprites.count - 13);
+      n.num_frames = r(5);
       n.speed = r(150);
-      n.splinterAmount = idx > 0 && r(5) == 0 ? r(10) : 0;
-      n.splinterColour = r(256);
-      n.splinterType = idx > 0 ? nobjMap[r(idx)] : 0;
-      n.timeToExplo = 50 + r(70 * 3);
-      n.timeToExploV = r(30);
-      n.wormDestroy = r(3) == 0;
-      n.wormExplode = r(2) == 0;
+      n.splinter_amount = idx > 0 && r(5) == 0 ? r(10) : 0;
+      n.splinter_colour = r(256);
+      n.splinter_type = idx > 0 ? nobj_map[r(idx)] : 0;
+      n.time_to_explo = 50 + r(70 * 3);
+      n.time_to_explo_v = r(30);
+      n.worm_destroy = r(3) == 0;
+      n.worm_explode = r(2) == 0;
     }
 
-    for (auto& s : common.sobjectTypes) {
-      s.animDelay = 1 + r(10);
-      s.blowAway = r(2) == 0 ? r(10000) : 0;
+    for (auto& s : common.sobject_types) {
+      s.anim_delay = 1 + r(10);
+      s.blow_away = r(2) == 0 ? r(10000) : 0;
       s.damage = r(30);
-      s.detectRange = r(20);
-      s.dirtEffect = r(9);
+      s.detect_range = r(20);
+      s.dirt_effect = r(9);
       s.flash = r(5);
-      s.startFrame = r((uint32_t)common.largeSprites.count - 7);
-      s.numFrames = r(7);
-      s.startSound = r(common.sounds.size());
+      s.start_frame = r((uint32_t)common.large_sprites.count - 7);
+      s.num_frames = r(7);
+      s.start_sound = r(common.sounds.size());
       s.shake = r(10);
       s.shadow = r(2);
-      s.numSounds = 1;
+      s.num_sounds = 1;
     }
   }
 
-  if (gfx->testSDLKey(SDL_SCANCODE_LEFT) || gfx->testControl(WormSettingsExtensions::Left) ||
-      gfx->testGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
-    if (!gfx->curMenu->onLeftRight(common, -1)) resetLeftRight();
+  if (gfx->TestSdlKey(SDL_SCANCODE_LEFT) || gfx->TestControl(WormSettingsExtensions::kLeft) ||
+      gfx->TestGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
+    if (!gfx->cur_menu->OnLeftRight(common, -1)) ResetLeftRight();
   }
-  if (gfx->testSDLKey(SDL_SCANCODE_RIGHT) || gfx->testControl(WormSettingsExtensions::Right) ||
-      gfx->testGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
-    if (!gfx->curMenu->onLeftRight(common, 1)) resetLeftRight();
-  }
-
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_PAGEUP)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-    gfx->curMenu->movementPage(-1);
+  if (gfx->TestSdlKey(SDL_SCANCODE_RIGHT) || gfx->TestControl(WormSettingsExtensions::kRight) ||
+      gfx->TestGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
+    if (!gfx->cur_menu->OnLeftRight(common, 1)) ResetLeftRight();
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-    gfx->curMenu->movementPage(1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_PAGEUP)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+    gfx->cur_menu->MovementPage(-1);
+  }
+
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+    gfx->cur_menu->MovementPage(1);
   }
 
   if (selected_ >= 0) {
     // Transition to fade-out
-    phase_ = Phase::FadingOut;
-    gfx->playRenderer.fadeValue = 32;
-    gfx->singleScreenRenderer.fadeValue = 32;
+    phase_ = Phase::kFadingOut;
+    gfx->play_renderer.fade_value = 32;
+    gfx->single_screen_renderer.fade_value = 32;
   }
 
   return true;
 }
 
-void MainMenuState::draw() {
-  gfx->drawBasicMenu();
-  gfx->drawSpectatorInfo();
+void MainMenuState::Draw() {
+  gfx->DrawBasicMenu();
+  gfx->DrawSpectatorInfo();
 
   Common& common = *gfx->common;
 
-  if (gfx->curMenu == &gfx->mainMenu)
-    gfx->settingsMenu.draw(common, gfx->playRenderer, true);
+  if (gfx->cur_menu == &gfx->main_menu)
+    gfx->settings_menu.Draw(common, gfx->play_renderer, true);
   else
-    gfx->curMenu->draw(common, gfx->playRenderer, false);
+    gfx->cur_menu->Draw(common, gfx->play_renderer, false);
 }

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -95,7 +95,7 @@ void MainMenuState::Enter() {
   gfx->Process();
 
   FillRect(gfx->play_renderer.bmp, 0, 151, 160, 7, 0);
-  common.font.DrawText(gfx->play_renderer.bmp, LS(Copyright2), 2, 152, 19);
+  common.font.DrawString(gfx->play_renderer.bmp, LS(Copyright2), 2, 152, 19);
 
   if (gfx->controller->Running()) {
     gfx->main_menu.SetVisibility(MainMenu::kMaResumeGame, true);

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -122,7 +122,8 @@ void MainMenuState::Enter() {
   gfx->single_screen_renderer.Clear();
   if (gfx->controller->CurrentLevel()) {
     gfx->controller->CurrentLevel()->DrawMiniature(gfx->single_screen_renderer.bmp, center_x - 126,
-                                                   gfx->single_screen_renderer.render_res_y - 208, 2);
+                                                   gfx->single_screen_renderer.render_res_y - 208,
+                                                   2);
   }
   gfx->frozen_spectator_screen.Copy(gfx->single_screen_renderer.bmp);
 
@@ -216,14 +217,14 @@ bool MainMenuState::Update() {
         case MainMenu::kMaJoinGame: {
           g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
           gfx->state_stack.Push(std::make_unique<InputStringState>(
-                                   "", 40, 10, 80, nullptr, "ADDRESS: ", false,
-                                   [this](bool accepted, std::string const& result) {
-                                     if (accepted && !result.empty()) {
-                                       gfx->pending_net_address = result;
-                                       gfx->pending_menu_selection = MainMenu::kMaJoinGame;
-                                     }
-                                   }),
-                               gfx);
+                                    "", 40, 10, 80, nullptr, "ADDRESS: ", false,
+                                    [this](bool accepted, std::string const& result) {
+                                      if (accepted && !result.empty()) {
+                                        gfx->pending_net_address = result;
+                                        gfx->pending_menu_selection = MainMenu::kMaJoinGame;
+                                      }
+                                    }),
+                                gfx);
           break;
         }
 
@@ -236,14 +237,14 @@ bool MainMenuState::Update() {
         case MainMenu::kMaJoinOnline: {
           g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
           gfx->state_stack.Push(std::make_unique<InputStringState>(
-                                   "", 6, 10, 80, ::toupper, "ROOM CODE: ", false,
-                                   [this](bool accepted, std::string const& result) {
-                                     if (accepted && result.size() == 6) {
-                                       gfx->pending_net_address = result;
-                                       gfx->pending_menu_selection = MainMenu::kMaJoinOnline;
-                                     }
-                                   }),
-                               gfx);
+                                    "", 6, 10, 80, ::toupper, "ROOM CODE: ", false,
+                                    [this](bool accepted, std::string const& result) {
+                                      if (accepted && result.size() == 6) {
+                                        gfx->pending_net_address = result;
+                                        gfx->pending_menu_selection = MainMenu::kMaJoinOnline;
+                                      }
+                                    }),
+                                gfx);
           break;
         }
 
@@ -309,17 +310,19 @@ bool MainMenuState::Update() {
         auto* item = gfx->player_menu.ItemFromId(item_id);
         if (item && gfx->player_menu.ItemPosition(*item, x, y)) {
           x += gfx->player_menu.value_offset_x + 2;
-          gfx->state_stack.Push(std::make_unique<InputStringState>(
-                                   ws.name, 20, x, y, nullptr, "", false,
-                                   [this](bool accepted, std::string const& result) {
-                                     auto& ws = *gfx->player_menu.ws;
-                                     if (accepted) ws.name = result;
-                                     if (ws.name.empty()) Settings::GenerateName(ws, gfx->rand);
-                                     ws.random_name = false;
-                                     g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
-                                     gfx->player_menu.UpdateItems(*gfx->common);
-                                   }),
-                               gfx);
+          gfx->state_stack.Push(
+              std::make_unique<InputStringState>(ws.name, 20, x, y, nullptr, "", false,
+                                                 [this](bool accepted, std::string const& result) {
+                                                   auto& ws = *gfx->player_menu.ws;
+                                                   if (accepted) ws.name = result;
+                                                   if (ws.name.empty())
+                                                     Settings::GenerateName(ws, gfx->rand);
+                                                   ws.random_name = false;
+                                                   g_sound_player->Play(
+                                                       gfx->common->sound_hook[SoundMenuSelect]);
+                                                   gfx->player_menu.UpdateItems(*gfx->common);
+                                                 }),
+              gfx);
         }
       } else if (item_id == PlayerMenu::kPlSaveProfileAs) {
         g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
@@ -332,7 +335,7 @@ bool MainMenuState::Update() {
                               [this](std::string const& result) {
                                 if (!result.empty()) {
                                   gfx->player_menu.ws->SaveProfile(gfx->GetUserConfigNode() /
-                                                                  "Profiles" / (result + ".toml"));
+                                                                   "Profiles" / (result + ".toml"));
                                 }
                                 g_sound_player->Play(gfx->common->sound_hook[SoundMenuSelect]);
                                 gfx->player_menu.UpdateItems(*gfx->common);
@@ -368,30 +371,30 @@ bool MainMenuState::Update() {
           x += gfx->player_menu.value_offset_x + 2;
           int weap_idx = item_id - PlayerMenu::kPlWeap0;
           gfx->state_stack.Push(std::make_unique<InputStringState>(
-                                   "", 10, x, y, nullptr, "", false,
-                                   [this, weap_idx](bool accepted, std::string const& result) {
-                                     if (accepted && !result.empty()) {
-                                       Common& common = *gfx->common;
-                                       auto& ws = *gfx->player_menu.ws;
-                                       uint32_t num_weapons = (uint32_t)common.weapons.size();
+                                    "", 10, x, y, nullptr, "", false,
+                                    [this, weap_idx](bool accepted, std::string const& result) {
+                                      if (accepted && !result.empty()) {
+                                        Common& common = *gfx->common;
+                                        auto& ws = *gfx->player_menu.ws;
+                                        uint32_t num_weapons = (uint32_t)common.weapons.size();
 
-                                       uint32_t best = ws.weapons[weap_idx];
-                                       double best_dist = std::numeric_limits<double>::max();
-                                       for (uint32_t i = 1; i <= num_weapons; ++i) {
-                                         std::string& name =
-                                             common.weapons[common.weap_order[i - 1]].name;
-                                         double dist = Levenshtein(name.c_str(), result.c_str()) /
-                                                       (double)name.length();
-                                         if (dist < best_dist) {
-                                           best = i;
-                                           best_dist = dist;
-                                         }
-                                       }
-                                       ws.weapons[weap_idx] = best;
-                                       gfx->player_menu.UpdateItems(common);
-                                     }
-                                   }),
-                               gfx);
+                                        uint32_t best = ws.weapons[weap_idx];
+                                        double best_dist = std::numeric_limits<double>::max();
+                                        for (uint32_t i = 1; i <= num_weapons; ++i) {
+                                          std::string& name =
+                                              common.weapons[common.weap_order[i - 1]].name;
+                                          double dist = Levenshtein(name.c_str(), result.c_str()) /
+                                                        (double)name.length();
+                                          if (dist < best_dist) {
+                                            best = i;
+                                            best_dist = dist;
+                                          }
+                                        }
+                                        ws.weapons[weap_idx] = best;
+                                        gfx->player_menu.UpdateItems(common);
+                                      }
+                                    }),
+                                gfx);
         }
       } else {
         selected_ = gfx->cur_menu->OnEnter(common);

--- a/src/game/mainMenuState.hpp
+++ b/src/game/mainMenuState.hpp
@@ -6,21 +6,21 @@
 struct MainMenuState : AppState {
   MainMenuState();
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
   // The menu item that was selected, or -1 if still active.
-  int selection() const { return selected_; }
+  int Selection() const { return selected_; }
 
   // True when fading out
-  bool isFadingOut() const { return phase_ == Phase::FadingOut; }
+  bool IsFadingOut() const { return phase_ == Phase::kFadingOut; }
 
  private:
-  enum class Phase { Active, FadingOut };
+  enum class Phase { kActive, kFadingOut };
 
-  Phase phase_ = Phase::Active;
+  Phase phase_ = Phase::kActive;
   int selected_ = -1;
   int startItemId_ = 0;
 };

--- a/src/game/material.hpp
+++ b/src/game/material.hpp
@@ -4,25 +4,25 @@
 
 struct Material {
   enum {
-    Dirt = 1 << 0,
-    Dirt2 = 1 << 1,
-    Rock = 1 << 2,
-    Background = 1 << 3,
-    SeeShadow = 1 << 4,
-    WormM = 1 << 5
+    kDirt = 1 << 0,
+    kDirt2 = 1 << 1,
+    kRock = 1 << 2,
+    kBackground = 1 << 3,
+    kSeeShadow = 1 << 4,
+    kWormM = 1 << 5
   };
 
-  bool dirt() { return (flags & Dirt) != 0; }
-  bool dirt2() { return (flags & Dirt2) != 0; }
-  bool rock() { return (flags & Rock) != 0; }
-  bool background() { return (flags & Background) != 0; }
-  bool seeShadow() { return (flags & SeeShadow) != 0; }
+  bool Dirt() { return (flags & kDirt) != 0; }
+  bool Dirt2() { return (flags & kDirt2) != 0; }
+  bool Rock() { return (flags & kRock) != 0; }
+  bool Background() { return (flags & kBackground) != 0; }
+  bool SeeShadow() { return (flags & kSeeShadow) != 0; }
 
   // Constructed
-  bool dirtRock() { return (flags & (Dirt | Dirt2 | Rock)) != 0; }
-  bool anyDirt() { return (flags & (Dirt | Dirt2)) != 0; }
-  bool dirtBack() { return (flags & (Dirt | Dirt2 | Background)) != 0; }
-  bool worm() { return (flags & WormM) != 0; }
+  bool DirtRock() { return (flags & (kDirt | kDirt2 | kRock)) != 0; }
+  bool AnyDirt() { return (flags & (kDirt | kDirt2)) != 0; }
+  bool DirtBack() { return (flags & (kDirt | kDirt2 | kBackground)) != 0; }
+  bool Worm() { return (flags & kWormM) != 0; }
 
   uint8_t flags;
 };

--- a/src/game/math.cpp
+++ b/src/game/math.cpp
@@ -2,9 +2,9 @@
 #include <cmath>
 #include <cstdint>
 
-fixedvec cossinTable[128];
+fixedvec cossin_table[128];
 
-uint32_t sqr(uint32_t op) {
+uint32_t Sqr(uint32_t op) {
   uint32_t res = 0;
   uint32_t one = 1uL << 30;  // The second-to-top bit is set: use 1u << 14 for uint16_t type; use
                              // 1uL<<30 for uint32_t type
@@ -23,12 +23,12 @@ uint32_t sqr(uint32_t op) {
   return res;
 }
 
-int vectorLength(int x, int y) { return int(sqr(x * x + y * y)); }
+int VectorLength(int x, int y) { return int(Sqr(x * x + y * y)); }
 
 struct FP {
   FP(int64_t s, int bits) : s(s), bits(bits) {}
 
-  void reduce(int tobits) {
+  void Reduce(int tobits) {
     int64_t lim = (1ll << tobits);
 
     while (s < (-lim - 1) || s > lim) {
@@ -37,7 +37,7 @@ struct FP {
     }
   }
 
-  int64_t reducedfrac(int tobits) {
+  int64_t Reducedfrac(int tobits) {
     int64_t rs = s;
     int rbits = bits;
     while (rbits > 60) {
@@ -52,7 +52,7 @@ struct FP {
   int bits;
 };
 
-void precomputeTables() {
+void PrecomputeTables() {
   int scalebits = 28;
   int32_t scale = 13176795;  // (2pi / 128) << scalebits
 
@@ -64,15 +64,15 @@ void precomputeTables() {
     // Simple Taylor series. Performance is not important.
     FP num(xf, scalebits);
     for (int t = 1; t < 26;) {
-      rf += c * num.reducedfrac(60);
+      rf += c * num.Reducedfrac(60);
 
       num.s /= ++t;
-      num.reduce(31);
+      num.Reduce(31);
       num.s = num.s * xf;
       num.bits += scalebits;
 
       num.s /= ++t;
-      num.reduce(31);
+      num.Reduce(31);
       num.s = num.s * xf;
       num.bits += scalebits;
 
@@ -85,7 +85,7 @@ void precomputeTables() {
 
     int32_t r = (int32_t)(rf >> shift);
 
-    cossinTable[i].x = r;
-    cossinTable[(i + 32) & 0x7f].y = r;
+    cossin_table[i].x = r;
+    cossin_table[(i + 32) & 0x7f].y = r;
   }
 }

--- a/src/game/math.hpp
+++ b/src/game/math.hpp
@@ -6,18 +6,18 @@ using fixedvec = IVec2;
 
 typedef int fixed;
 
-inline fixed itof(int v) { return v << 16; }
+inline fixed Itof(int v) { return v << 16; }
 
-inline int ftoi(fixed v) { return v >> 16; }
+inline int Ftoi(fixed v) { return v >> 16; }
 
-inline fixedvec itof(IVec2 v) { return fixedvec(itof(v.x), itof(v.y)); }
+inline fixedvec Itof(IVec2 v) { return fixedvec(Itof(v.x), Itof(v.y)); }
 
-inline IVec2 ftoi(fixedvec v) { return IVec2(ftoi(v.x), ftoi(v.y)); }
+inline IVec2 Ftoi(fixedvec v) { return IVec2(Ftoi(v.x), Ftoi(v.y)); }
 
-extern fixedvec cossinTable[128];
+extern fixedvec cossin_table[128];
 
-int vectorLength(int x, int y);
+int VectorLength(int x, int y);
 
-inline int distanceTo(int x1, int y1, int x2, int y2) { return vectorLength(x1 - x2, y1 - y2); }
+inline int DistanceTo(int x1, int y1, int x2, int y2) { return VectorLength(x1 - x2, y1 - y2); }
 
-void precomputeTables();
+void PrecomputeTables();

--- a/src/game/math/rect.hpp
+++ b/src/game/math/rect.hpp
@@ -12,13 +12,13 @@ struct BasicVec<T, 2> {
   T y = T(0);
 
   constexpr BasicVec() = default;
-  constexpr BasicVec(T x_, T y_) : x(x_), y(y_) {}
+  constexpr BasicVec(T x, T y) : x(x), y(y) {}
 
   template <typename U>
   constexpr explicit BasicVec(BasicVec<U, 2> const& other)
       : x(static_cast<T>(other.x)), y(static_cast<T>(other.y)) {}
 
-  constexpr void zero() {
+  constexpr void Zero() {
     x = T(0);
     y = T(0);
   }
@@ -65,34 +65,34 @@ struct BasicRect {
   T y2 = T(0);
 
   constexpr BasicRect() = default;
-  constexpr BasicRect(T x1_, T y1_, T x2_, T y2_) : x1(x1_), y1(y1_), x2(x2_), y2(y2_) {}
+  constexpr BasicRect(T x1, T y1, T x2, T y2) : x1(x1), y1(y1), x2(x2), y2(y2) {}
 
-  constexpr T width() const { return x2 - x1; }
-  constexpr T height() const { return y2 - y1; }
-  constexpr T center_x() const { return (x1 + x2) / T(2); }
-  constexpr T center_y() const { return (y1 + y2) / T(2); }
-  constexpr BasicVec<T, 2> center() const { return {center_x(), center_y()}; }
-  constexpr BasicVec<T, 2> ul() const { return {x1, y1}; }
+  constexpr T Width() const { return x2 - x1; }
+  constexpr T Height() const { return y2 - y1; }
+  constexpr T CenterX() const { return (x1 + x2) / T(2); }
+  constexpr T CenterY() const { return (y1 + y2) / T(2); }
+  constexpr BasicVec<T, 2> Center() const { return {CenterX(), CenterY()}; }
+  constexpr BasicVec<T, 2> Ul() const { return {x1, y1}; }
 
-  constexpr bool inside(T vx, T vy) const {
+  constexpr bool Inside(T vx, T vy) const {
     T dx = vx - x1, dy = vy - y1;
-    return dx >= T(0) && dx < width() && dy >= T(0) && dy < height();
+    return dx >= T(0) && dx < Width() && dy >= T(0) && dy < Height();
   }
 
-  constexpr bool encloses(BasicVec<T, 2> v) const { return inside(v.x, v.y); }
-  constexpr bool encloses(T vx, T vy) const { return inside(vx, vy); }
+  constexpr bool Encloses(BasicVec<T, 2> v) const { return Inside(v.x, v.y); }
+  constexpr bool Encloses(T vx, T vy) const { return Inside(vx, vy); }
 
-  constexpr bool valid() const { return x1 <= x2 && y1 <= y2; }
+  constexpr bool Valid() const { return x1 <= x2 && y1 <= y2; }
 
-  bool intersect(BasicRect const& b) {
+  bool Intersect(BasicRect const& b) {
     x1 = std::max(x1, b.x1);
     y1 = std::max(y1, b.y1);
     x2 = std::min(x2, b.x2);
     y2 = std::min(y2, b.y2);
-    return valid();
+    return Valid();
   }
 
-  void join(BasicRect const& b) {
+  void Join(BasicRect const& b) {
     x1 = std::min(x1, b.x1);
     y1 = std::min(y1, b.y1);
     x2 = std::max(x2, b.x2);
@@ -100,11 +100,11 @@ struct BasicRect {
   }
 
   friend BasicRect operator|(BasicRect a, BasicRect const& b) {
-    a.join(b);
+    a.Join(b);
     return a;
   }
   friend BasicRect operator&(BasicRect a, BasicRect const& b) {
-    a.intersect(b);
+    a.Intersect(b);
     return a;
   }
 };

--- a/src/game/menu/arrayEnumBehavior.hpp
+++ b/src/game/menu/arrayEnumBehavior.hpp
@@ -10,12 +10,12 @@ struct Menu;
 struct ArrayEnumBehavior : EnumBehavior {
   template <int N>
   ArrayEnumBehavior(Common& common, uint32_t& v, std::string const (&arr)[N],
-                    bool brokenEnter = false)
-      : EnumBehavior(common, v, 0, N - 1, brokenEnter), arr(arr) {}
+                    bool broken_enter = false)
+      : EnumBehavior(common, v, 0, N - 1, broken_enter), arr(arr) {}
 
-  void onUpdate(Menu& menu, MenuItem& item) {
+  void OnUpdate(Menu& menu, MenuItem& item) {
     item.value = arr[v];
-    item.hasValue = true;
+    item.has_value = true;
   }
 
   std::string const* arr;

--- a/src/game/menu/booleanSwitchBehavior.cpp
+++ b/src/game/menu/booleanSwitchBehavior.cpp
@@ -5,25 +5,25 @@
 #include "menu.hpp"
 #include "menuItem.hpp"
 
-bool BooleanSwitchBehavior::onLeftRight(Menu& menu, MenuItem& item, int dir) {
+bool BooleanSwitchBehavior::OnLeftRight(Menu& menu, MenuItem& item, int dir) {
   if (dir > 0)
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
   else
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
   set(!v);
-  onUpdate(menu, item);
+  OnUpdate(menu, item);
   return false;
 }
 
-int BooleanSwitchBehavior::onEnter(Menu& menu, MenuItem& item) {
-  g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+int BooleanSwitchBehavior::OnEnter(Menu& menu, MenuItem& item) {
+  g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
   set(!v);
-  onUpdate(menu, item);
+  OnUpdate(menu, item);
   return -1;
 }
 
-void BooleanSwitchBehavior::onUpdate(Menu& menu, MenuItem& item) {
+void BooleanSwitchBehavior::OnUpdate(Menu& menu, MenuItem& item) {
   item.value = common.texts.onoff[v];
-  item.hasValue = true;
+  item.has_value = true;
 }

--- a/src/game/menu/booleanSwitchBehavior.hpp
+++ b/src/game/menu/booleanSwitchBehavior.hpp
@@ -8,16 +8,16 @@ struct Menu;
 
 struct BooleanSwitchBehavior : ItemBehavior {
   BooleanSwitchBehavior(Common& common, bool& v)
-      : set([&](bool newV) { v = newV; }), common(common), v(v) {}
+      : set([&](bool new_v) { v = new_v; }), common(common), v(v) {}
 
   BooleanSwitchBehavior(Common& common, bool& v, std::function<void(bool)> set)
       : set(set), common(common), v(v) {}
 
   std::function<void(bool)> set;
 
-  bool onLeftRight(Menu& menu, MenuItem& item, int dir);
-  int onEnter(Menu& menu, MenuItem& item);
-  void onUpdate(Menu& menu, MenuItem& item);
+  bool OnLeftRight(Menu& menu, MenuItem& item, int dir);
+  int OnEnter(Menu& menu, MenuItem& item);
+  void OnUpdate(Menu& menu, MenuItem& item);
 
   Common& common;
   bool& v;

--- a/src/game/menu/enumBehavior.cpp
+++ b/src/game/menu/enumBehavior.cpp
@@ -6,36 +6,36 @@
 #include "menu.hpp"
 #include "menuItem.hpp"
 
-bool EnumBehavior::onLeftRight(Menu& menu, MenuItem& item, int dir) {
-  if (brokenLeftRight) return false;  // Left/right doesn't work for this item
+bool EnumBehavior::OnLeftRight(Menu& menu, MenuItem& item, int dir) {
+  if (broken_left_right) return false;  // Left/right doesn't work for this item
   if (dir > 0)
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
   else
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
-  change(menu, item, dir);
+  Change(menu, item, dir);
 
   return false;
 }
 
-int EnumBehavior::onEnter(Menu& menu, MenuItem& item) {
-  g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+int EnumBehavior::OnEnter(Menu& menu, MenuItem& item) {
+  g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
 
-  change(menu, item, 1);
+  Change(menu, item, 1);
   return -1;
 }
 
-void EnumBehavior::change(Menu& menu, MenuItem& item, int dir) {
+void EnumBehavior::Change(Menu& menu, MenuItem& item, int dir) {
   uint32_t range = max - min + 1;
-  uint32_t newV = ((v + dir + range - min) % range) + min;
+  uint32_t new_v = ((v + dir + range - min) % range) + min;
 
-  if (newV != v) {
-    v = newV;
-    menu.updateItems(common);
+  if (new_v != v) {
+    v = new_v;
+    menu.UpdateItems(common);
   }
 }
 
-void EnumBehavior::onUpdate(Menu& menu, MenuItem& item) {
-  item.value = toString(v);
-  item.hasValue = true;
+void EnumBehavior::OnUpdate(Menu& menu, MenuItem& item) {
+  item.value = ToString(v);
+  item.has_value = true;
 }

--- a/src/game/menu/enumBehavior.hpp
+++ b/src/game/menu/enumBehavior.hpp
@@ -9,17 +9,17 @@ struct Menu;
 
 struct EnumBehavior : ItemBehavior {
   EnumBehavior(Common& common, uint32_t& v, uint32_t min, uint32_t max,
-               bool brokenLeftRight = false)
-      : common(common), v(v), min(min), max(max), brokenLeftRight(brokenLeftRight) {}
+               bool broken_left_right = false)
+      : common(common), v(v), min(min), max(max), broken_left_right(broken_left_right) {}
 
-  bool onLeftRight(Menu& menu, MenuItem& item, int dir);
-  int onEnter(Menu& menu, MenuItem& item);
-  void onUpdate(Menu& menu, MenuItem& item);
+  bool OnLeftRight(Menu& menu, MenuItem& item, int dir);
+  int OnEnter(Menu& menu, MenuItem& item);
+  void OnUpdate(Menu& menu, MenuItem& item);
 
-  void change(Menu& menu, MenuItem& item, int dir);
+  void Change(Menu& menu, MenuItem& item, int dir);
 
   Common& common;
   uint32_t& v;
   uint32_t min, max;
-  bool brokenLeftRight;
+  bool broken_left_right;
 };

--- a/src/game/menu/fileSelector.hpp
+++ b/src/game/menu/fileSelector.hpp
@@ -17,110 +17,110 @@ typedef bool (*FileFilter)(string const& name, string const& ext);
 
 struct FileNode {
   FileNode()
-      : folder(true), id(0), selectedChild(0), parent(0), filter(0), menu(178, 28), filled(false) {
-    menu.setHeight(14);
+      : folder(true), id(0), selected_child(0), parent(0), filter(0), menu(178, 28), filled(false) {
+    menu.SetHeight(14);
   }
 
-  FileNode(string const& name, string const& pathName, string const& fullPath, bool folder,
+  FileNode(string const& name, string const& path_name, string const& full_path, bool folder,
            FileNode* parent, FileFilter filter = 0)
       : name(name),
-        fullPath(fullPath),
+        full_path(full_path),
         folder(folder),
         id(0),
-        selectedChild(0),
+        selected_child(0),
         parent(parent),
         filter(filter),
         menu(178, 28),
-        pathName(pathName),
+        path_name(path_name),
         filled(false) {
-    menu.setHeight(14);
+    menu.SetHeight(14);
   }
 
-  void fill();
+  void Fill();
 
-  Menu& getMenu() {
-    ensureFilled();
+  Menu& GetMenu() {
+    EnsureFilled();
 
     if (menu.items.empty()) {
-      for (auto& c : children) menu.addItem(MenuItem(c->folder ? 47 : 48, 7, c->name));
+      for (auto& c : children) menu.AddItem(MenuItem(c->folder ? 47 : 48, 7, c->name));
 
-      menu.moveToFirstVisible();
+      menu.MoveToFirstVisible();
     }
 
     return menu;
   }
 
-  FileNode* find(string const& path) {
-    if (ciCompare(fullPath, path)) return this;
-    if (!ciStartsWith(path, fullPath)) return 0;
+  FileNode* Find(string const& path) {
+    if (CiCompare(full_path, path)) return this;
+    if (!CiStartsWith(path, full_path)) return 0;
     if (!folder) return 0;
 
-    ensureFilled();
+    EnsureFilled();
 
     for (auto& c : children) {
-      auto* r = c->find(path);
+      auto* r = c->Find(path);
       if (r) return r;
     }
 
     return 0;
   }
 
-  FsNode& getFsNode() {
-    if (!fsNode) {
+  FsNode& GetFsNode() {
+    if (!fs_node) {
       assert(parent);
-      assert(parent->fsNode);
-      fsNode = parent->fsNode / pathName;
+      assert(parent->fs_node);
+      fs_node = parent->fs_node / path_name;
     }
 
-    return fsNode;
+    return fs_node;
   }
 
-  void ensureFilled() {
+  void EnsureFilled() {
     if (!filled && parent) {
-      getFsNode();
-      fill();
+      GetFsNode();
+      Fill();
     }
   }
 
   string name;
-  string fullPath;
+  string full_path;
   bool folder;
   int id;
-  FileNode* selectedChild;
+  FileNode* selected_child;
   FileNode* parent;
   vector<shared_ptr<FileNode> > children;
   bool (*filter)(std::string const& name, std::string const& ext);
   Menu menu;
 
-  string pathName;
+  string path_name;
   bool filled;
-  FsNode fsNode;  // Starts out invalid
+  FsNode fs_node;  // Starts out invalid
 };
 
 struct ChildSort {
   typedef shared_ptr<FileNode> type;
 
   bool operator()(type const& a, type const& b) const {
-    if (a->folder == b->folder) return ciLess(a->name, b->name);
+    if (a->folder == b->folder) return CiLess(a->name, b->name);
     return a->folder > b->folder;
   }
 };
 
-inline void FileNode::fill() {
-  assert(fsNode);
-  DirectoryListing di(fsNode.iter());
+inline void FileNode::Fill() {
+  assert(fs_node);
+  DirectoryListing di(fs_node.Iter());
 
   for (auto const& name : di) {
-    string const& fullPath = joinPath(this->fullPath, name.name);
-    auto const& ext = getExtension(name.name);
+    string const& full_path = JoinPath(this->full_path, name.name);
+    auto const& ext = GetExtension(name.name);
 
-    if (name.isDir) {
-      shared_ptr<FileNode> node(new FileNode(name.name, name.name, fullPath, true, this, filter));
+    if (name.is_dir) {
+      shared_ptr<FileNode> node(new FileNode(name.name, name.name, full_path, true, this, filter));
 
       children.push_back(node);
     } else if (!filter || filter(name.name, ext)) {
       children.push_back(shared_ptr<FileNode>(
-          new FileNode(getBasename(name.name), name.name, fullPath, false, this, filter)));
+          new FileNode(GetBasename(name.name), name.name, full_path, false, this, filter)));
     }
   }
 
@@ -132,32 +132,32 @@ inline void FileNode::fill() {
 struct FileSelector {
   FileSelector(Common& common, int x = 178) : common(common) {}
 
-  void fill(string const& path, FileFilter filter)  // TODO: Get rid of this
+  void Fill(string const& path, FileFilter filter)  // TODO: Get rid of this
   {
-    fill(FsNode(path), filter);
+    Fill(FsNode(path), filter);
   }
 
-  void fill(FsNode node, FileFilter filter) {
-    rootNode.fsNode = std::move(node);
-    rootNode.fullPath = rootNode.fsNode.fullPath();
-    rootNode.filter = filter;
-    rootNode.fill();
+  void Fill(FsNode node, FileFilter filter) {
+    root_node.fs_node = std::move(node);
+    root_node.full_path = root_node.fs_node.FullPath();
+    root_node.filter = filter;
+    root_node.Fill();
   }
 
-  void draw() {
-    if (currentNode && currentNode->parent) {
-      common.font.drawFramedText(gfx.playRenderer.bmp, "Parent directory", 28, 20, 50);
-      currentNode->parent->getMenu().draw(common, gfx.playRenderer, true, 28, true);
+  void Draw() {
+    if (current_node && current_node->parent) {
+      common.font.DrawFramedText(gfx.play_renderer.bmp, "Parent directory", 28, 20, 50);
+      current_node->parent->GetMenu().Draw(common, gfx.play_renderer, true, 28, true);
     }
-    menu().draw(common, gfx.playRenderer, false, 178);
+    CurrentMenu().Draw(common, gfx.play_renderer, false, 178);
   }
 
-  Menu& menu() { return currentNode->getMenu(); }
+  Menu& CurrentMenu() { return current_node->GetMenu(); }
 
-  void setFolder(FileNode& fn) { currentNode = &fn; }
+  void SetFolder(FileNode& fn) { current_node = &fn; }
 
-  bool select(string const& path) {
-    FileNode* fn = rootNode.find(path);
+  bool Select(string const& path) {
+    FileNode* fn = root_node.Find(path);
 
     if (!fn) return false;
 
@@ -167,100 +167,100 @@ struct FileSelector {
       while (p->parent) {
         FileNode* ch = p;
         p = p->parent;
-        p->selectedChild = fn;
+        p->selected_child = fn;
 
         for (std::size_t i = 0; i < p->children.size(); ++i) {
-          if (ch == p->children[i].get()) p->getMenu().moveTo((int)i);
+          if (ch == p->children[i].get()) p->GetMenu().MoveTo((int)i);
         }
       }
 
       if (fn->folder)
-        setFolder(*fn);
+        SetFolder(*fn);
       else
-        setFolder(*parent);
+        SetFolder(*parent);
     }
 
     return true;
   }
 
-  FileNode* curSel() {
-    if (!menu().isSelectionValid()) return 0;
+  FileNode* CurSel() {
+    if (!Menu().IsSelectionValid()) return 0;
 
-    auto* c = currentNode->children[menu().selection()].get();
+    auto* c = current_node->children[Menu().Selection()].get();
 
     return c;
   }
 
-  FileNode* enter() {
-    auto* c = curSel();
+  FileNode* Enter() {
+    auto* c = CurSel();
     if (!c) {
       return 0;
     }
 
     if (c->folder) {
-      currentNode->selectedChild = c;
-      setFolder(*c);
+      current_node->selected_child = c;
+      SetFolder(*c);
       return 0;
     }
 
     return c;
   }
 
-  bool exit() {
-    if (currentNode->parent == 0) return false;
+  bool Exit() {
+    if (current_node->parent == 0) return false;
 
-    setFolder(*currentNode->parent);
+    SetFolder(*current_node->parent);
 
     return true;
   }
 
-  bool process() {
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_UP) || gfx.testControlOnce(WormSettingsExtensions::Up) ||
-        gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+  bool Process() {
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_UP) || gfx.TestControlOnce(WormSettingsExtensions::kUp) ||
+        gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
-      menu().movement(-1);
+      Menu().Movement(-1);
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_DOWN) ||
-        gfx.testControlOnce(WormSettingsExtensions::Down) ||
-        gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
+        gfx.TestControlOnce(WormSettingsExtensions::kDown) ||
+        gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
 
-      menu().movement(1);
+      Menu().Movement(1);
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_PAGEUP)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_PAGEUP)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
-      menu().movementPage(-1);
+      Menu().MovementPage(-1);
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
 
-      menu().movementPage(1);
+      Menu().MovementPage(1);
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
-        gfx.testControlOnce(WormSettingsExtensions::Jump) ||
-        gfx.testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
+        gfx.TestControlOnce(WormSettingsExtensions::kJump) ||
+        gfx.TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
       return false;
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_LEFT) ||
-        gfx.testControlOnce(WormSettingsExtensions::Left) ||
-        gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
-      exit();
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_LEFT) ||
+        gfx.TestControlOnce(WormSettingsExtensions::kLeft) ||
+        gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
+      Exit();
     }
 
-    if (gfx.testSDLKeyOnce(SDL_SCANCODE_RIGHT) ||
-        gfx.testControlOnce(WormSettingsExtensions::Right) ||
-        gfx.testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
-      enter();
+    if (gfx.TestSdlKeyOnce(SDL_SCANCODE_RIGHT) ||
+        gfx.TestControlOnce(WormSettingsExtensions::kRight) ||
+        gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
+      Enter();
     }
 
-    menu().onKeys(gfx.keyBuf, gfx.keyBufPtr, true);
+    Menu().OnKeys(gfx.key_buf, gfx.key_buf_ptr, true);
 
     return true;
   }
@@ -268,8 +268,8 @@ struct FileSelector {
   Common& common;
   // vector<pair<FileNode*, int> > history;
 
-  FileNode rootNode;
-  FileNode* currentNode;
+  FileNode root_node;
+  FileNode* current_node;
 
   // Menu menu;
 };

--- a/src/game/menu/hiddenMenu.cpp
+++ b/src/game/menu/hiddenMenu.cpp
@@ -6,60 +6,60 @@
 #include "../gfx.hpp"
 #include "../mixer/player.hpp"
 
-static std::string const botWeaponSel[3] = {"RANDOM", "PICK", "KEEP"};
+static std::string const kBotWeaponSel[3] = {"RANDOM", "PICK", "KEEP"};
 
-ItemBehavior* HiddenMenu::getItemBehavior(Common& common, MenuItem& item) {
+ItemBehavior* HiddenMenu::GetItemBehavior(Common& common, MenuItem& item) {
   switch (item.id) {
-    case RecordReplays:
-      return new BooleanSwitchBehavior(common, gfx.settings->recordReplays);
-    case LoadPowerLevels:
-      return new BooleanSwitchBehavior(common, gfx.settings->loadPowerlevelPalette);
-    case DoubleRes:
-      return new BooleanSwitchBehavior(common, gfx.doubleRes, [](bool v) { gfx.setDoubleRes(v); });
-    case Fullscreen:
+    case kRecordReplays:
+      return new BooleanSwitchBehavior(common, gfx.settings->record_replays);
+    case kLoadPowerLevels:
+      return new BooleanSwitchBehavior(common, gfx.settings->load_powerlevel_palette);
+    case kDoubleRes:
+      return new BooleanSwitchBehavior(common, gfx.double_res, [](bool v) { gfx.SetDoubleRes(v); });
+    case kFullscreen:
       return new BooleanSwitchBehavior(common, gfx.settings->fullscreen,
-                                       [](bool v) { gfx.setFullscreen(v); });
-    case AiFrames:
-      return new IntegerBehavior(common, gfx.settings->aiFrames, 1, 70 * 5);
-    case AiMutations:
-      return new IntegerBehavior(common, gfx.settings->aiMutations, 1, 20);
-    case PaletteSelect:
-      return new IntegerBehavior(common, paletteColor, 0, 255);
-    case Shadows:
+                                       [](bool v) { gfx.SetFullscreen(v); });
+    case kAiFrames:
+      return new IntegerBehavior(common, gfx.settings->ai_frames, 1, 70 * 5);
+    case kAiMutations:
+      return new IntegerBehavior(common, gfx.settings->ai_mutations, 1, 20);
+    case kPaletteSelect:
+      return new IntegerBehavior(common, palette_color, 0, 255);
+    case kShadows:
       return new BooleanSwitchBehavior(common, gfx.settings->shadow);
-    case ScreenSync:
-      return new BooleanSwitchBehavior(common, gfx.settings->screenSync);
-    case SelectBotWeapons:
-      return new ArrayEnumBehavior(common, gfx.settings->selectBotWeapons, botWeaponSel);
-    case AiTraces:
-      return new BooleanSwitchBehavior(common, gfx.settings->aiTraces);
-    case AiParallels:
-      return new IntegerBehavior(common, gfx.settings->aiParallels, 1, 16);
-    case AllowViewingSpawnPoint:
-      return new BooleanSwitchBehavior(common, gfx.settings->allowViewingSpawnPoint);
-    case SingleScreenReplay:
-      return new BooleanSwitchBehavior(common, gfx.settings->singleScreenReplay);
-    case SpectatorWindow:
-      return new BooleanSwitchBehavior(common, gfx.settings->spectatorWindow, [](bool v) {
-        gfx.settings->spectatorWindow = v;
-        gfx.setVideoMode();
+    case kScreenSync:
+      return new BooleanSwitchBehavior(common, gfx.settings->screen_sync);
+    case kSelectBotWeapons:
+      return new ArrayEnumBehavior(common, gfx.settings->select_bot_weapons, kBotWeaponSel);
+    case kAiTraces:
+      return new BooleanSwitchBehavior(common, gfx.settings->ai_traces);
+    case kAiParallels:
+      return new IntegerBehavior(common, gfx.settings->ai_parallels, 1, 16);
+    case kAllowViewingSpawnPoint:
+      return new BooleanSwitchBehavior(common, gfx.settings->allow_viewing_spawn_point);
+    case kSingleScreenReplay:
+      return new BooleanSwitchBehavior(common, gfx.settings->single_screen_replay);
+    case kSpectatorWindow:
+      return new BooleanSwitchBehavior(common, gfx.settings->spectator_window, [](bool v) {
+        gfx.settings->spectator_window = v;
+        gfx.SetVideoMode();
       });
 
     default:
-      return Menu::getItemBehavior(common, item);
+      return Menu::GetItemBehavior(common, item);
   }
 }
 
-void HiddenMenu::onUpdate() {}
+void HiddenMenu::OnUpdate() {}
 
-void HiddenMenu::drawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
+void HiddenMenu::DrawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
                                  bool disabled) {
-  if (item.id == PaletteSelect)  // Color settings
+  if (item.id == kPaletteSelect)  // Color settings
   {
     int w = 30;
-    int offsX = 44;
+    int offs_x = 44;
 
-    drawRoundedBox(gfx.playRenderer.bmp, x + offsX, y, selected ? 168 : 0, 7, w);
-    fillRect(gfx.playRenderer.bmp, x + offsX + 1, y + 1, w + 1, 5, paletteColor);
+    DrawRoundedBox(gfx.play_renderer.bmp, x + offs_x, y, selected ? 168 : 0, 7, w);
+    FillRect(gfx.play_renderer.bmp, x + offs_x + 1, y + 1, w + 1, 5, palette_color);
   }
 }

--- a/src/game/menu/hiddenMenu.hpp
+++ b/src/game/menu/hiddenMenu.hpp
@@ -7,32 +7,32 @@ struct ItemBehavior;
 
 struct HiddenMenu : Menu {
   enum {
-    RecordReplays,
-    LoadPowerLevels,
+    kRecordReplays,
+    kLoadPowerLevels,
     // ScalingFilter,
-    DoubleRes,
-    Fullscreen,
-    AiFrames,
-    AiMutations,
-    PaletteSelect,
-    Shadows,
-    ScreenSync,
-    SelectBotWeapons,
-    AiTraces,
-    AiParallels,
-    AllowViewingSpawnPoint,
-    SingleScreenReplay,
-    SpectatorWindow,
+    kDoubleRes,
+    kFullscreen,
+    kAiFrames,
+    kAiMutations,
+    kPaletteSelect,
+    kShadows,
+    kScreenSync,
+    kSelectBotWeapons,
+    kAiTraces,
+    kAiParallels,
+    kAllowViewingSpawnPoint,
+    kSingleScreenReplay,
+    kSpectatorWindow,
   };
 
-  HiddenMenu(int x, int y) : Menu(x, y), paletteColor(0) {}
+  HiddenMenu(int x, int y) : Menu(x, y), palette_color(0) {}
 
-  virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item);
+  virtual ItemBehavior* GetItemBehavior(Common& common, MenuItem& item);
 
-  virtual void drawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
+  virtual void DrawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
                                bool disabled);
 
-  virtual void onUpdate();
+  virtual void OnUpdate();
 
-  int paletteColor;
+  int palette_color;
 };

--- a/src/game/menu/integerBehavior.cpp
+++ b/src/game/menu/integerBehavior.cpp
@@ -10,53 +10,53 @@
 
 #include <cmath>
 
-bool IntegerBehavior::onLeftRight(Menu& menu, MenuItem& item, int dir) {
-  if ((gfx.menuCycles % scrollInterval) != 0) return true;
+bool IntegerBehavior::OnLeftRight(Menu& menu, MenuItem& item, int dir) {
+  if ((gfx.menu_cycles % scroll_interval) != 0) return true;
 
-  int newV = v;
-  if ((dir < 0 && newV > min) || (dir > 0 && newV < max)) {
-    newV += dir * step;
+  int new_v = v;
+  if ((dir < 0 && new_v > min) || (dir > 0 && new_v < max)) {
+    new_v += dir * step;
   }
 
-  if (newV != v) {
-    v = newV;
-    onUpdate(menu, item);
+  if (new_v != v) {
+    v = new_v;
+    OnUpdate(menu, item);
   }
 
   return true;
 }
 
-static int filterDigits(int k) { return std::isdigit(k) ? k : 0; }
+static int FilterDigits(int k) { return std::isdigit(k) ? k : 0; }
 
-int IntegerBehavior::onEnter(Menu& menu, MenuItem& item) {
-  g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+int IntegerBehavior::OnEnter(Menu& menu, MenuItem& item) {
+  g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
 
-  if (!allowEntry) return -1;  // Not allowed
+  if (!allow_entry) return -1;  // Not allowed
 
   int x, y;
-  if (menu.itemPosition(item, x, y)) {
-    x += menu.valueOffsetX;
+  if (menu.ItemPosition(item, x, y)) {
+    x += menu.value_offset_x;
     int digits = 1 + int(std::floor(std::log10(double(max))));
 
-    int* destPtr = &v;
-    int minVal = min, maxVal = max;
+    int* dest_ptr = &v;
+    int min_val = min, max_val = max;
     bool pct = percentage;
 
-    gfx.stateStack.push(
+    gfx.state_stack.Push(
         std::make_unique<InputStringState>(
-            toString(v), digits, x + 2, y, filterDigits, "", false,
-            [destPtr, minVal, maxVal, pct, &menu, &item](bool accepted, std::string const& result) {
+            ToString(v), digits, x + 2, y, FilterDigits, "", false,
+            [dest_ptr, min_val, max_val, pct, &menu, &item](bool accepted, std::string const& result) {
               if (accepted && !result.empty()) {
                 int val = std::atoi(result.c_str());
-                if (val < minVal)
-                  val = minVal;
-                else if (val > maxVal)
-                  val = maxVal;
-                *destPtr = val;
+                if (val < min_val)
+                  val = min_val;
+                else if (val > max_val)
+                  val = max_val;
+                *dest_ptr = val;
               }
               // Update the menu item display
-              item.value = toString(*destPtr);
-              item.hasValue = true;
+              item.value = ToString(*dest_ptr);
+              item.has_value = true;
               if (pct) item.value += "%";
             }),
         &gfx);
@@ -64,8 +64,8 @@ int IntegerBehavior::onEnter(Menu& menu, MenuItem& item) {
   return -1;
 }
 
-void IntegerBehavior::onUpdate(Menu& menu, MenuItem& item) {
-  item.value = toString(v);
-  item.hasValue = true;
+void IntegerBehavior::OnUpdate(Menu& menu, MenuItem& item) {
+  item.value = ToString(v);
+  item.has_value = true;
   if (percentage) item.value += "%";
 }

--- a/src/game/menu/integerBehavior.cpp
+++ b/src/game/menu/integerBehavior.cpp
@@ -43,22 +43,22 @@ int IntegerBehavior::OnEnter(Menu& menu, MenuItem& item) {
     bool pct = percentage;
 
     gfx.state_stack.Push(
-        std::make_unique<InputStringState>(
-            ToString(v), digits, x + 2, y, FilterDigits, "", false,
-            [dest_ptr, min_val, max_val, pct, &menu, &item](bool accepted, std::string const& result) {
-              if (accepted && !result.empty()) {
-                int val = std::atoi(result.c_str());
-                if (val < min_val)
-                  val = min_val;
-                else if (val > max_val)
-                  val = max_val;
-                *dest_ptr = val;
-              }
-              // Update the menu item display
-              item.value = ToString(*dest_ptr);
-              item.has_value = true;
-              if (pct) item.value += "%";
-            }),
+        std::make_unique<InputStringState>(ToString(v), digits, x + 2, y, FilterDigits, "", false,
+                                           [dest_ptr, min_val, max_val, pct, &menu, &item](
+                                               bool accepted, std::string const& result) {
+                                             if (accepted && !result.empty()) {
+                                               int val = std::atoi(result.c_str());
+                                               if (val < min_val)
+                                                 val = min_val;
+                                               else if (val > max_val)
+                                                 val = max_val;
+                                               *dest_ptr = val;
+                                             }
+                                             // Update the menu item display
+                                             item.value = ToString(*dest_ptr);
+                                             item.has_value = true;
+                                             if (pct) item.value += "%";
+                                           }),
         &gfx);
   }
   return -1;

--- a/src/game/menu/integerBehavior.hpp
+++ b/src/game/menu/integerBehavior.hpp
@@ -12,18 +12,18 @@ struct IntegerBehavior : ItemBehavior {
         min(min),
         max(max),
         step(step),
-        scrollInterval(5),
+        scroll_interval(5),
         percentage(percentage),
-        allowEntry(true) {}
+        allow_entry(true) {}
 
-  bool onLeftRight(Menu& menu, MenuItem& item, int dir);
-  int onEnter(Menu& menu, MenuItem& item);
-  void onUpdate(Menu& menu, MenuItem& item);
+  bool OnLeftRight(Menu& menu, MenuItem& item, int dir);
+  int OnEnter(Menu& menu, MenuItem& item);
+  void OnUpdate(Menu& menu, MenuItem& item);
 
   Common& common;
   int& v;
   int min, max, step;
-  int scrollInterval;
+  int scroll_interval;
   bool percentage;
-  bool allowEntry;
+  bool allow_entry;
 };

--- a/src/game/menu/itemBehavior.hpp
+++ b/src/game/menu/itemBehavior.hpp
@@ -10,9 +10,9 @@ struct ItemBehavior {
 
   virtual ~ItemBehavior() {}
 
-  virtual bool onLeftRight(Menu& menu, MenuItem& item, int dir) { return true; }
+  virtual bool OnLeftRight(Menu& menu, MenuItem& item, int dir) { return true; }
 
-  virtual int onEnter(Menu& menu, MenuItem& item) { return -1; }
+  virtual int OnEnter(Menu& menu, MenuItem& item) { return -1; }
 
-  virtual void onUpdate(Menu& menu, MenuItem& item) {}
+  virtual void OnUpdate(Menu& menu, MenuItem& item) {}
 };

--- a/src/game/menu/mainMenu.cpp
+++ b/src/game/menu/mainMenu.cpp
@@ -3,8 +3,8 @@
 #include "../gfx.hpp"
 #include "../mixer/player.hpp"
 
-ItemBehavior* MainMenu::getItemBehavior(Common& common, MenuItem& item) {
+ItemBehavior* MainMenu::GetItemBehavior(Common& common, MenuItem& item) {
   // MaReplays and MaTc are intercepted by MainMenuState before
   // onEnter() is reached. Return the default no-op behavior.
-  return Menu::getItemBehavior(common, item);
+  return Menu::GetItemBehavior(common, item);
 }

--- a/src/game/menu/mainMenu.hpp
+++ b/src/game/menu/mainMenu.hpp
@@ -7,24 +7,24 @@ struct ItemBehavior;
 
 struct MainMenu : Menu {
   enum {
-    MaResumeGame,
-    MaNewGame,
-    MaSettings,
-    MaPlayer1Settings,
-    MaPlayer2Settings,
-    MaAdvanced,
-    MaQuit,
-    MaReplays,
-    MaReplay,
-    MaTc,
-    MaHostGame,
-    MaJoinGame,
-    MaNetPlayerSettings,
-    MaHostOnline,
-    MaJoinOnline,
+    kMaResumeGame,
+    kMaNewGame,
+    kMaSettings,
+    kMaPlayer1Settings,
+    kMaPlayer2Settings,
+    kMaAdvanced,
+    kMaQuit,
+    kMaReplays,
+    kMaReplay,
+    kMaTc,
+    kMaHostGame,
+    kMaJoinGame,
+    kMaNetPlayerSettings,
+    kMaHostOnline,
+    kMaJoinOnline,
   };
 
   MainMenu(int x, int y) : Menu(x, y) {}
 
-  virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item);
+  virtual ItemBehavior* GetItemBehavior(Common& common, MenuItem& item);
 };

--- a/src/game/menu/menu.cpp
+++ b/src/game/menu/menu.cpp
@@ -10,147 +10,147 @@
 
 #include "../common.hpp"
 
-void Menu::onKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains) {
+void Menu::OnKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains) {
   for (; begin != end; ++begin) {
     SDL_Scancode scancode = *begin;
     SDL_Keycode sym = SDL_GetKeyFromScancode(scancode, SDL_KMOD_NONE, false);
-    bool isTab = scancode == SDL_SCANCODE_TAB;
+    bool is_tab = scancode == SDL_SCANCODE_TAB;
     if ((sym >= 32 && sym <= 127)  // x >= SDLK_SPACE && x <= SDLK_DELETE
-        || isTab) {
+        || is_tab) {
       auto time = SDL_GetTicks();
-      if (!isTab && time - searchTime > 1500) searchPrefix.clear();
+      if (!is_tab && time - search_time > 1500) search_prefix.clear();
 
       while (true) {
-        bool wasEmpty = searchPrefix.empty();
-        auto newPrefix = searchPrefix;
+        bool was_empty = search_prefix.empty();
+        auto new_prefix = search_prefix;
 
-        if (!isTab) newPrefix += char(sym);
-        searchTime = time;
+        if (!is_tab) new_prefix += char(sym);
+        search_time = time;
 
         bool found = false;
 
-        int skip = isTab ? 1 : 0;
+        int skip = is_tab ? 1 : 0;
 
         for (std::size_t offs = skip; offs < items.size(); ++offs) {
           int i = (selection_ + offs) % (int)items.size();
-          auto const& menuString = items[i].string;
+          auto const& menu_string = items[i].string;
 
-          if (items[i].visible && menuString.size() >= newPrefix.size()) {
+          if (items[i].visible && menu_string.size() >= new_prefix.size()) {
             bool result;
 
             if (contains) {
-              result = std::search(menuString.begin(), menuString.end(), newPrefix.begin(),
-                                   newPrefix.end(), [](char a, char b) {
+              result = std::search(menu_string.begin(), menu_string.end(), new_prefix.begin(),
+                                   new_prefix.end(), [](char a, char b) {
                                      return std::toupper((unsigned char)a) ==
                                             std::toupper((unsigned char)b);
-                                   }) != menuString.end();
+                                   }) != menu_string.end();
             } else {
               result = std::equal(
-                  newPrefix.begin(), newPrefix.end(), menuString.begin(), [](char a, char b) {
+                  new_prefix.begin(), new_prefix.end(), menu_string.begin(), [](char a, char b) {
                     return std::toupper((unsigned char)a) == std::toupper((unsigned char)b);
                   });
             }
 
             if (result) {
               found = true;
-              moveTo(i);
+              MoveTo(i);
               break;
             }
           }
         }
 
         if (found) {
-          searchPrefix = newPrefix;
+          search_prefix = new_prefix;
           break;
         }
 
-        searchPrefix.clear();
-        if (wasEmpty) break;
+        search_prefix.clear();
+        if (was_empty) break;
       }
     }
   }
 }
 
-void Menu::draw(Common& common, Renderer& renderer, bool disabled, int x,
-                bool showDisabledSelection) {
-  int itemsLeft = height;
-  int curY = y;
+void Menu::Draw(Common& common, Renderer& renderer, bool disabled, int x,
+                bool show_disabled_selection) {
+  int items_left = height;
+  int cur_y = y;
 
   if (x < 0) x = this->x;
 
-  for (int c = itemFromVisibleIndex(topItem); itemsLeft > 0 && c < (int)items.size(); ++c) {
+  for (int c = ItemFromVisibleIndex(top_item); items_left > 0 && c < (int)items.size(); ++c) {
     MenuItem& item = items[c];
     if (!item.visible) continue;
 
-    --itemsLeft;
+    --items_left;
 
-    bool selected = (c == selection_) && (!disabled || showDisabledSelection);
+    bool selected = (c == selection_) && (!disabled || show_disabled_selection);
 
-    item.draw(common, renderer, x, curY, selected, disabled, centered, valueOffsetX);
-    drawItemOverlay(common, item, x, curY, selected, disabled);
+    item.Draw(common, renderer, x, cur_y, selected, disabled, centered, value_offset_x);
+    DrawItemOverlay(common, item, x, cur_y, selected, disabled);
 
-    curY += itemHeight;
+    cur_y += item_height;
   }
 
-  if (visibleItemCount > height) {
-    int menuHeight = height * itemHeight + 1;
+  if (visible_item_count > height) {
+    int menu_height = height * item_height + 1;
 
-    common.font.drawChar(renderer.bmp, 22, x - 6, y + 2, 0);
-    common.font.drawChar(renderer.bmp, 22, x - 7, y + 1, 50);
-    common.font.drawChar(renderer.bmp, 23, x - 6, y + menuHeight - 7, 0);
-    common.font.drawChar(renderer.bmp, 23, x - 7, y + menuHeight - 8, 50);
+    common.font.DrawChar(renderer.bmp, 22, x - 6, y + 2, 0);
+    common.font.DrawChar(renderer.bmp, 22, x - 7, y + 1, 50);
+    common.font.DrawChar(renderer.bmp, 23, x - 6, y + menu_height - 7, 0);
+    common.font.DrawChar(renderer.bmp, 23, x - 7, y + menu_height - 8, 50);
 
-    int scrollBarHeight = menuHeight - 17;
+    int scroll_bar_height = menu_height - 17;
 
-    int scrollTabHeight = int(height * scrollBarHeight / visibleItemCount);
-    scrollTabHeight = std::min(scrollTabHeight, scrollBarHeight);
-    scrollTabHeight = std::max(scrollTabHeight, 0);
-    int scrollTabY = y + int(topItem * scrollBarHeight / visibleItemCount);
+    int scroll_tab_height = int(height * scroll_bar_height / visible_item_count);
+    scroll_tab_height = std::min(scroll_tab_height, scroll_bar_height);
+    scroll_tab_height = std::max(scroll_tab_height, 0);
+    int scroll_tab_y = y + int(top_item * scroll_bar_height / visible_item_count);
 
-    fillRect(renderer.bmp, x - 7, scrollTabY + 9, 7, scrollTabHeight, 0);
-    fillRect(renderer.bmp, x - 8, scrollTabY + 8, 7, scrollTabHeight, 7);
+    FillRect(renderer.bmp, x - 7, scroll_tab_y + 9, 7, scroll_tab_height, 0);
+    FillRect(renderer.bmp, x - 8, scroll_tab_y + 8, 7, scroll_tab_height, 7);
   }
 }
 
-void Menu::moveToId(int id) { moveTo(indexFromId(id)); }
+void Menu::MoveToId(int id) { MoveTo(IndexFromId(id)); }
 
-void Menu::moveTo(int newSelection) {
-  newSelection = std::max(newSelection, 0);
-  newSelection = std::min(newSelection, (int)items.size() - 1);
-  selection_ = firstVisibleFrom(newSelection);
-  ensureInView(selection_);
+void Menu::MoveTo(int new_selection) {
+  new_selection = std::max(new_selection, 0);
+  new_selection = std::min(new_selection, (int)items.size() - 1);
+  selection_ = FirstVisibleFrom(new_selection);
+  EnsureInView(selection_);
 }
 
-void Menu::moveToFirstVisible() { moveTo(firstVisibleFrom(0)); }
+void Menu::MoveToFirstVisible() { MoveTo(FirstVisibleFrom(0)); }
 
-bool Menu::isInView(int item) {
-  int visibleIndex = visibleItemIndex(item);
-  return visibleIndex >= topItem && visibleIndex < bottomItem;
+bool Menu::IsInView(int item) {
+  int visible_index = VisibleItemIndex(item);
+  return visible_index >= top_item && visible_index < bottom_item;
 }
 
-bool Menu::itemPosition(MenuItem& item, int& x, int& y) {
+bool Menu::ItemPosition(MenuItem& item, int& x, int& y) {
   int index = int(&item - &items[0]);
-  if (!isInView(index)) return false;
+  if (!IsInView(index)) return false;
 
-  int visIdx = visibleItemIndex(index);
+  int vis_idx = VisibleItemIndex(index);
   x = this->x;
-  y = this->y + (visIdx - topItem) * itemHeight;
+  y = this->y + (vis_idx - top_item) * item_height;
   return true;
 }
 
-void Menu::ensureInView(int item) {
+void Menu::EnsureInView(int item) {
   if (item < 0 || item >= (int)items.size() || !items[item].visible)
     return;  // Can't show items outside the menu or invisible items
 
-  int visibleIndex = visibleItemIndex(item);
+  int visible_index = VisibleItemIndex(item);
 
-  if (visibleIndex < topItem)
-    setTop(visibleIndex);
-  else if (visibleIndex >= bottomItem)
-    setBottom(visibleIndex + 1);
+  if (visible_index < top_item)
+    SetTop(visible_index);
+  else if (visible_index >= bottom_item)
+    SetBottom(visible_index + 1);
 }
 
-int Menu::firstVisibleFrom(int item) {
+int Menu::FirstVisibleFrom(int item) {
   for (std::size_t i = item; i < items.size(); ++i) {
     if (items[i].visible && items[i].selectable) {
       return (int)i;
@@ -160,7 +160,7 @@ int Menu::firstVisibleFrom(int item) {
   return (int)items.size();
 }
 
-int Menu::lastVisibleFrom(int item) {
+int Menu::LastVisibleFrom(int item) {
   for (std::size_t i = item; i-- > 0;) {
     if (items[i].visible && items[i].selectable) {
       return (int)i + 1;
@@ -170,7 +170,7 @@ int Menu::lastVisibleFrom(int item) {
   return 0;
 }
 
-int Menu::visibleItemIndex(int item) {
+int Menu::VisibleItemIndex(int item) {
   int idx = 0;
   for (int i = 0; i < (int)items.size(); ++i) {
     if (!items[i].visible) continue;
@@ -181,7 +181,7 @@ int Menu::visibleItemIndex(int item) {
   return idx;
 }
 
-int Menu::itemFromVisibleIndex(int idx) {
+int Menu::ItemFromVisibleIndex(int idx) {
   for (int i = 0; i < (int)items.size(); ++i) {
     if (!items[i].visible) continue;
 
@@ -191,98 +191,98 @@ int Menu::itemFromVisibleIndex(int idx) {
   return (int)items.size();
 }
 
-void Menu::setBottom(int newBottomVisIdx) { setTop(newBottomVisIdx - height); }
+void Menu::SetBottom(int new_bottom_vis_idx) { SetTop(new_bottom_vis_idx - height); }
 
-void Menu::setTop(int newTopVisIdx) {
-  newTopVisIdx = std::min(newTopVisIdx, visibleItemCount - height);
-  newTopVisIdx = std::max(newTopVisIdx, 0);
-  topItem = newTopVisIdx;
-  bottomItem = std::min(topItem + height, visibleItemCount);
+void Menu::SetTop(int new_top_vis_idx) {
+  new_top_vis_idx = std::min(new_top_vis_idx, visible_item_count - height);
+  new_top_vis_idx = std::max(new_top_vis_idx, 0);
+  top_item = new_top_vis_idx;
+  bottom_item = std::min(top_item + height, visible_item_count);
 }
 
-void Menu::setVisibility(int id, bool state) {
-  int item = indexFromId(id);
+void Menu::SetVisibility(int id, bool state) {
+  int item = IndexFromId(id);
   if (item < 0) {
     assert(false);
     return;
   }
 
   if (items[item].visible && !state)
-    --visibleItemCount;
+    --visible_item_count;
   else if (!items[item].visible && state)
-    ++visibleItemCount;
+    ++visible_item_count;
 
-  int realTopItem = itemFromVisibleIndex(topItem);
+  int real_top_item = ItemFromVisibleIndex(top_item);
 
   items[item].visible = state;
 
-  setTop(visibleItemIndex(realTopItem));
-  ensureInView(selection());
+  SetTop(VisibleItemIndex(real_top_item));
+  EnsureInView(Selection());
 }
 
-void Menu::scroll(int dir) { setTop(topItem + dir); }
+void Menu::Scroll(int dir) { SetTop(top_item + dir); }
 
-void Menu::movementPage(int direction) {
-  int sel = visibleItemIndex(selection_);
+void Menu::MovementPage(int direction) {
+  int sel = VisibleItemIndex(selection_);
 
   int offset = direction * (height / 2);
   sel += offset;
-  setTop(topItem + offset);
+  SetTop(top_item + offset);
 
   sel = std::max(sel, 0);
-  sel = std::min(sel, visibleItemCount - 1);
+  sel = std::min(sel, visible_item_count - 1);
 
-  moveTo(itemFromVisibleIndex(sel));
+  MoveTo(ItemFromVisibleIndex(sel));
 }
 
-void Menu::movement(int direction) {
+void Menu::Movement(int direction) {
   if (direction < 0) {
     for (int i = selection_ - 1; i >= 0; --i) {
       if (items[i].visible && items[i].selectable) {
-        moveTo(i);
+        MoveTo(i);
         return;
       }
     }
 
     for (int i = (int)items.size() - 1; i > selection_; --i) {
       if (items[i].visible && items[i].selectable) {
-        moveTo(i);
+        MoveTo(i);
         return;
       }
     }
   } else if (direction > 0) {
     for (int i = selection_ + 1; i < (int)items.size(); ++i) {
       if (items[i].visible && items[i].selectable) {
-        moveTo(i);
+        MoveTo(i);
         return;
       }
     }
 
     for (int i = 0; i < selection_; ++i) {
       if (items[i].visible && items[i].selectable) {
-        moveTo(i);
+        MoveTo(i);
         return;
       }
     }
   }
 }
 
-int Menu::addItem(MenuItem item) {
+int Menu::AddItem(MenuItem item) {
   int idx = (int)items.size();
   items.push_back(item);
-  if (item.visible) ++visibleItemCount;
+  if (item.visible) ++visible_item_count;
   return idx;
 }
 
-void Menu::clear() {
+void Menu::Clear() {
   items.clear();
-  visibleItemCount = 0;
-  setTop(0);
+  visible_item_count = 0;
+  SetTop(0);
 }
 
-int Menu::addItem(MenuItem item, int pos) {
+int Menu::AddItem(MenuItem item, int pos) {
   int idx = (int)items.size();
   items.insert(items.begin() + pos, item);
-  if (item.visible) ++visibleItemCount;
+  if (item.visible) ++visible_item_count;
   return idx;
 }

--- a/src/game/menu/menu.hpp
+++ b/src/game/menu/menu.hpp
@@ -23,118 +23,118 @@ struct Common;
 struct Gfx;
 
 struct Menu {
-  Menu(bool centered = false) { init(centered); }
+  Menu(bool centered = false) { Init(centered); }
 
   Menu(int x, int y, bool centered = false) {
-    init(centered);
-    place(x, y);
+    Init(centered);
+    Place(x, y);
   }
 
   virtual ~Menu() {}
 
-  void init(bool centeredInit = false) {
-    itemHeight = 8;
-    centered = centeredInit;
+  void Init(bool centered_init = false) {
+    item_height = 8;
+    centered = centered_init;
     selection_ = 0;
-    valueOffsetX = 0;
+    value_offset_x = 0;
     x = 0;
     y = 0;
     height = 15;
-    topItem = 0;
-    bottomItem = 0;
+    top_item = 0;
+    bottom_item = 0;
     // showScroll = false;
-    visibleItemCount = 0;
-    searchTime = 0;
+    visible_item_count = 0;
+    search_time = 0;
   }
 
-  void draw(Common& common, Renderer& renderer, bool disabled, int x = -1,
-            bool showDisabledSelection = false);
-  void process();
+  void Draw(Common& common, Renderer& renderer, bool disabled, int x = -1,
+            bool show_disabled_selection = false);
+  void Process();
 
-  virtual void drawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
+  virtual void DrawItemOverlay(Common& common, MenuItem& item, int x, int y, bool selected,
                                bool disabled) {
     // Nothing by default
   }
 
-  virtual ItemBehavior* getItemBehavior(Common& common, MenuItem& item) {
+  virtual ItemBehavior* GetItemBehavior(Common& common, MenuItem& item) {
     // Dummy item behavior by default
     return new ItemBehavior;
   }
 
-  virtual void onUpdate() {
+  virtual void OnUpdate() {
     // Nothing by default
   }
 
-  bool onLeftRight(Common& common, int dir) {
-    auto* s = selected();
+  bool OnLeftRight(Common& common, int dir) {
+    auto* s = Selected();
     if (!s) return false;
-    std::unique_ptr<ItemBehavior> b(getItemBehavior(common, *s));
-    return b->onLeftRight(*this, *s, dir);
+    std::unique_ptr<ItemBehavior> b(GetItemBehavior(common, *s));
+    return b->OnLeftRight(*this, *s, dir);
   }
 
-  int onEnter(Common& common) {
-    auto* s = selected();
+  int OnEnter(Common& common) {
+    auto* s = Selected();
     if (!s) return false;
-    std::unique_ptr<ItemBehavior> b(getItemBehavior(common, *s));
-    return b->onEnter(*this, *s);
+    std::unique_ptr<ItemBehavior> b(GetItemBehavior(common, *s));
+    return b->OnEnter(*this, *s);
   }
 
-  void onKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains = false);
+  void OnKeys(SDL_Scancode* begin, SDL_Scancode* end, bool contains = false);
 
-  void updateItems(Common& common) {
+  void UpdateItems(Common& common) {
     for (std::size_t i = 0; i < items.size(); ++i) {
-      std::unique_ptr<ItemBehavior> b(getItemBehavior(common, items[i]));
+      std::unique_ptr<ItemBehavior> b(GetItemBehavior(common, items[i]));
 
-      b->onUpdate(*this, items[i]);
+      b->OnUpdate(*this, items[i]);
     }
 
-    onUpdate();
+    OnUpdate();
   }
 
-  void place(int newX, int newY) {
-    x = newX;
-    y = newY;
+  void Place(int new_x, int new_y) {
+    x = new_x;
+    y = new_y;
   }
 
-  bool isSelectionValid() { return selection_ >= 0 && selection_ < (int)items.size(); }
+  bool IsSelectionValid() { return selection_ >= 0 && selection_ < (int)items.size(); }
 
-  void moveToFirstVisible();
-  void movement(int direction);
-  void movementPage(int direction);
+  void MoveToFirstVisible();
+  void Movement(int direction);
+  void MovementPage(int direction);
 
-  int addItem(MenuItem item);
-  int addItem(MenuItem item, int pos);
-  void clear();
+  int AddItem(MenuItem item);
+  int AddItem(MenuItem item, int pos);
+  void Clear();
 
-  bool itemPosition(MenuItem& item, int& x, int& y);
+  bool ItemPosition(MenuItem& item, int& x, int& y);
 
-  int visibleItemIndex(int item);
-  int itemFromVisibleIndex(int idx);
+  int VisibleItemIndex(int item);
+  int ItemFromVisibleIndex(int idx);
 
-  void setHeight(int newHeight) {
-    height = newHeight;
-    setTop(topItem);
+  void SetHeight(int new_height) {
+    height = new_height;
+    SetTop(top_item);
   }
 
-  int selection() { return selection_; }
+  int Selection() { return selection_; }
 
   // Used by the rollback weapon-select snapshot restore. Sets the
   // selection_ field directly, bypassing visibility/scroll adjustments.
   // Callers are expected to also restore topItem/bottomItem from the
   // same snapshot.
-  void setSelection(int newSelection) { selection_ = newSelection; }
+  void SetSelection(int new_selection) { selection_ = new_selection; }
 
-  MenuItem* selected() {
-    if (!isSelectionValid()) return 0;
+  MenuItem* Selected() {
+    if (!IsSelectionValid()) return 0;
     return &items[selection_];
   }
 
-  int selectedId() {
-    MenuItem* s = selected();
+  int SelectedId() {
+    MenuItem* s = Selected();
     return s ? s->id : -1;
   }
 
-  int indexFromId(int id) {
+  int IndexFromId(int id) {
     for (int i = 0; i < (int)items.size(); ++i) {
       if (items[i].id == id) return i;
     }
@@ -142,7 +142,7 @@ struct Menu {
     return -1;
   }
 
-  MenuItem* itemFromId(int id) {
+  MenuItem* ItemFromId(int id) {
     for (int i = 0; i < (int)items.size(); ++i) {
       if (items[i].id == id) return &items[i];
     }
@@ -150,32 +150,32 @@ struct Menu {
     return 0;
   }
 
-  void setVisibility(int id, bool state);
-  int firstVisibleFrom(int item);
-  int lastVisibleFrom(int item);
-  void moveTo(int newSelection);
-  void moveToId(int id);
-  bool isInView(int item);
-  void ensureInView(int item);
-  void setBottom(int newBottomVisIdx);
-  void setTop(int newTopVisIdx);
-  void scroll(int amount);
+  void SetVisibility(int id, bool state);
+  int FirstVisibleFrom(int item);
+  int LastVisibleFrom(int item);
+  void MoveTo(int new_selection);
+  void MoveToId(int id);
+  bool IsInView(int item);
+  void EnsureInView(int item);
+  void SetBottom(int new_bottom_vis_idx);
+  void SetTop(int new_top_vis_idx);
+  void Scroll(int amount);
 
-  std::string searchPrefix;
-  Uint64 searchTime;
+  std::string search_prefix;
+  Uint64 search_time;
 
   std::vector<MenuItem> items;
-  int itemHeight;
-  int valueOffsetX;
+  int item_height;
+  int value_offset_x;
 
   int x, y;
   int height;
 
-  int topItem;     // Visible index
-  int bottomItem;  // Visible index
+  int top_item;     // Visible index
+  int bottom_item;  // Visible index
   // bool showScroll;
 
-  int visibleItemCount;
+  int visible_item_count;
 
   bool centered;
 

--- a/src/game/menu/menuItem.cpp
+++ b/src/game/menu/menuItem.cpp
@@ -14,10 +14,10 @@ void MenuItem::Draw(Common& common, Renderer& renderer, int x, int y, bool selec
     if (has_value)
       DrawRoundedBox(renderer.bmp, x + value_offset_x - (value_wid >> 1), y, 0, 7, value_wid);
   } else {
-    common.font.DrawText(renderer.bmp, string, x + 3, y + 2, 0);
+    common.font.DrawString(renderer.bmp, string, x + 3, y + 2, 0);
     if (has_value)
-      common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 3, y + 2,
-                           0);
+      common.font.DrawString(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 3, y + 2,
+                             0);
   }
 
   PalIdx c;
@@ -29,7 +29,8 @@ void MenuItem::Draw(Common& common, Renderer& renderer, int x, int y, bool selec
   else
     c = color;
 
-  common.font.DrawText(renderer.bmp, string, x + 2, y + 1, c);
+  common.font.DrawString(renderer.bmp, string, x + 2, y + 1, c);
   if (has_value)
-    common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 2, y + 1, c);
+    common.font.DrawString(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 2, y + 1,
+                           c);
 }

--- a/src/game/menu/menuItem.cpp
+++ b/src/game/menu/menuItem.cpp
@@ -3,32 +3,32 @@
 #include "../common.hpp"
 #include "../gfx.hpp"
 
-void MenuItem::draw(Common& common, Renderer& renderer, int x, int y, bool selected, bool disabled,
-                    bool centered, int valueOffsetX) {
-  int wid = common.font.getDims(string);
-  int valueWid = common.font.getDims(value);
+void MenuItem::Draw(Common& common, Renderer& renderer, int x, int y, bool selected, bool disabled,
+                    bool centered, int value_offset_x) {
+  int wid = common.font.GetDims(string);
+  int value_wid = common.font.GetDims(value);
   if (centered) x -= (wid >> 1);
 
   if (selected) {
-    drawRoundedBox(renderer.bmp, x, y, 0, 7, wid);
-    if (hasValue)
-      drawRoundedBox(renderer.bmp, x + valueOffsetX - (valueWid >> 1), y, 0, 7, valueWid);
+    DrawRoundedBox(renderer.bmp, x, y, 0, 7, wid);
+    if (has_value)
+      DrawRoundedBox(renderer.bmp, x + value_offset_x - (value_wid >> 1), y, 0, 7, value_wid);
   } else {
-    common.font.drawText(renderer.bmp, string, x + 3, y + 2, 0);
-    if (hasValue)
-      common.font.drawText(renderer.bmp, value, x + valueOffsetX - (valueWid >> 1) + 3, y + 2, 0);
+    common.font.DrawText(renderer.bmp, string, x + 3, y + 2, 0);
+    if (has_value)
+      common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 3, y + 2, 0);
   }
 
   PalIdx c;
 
   if (disabled)
-    c = disColour;
+    c = dis_colour;
   else if (selected)
     c = disabled ? 7 : 168;
   else
     c = color;
 
-  common.font.drawText(renderer.bmp, string, x + 2, y + 1, c);
-  if (hasValue)
-    common.font.drawText(renderer.bmp, value, x + valueOffsetX - (valueWid >> 1) + 2, y + 1, c);
+  common.font.DrawText(renderer.bmp, string, x + 2, y + 1, c);
+  if (has_value)
+    common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 2, y + 1, c);
 }

--- a/src/game/menu/menuItem.cpp
+++ b/src/game/menu/menuItem.cpp
@@ -16,7 +16,8 @@ void MenuItem::Draw(Common& common, Renderer& renderer, int x, int y, bool selec
   } else {
     common.font.DrawText(renderer.bmp, string, x + 3, y + 2, 0);
     if (has_value)
-      common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 3, y + 2, 0);
+      common.font.DrawText(renderer.bmp, value, x + value_offset_x - (value_wid >> 1) + 3, y + 2,
+                           0);
   }
 
   PalIdx c;

--- a/src/game/menu/menuItem.hpp
+++ b/src/game/menu/menuItem.hpp
@@ -7,29 +7,29 @@
 struct Common;
 
 struct MenuItem {
-  MenuItem(PalIdx color, PalIdx disColour, std::string string, int id = -1)
+  MenuItem(PalIdx color, PalIdx dis_colour, std::string string, int id = -1)
       : color(color),
-        disColour(disColour),
+        dis_colour(dis_colour),
         string(string),
-        hasValue(false),
+        has_value(false),
         visible(true),
         selectable(true),
         id(id) {}
 
-  static MenuItem space() {
+  static MenuItem Space() {
     MenuItem m(0, 0, "");
     m.selectable = false;
     return m;
   }
 
-  void draw(Common& common, Renderer& renderer, int x, int y, bool selected, bool disabled,
-            bool centered, int valueOffsetX);
+  void Draw(Common& common, Renderer& renderer, int x, int y, bool selected, bool disabled,
+            bool centered, int value_offset_x);
 
   PalIdx color;
-  PalIdx disColour;
+  PalIdx dis_colour;
   std::string string;
 
-  bool hasValue;
+  bool has_value;
   std::string value;
 
   bool visible, selectable;

--- a/src/game/menu/timeBehavior.cpp
+++ b/src/game/menu/timeBehavior.cpp
@@ -5,7 +5,7 @@
 #include "menu.hpp"
 #include "menuItem.hpp"
 
-void TimeBehavior::onUpdate(Menu& menu, MenuItem& item) {
-  item.value = frames ? timeToStringFrames(v) : timeToString(v);
-  item.hasValue = true;
+void TimeBehavior::OnUpdate(Menu& menu, MenuItem& item) {
+  item.value = frames ? TimeToStringFrames(v) : TimeToString(v);
+  item.has_value = true;
 }

--- a/src/game/menu/timeBehavior.hpp
+++ b/src/game/menu/timeBehavior.hpp
@@ -8,10 +8,10 @@ struct Menu;
 struct TimeBehavior : IntegerBehavior {
   TimeBehavior(Common& common, int& v, int min, int max, int step = 1, bool frames = false)
       : IntegerBehavior(common, v, min, max, step, false), frames(frames) {
-    allowEntry = false;
+    allow_entry = false;
   }
 
-  void onUpdate(Menu& menu, MenuItem& item);
+  void OnUpdate(Menu& menu, MenuItem& item);
 
   bool frames;
 };

--- a/src/game/metadata.hpp
+++ b/src/game/metadata.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-const char* build_version(void);
-const char* build_hash(void);
-const char* build_date(void);
-const char* build_time(void);
+const char* BuildVersion(void);
+const char* BuildHash(void);
+const char* BuildDate(void);
+const char* BuildTime(void);

--- a/src/game/mixer/mixer.cpp
+++ b/src/game/mixer/mixer.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <vector>
 
-typedef struct channel {
+typedef struct Channel {
   // Mutator write once, mutator read, mixer write
   void* id;
 
@@ -27,7 +27,7 @@ typedef struct channel {
   */
 } channel;
 
-struct sfx_mixer {
+struct SfxMixer {
   channel channel_states[CHANNEL_COUNT];
 
   int32_t base_frame;
@@ -36,28 +36,28 @@ struct sfx_mixer {
   double sample_rate;
 };
 
-struct sfx_sound {
+struct SfxSound {
   std::vector<int16_t> samples;
 };
 
-int32_t sfx_mixer_now(sfx_mixer* mixer) { return mixer->base_frame; }
+int32_t SfxMixerNow(sfx_mixer* mixer) { return mixer->base_frame; }
 
-sfx_sound* sfx_new_sound(std::size_t samples) {
+sfx_sound* SfxNewSound(std::size_t samples) {
   sfx_sound* snd = new sfx_sound();
 
   snd->samples = std::vector<int16_t>(samples);
   return snd;
 }
 
-void sfx_free_sound(sfx_sound* snd) { delete snd; }
+void SfxFreeSound(sfx_sound* snd) { delete snd; }
 
-std::vector<int16_t>& sfx_sound_data(sfx_sound* snd) { return snd->samples; }
+std::vector<int16_t>& SfxSoundData(sfx_sound* snd) { return snd->samples; }
 
 #define INACTIVE_FLAGS (-1)
 #define MK_HANDLE(num, idx) ((uint32)(((num) << 8) + (idx)))
 #define CHECK_HANDLE(h) (((self)->channel_states[(h) & 0xff].id == (h)) ? ((h) & 0xff) : -1)
 
-sfx_mixer* sfx_mixer_create(void) {
+sfx_mixer* SfxMixerCreate(void) {
   sfx_mixer* self = new sfx_mixer();
   uint32_t i;
   for (i = 0; i < CHANNEL_COUNT; ++i) self->channel_states[i].flags = INACTIVE_FLAGS;
@@ -65,7 +65,7 @@ sfx_mixer* sfx_mixer_create(void) {
   return self;
 }
 
-static int add_channel(int16_t* out, unsigned long frame_count, uint32_t now, channel* ch) {
+static int AddChannel(int16_t* out, unsigned long frame_count, uint32_t now, channel* ch) {
   sfx_sound* sound = ch->sound;
   uint32_t pos = ch->pos;
   int32_t scaler;
@@ -103,7 +103,7 @@ static int add_channel(int16_t* out, unsigned long frame_count, uint32_t now, ch
   return 1;
 }
 
-void sfx_mixer_mix(sfx_mixer* self, void* output, unsigned long frame_count) {
+void SfxMixerMix(sfx_mixer* self, void* output, unsigned long frame_count) {
   int16_t* out = (int16_t*)(output);
   uint32_t c;
   memset(out, 0, frame_count * sizeof(int16_t));
@@ -116,7 +116,7 @@ void sfx_mixer_mix(sfx_mixer* self, void* output, unsigned long frame_count) {
     channel* ch = self->channel_states + c;
 
     if (ch->flags != INACTIVE_FLAGS) {
-      if (!add_channel(out, frame_count, self->base_frame, ch)) {
+      if (!AddChannel(out, frame_count, self->base_frame, ch)) {
         // Remove
         SDL_MemoryBarrierAcquire();
         ch->flags = INACTIVE_FLAGS;
@@ -136,7 +136,7 @@ void sfx_mixer_fill(sfx_stream* str, uint32_t start, uint32_t frames)
         sfx_mixer_mix(self, str->buffer, frames, start);
 }*/
 
-static int find_channel(sfx_mixer* self, void* h) {
+static int FindChannel(sfx_mixer* self, void* h) {
   uint32_t c;
 
   for (c = 0; c < CHANNEL_COUNT;) {
@@ -148,7 +148,7 @@ static int find_channel(sfx_mixer* self, void* h) {
   return -1;
 }
 
-static int find_free_channel(sfx_mixer* self) {
+static int FindFreeChannel(sfx_mixer* self) {
   uint32_t c;
 
   for (c = 0; c < CHANNEL_COUNT;) {
@@ -159,9 +159,9 @@ static int find_free_channel(sfx_mixer* self) {
   return -1;
 }
 
-void sfx_set_volume(sfx_mixer* self, void* h, double volume) {
+void SfxSetVolume(sfx_mixer* self, void* h, double volume) {
   uint32_t v;
-  int ch = find_channel(self, h);
+  int ch = FindChannel(self, h);
   if (ch < 0) return;
 
   v = (uint32_t)(volume * 0x1000);
@@ -169,24 +169,24 @@ void sfx_set_volume(sfx_mixer* self, void* h, double volume) {
   self->channel_states[ch].volumes = (v << 16) + v;
 }
 
-int sfx_is_playing(sfx_mixer* self, void* h) {
-  int ch = find_channel(self, h);
+int SfxIsPlaying(sfx_mixer* self, void* h) {
+  int ch = FindChannel(self, h);
   return (ch >= 0);
 }
 
-void sfx_mixer_stop(sfx_mixer* self, void* h) {
-  int ch = find_channel(self, h);
+void SfxMixerStop(sfx_mixer* self, void* h) {
+  int ch = FindChannel(self, h);
   if (ch < 0) return;
 
   self->channel_states[ch].flags = -1;
 }
 
-void* sfx_mixer_add(sfx_mixer* self, sfx_sound* snd, uint32_t time, void* h, uint32_t flags) {
+void* SfxMixerAdd(sfx_mixer* self, sfx_sound* snd, uint32_t time, void* h, uint32_t flags) {
   // A null sound is a disabled/placeholder slot. Silently ignore it so
   // callers that play by index don't need to special-case it.
   if (!snd) return NULL;
 
-  int ch_idx = find_free_channel(self);
+  int ch_idx = FindFreeChannel(self);
 
   if (ch_idx >= 0) {
     SDL_MemoryBarrierAcquire();

--- a/src/game/mixer/mixer.hpp
+++ b/src/game/mixer/mixer.hpp
@@ -5,24 +5,24 @@
 
 #define CHANNEL_COUNT (8)
 
-typedef struct sfx_mixer sfx_mixer;
+typedef struct SfxMixer sfx_mixer;
 
-typedef struct sfx_sound sfx_sound;
+typedef struct SfxSound sfx_sound;
 
 #define SFX_SOUND_NORMAL (0)
 #define SFX_SOUND_LOOP (1)
 
-sfx_mixer* sfx_mixer_create(void);
-int32_t sfx_mixer_now(sfx_mixer* mixer);
-void sfx_set_volume(sfx_mixer* self, void* h, double volume);
-int sfx_is_playing(sfx_mixer* self, void* h);
+sfx_mixer* SfxMixerCreate(void);
+int32_t SfxMixerNow(sfx_mixer* mixer);
+void SfxSetVolume(sfx_mixer* self, void* h, double volume);
+int SfxIsPlaying(sfx_mixer* self, void* h);
 
-void* sfx_mixer_add(sfx_mixer* self, sfx_sound* snd, uint32_t time, void* h, uint32_t flags);
-void sfx_mixer_stop(sfx_mixer* self, void* h);
+void* SfxMixerAdd(sfx_mixer* self, sfx_sound* snd, uint32_t time, void* h, uint32_t flags);
+void SfxMixerStop(sfx_mixer* self, void* h);
 
-sfx_sound* sfx_new_sound(std::size_t samples);
-void sfx_free_sound(sfx_sound* snd);
-std::vector<int16_t>& sfx_sound_data(sfx_sound* snd);
+sfx_sound* SfxNewSound(std::size_t samples);
+void SfxFreeSound(sfx_sound* snd);
+std::vector<int16_t>& SfxSoundData(sfx_sound* snd);
 
-void sfx_mixer_mix(sfx_mixer* self, void* output, unsigned long frame_count);
+void SfxMixerMix(sfx_mixer* self, void* output, unsigned long frame_count);
 // void sfx_mixer_fill(sfx_stream* str, uint32_t start, uint32_t frames);

--- a/src/game/mixer/player.cpp
+++ b/src/game/mixer/player.cpp
@@ -3,22 +3,22 @@
 #include "../common.hpp"
 #include "../console.hpp"
 
-SoundPlayer* g_soundPlayer = nullptr;
+SoundPlayer* g_sound_player = nullptr;
 
-void SoundPlayer::play(SOUND_DEF_T hook, void* id, int loops) {
-  Common* c = common();
-  if (c) play(c->soundHook[hook], id, loops);
+void SoundPlayer::Play(SoundDefT hook, void* id, int loops) {
+  Common* c = GetCommonPtr();
+  if (c) Play(c->sound_hook[hook], id, loops);
 }
 
 #if !DISABLE_SOUND
-static void SDLCALL DefaultSoundPlayer_stream_callback(void* userdata, SDL_AudioStream* stream,
+static void SDLCALL DefaultSoundPlayerStreamCallback(void* userdata, SDL_AudioStream* stream,
                                                        int additional_amount,
                                                        int /*total_amount*/) {
   if (additional_amount > 0) {
     uint8_t* data = (uint8_t*)SDL_stack_alloc(uint8_t, additional_amount);
     if (data) {
       uint32_t frame_count = additional_amount / 2;
-      sfx_mixer_mix((sfx_mixer*)userdata, data, frame_count);
+      SfxMixerMix((sfx_mixer*)userdata, data, frame_count);
       SDL_PutAudioStreamData(stream, data, additional_amount);
       SDL_stack_free(data);
     }
@@ -27,14 +27,14 @@ static void SDLCALL DefaultSoundPlayer_stream_callback(void* userdata, SDL_Audio
 #endif
 
 DefaultSoundPlayer::DefaultSoundPlayer(Common& c)
-    : m_common(&c),
-      mixer(nullptr)
+    : m_common_(&c),
+      mixer_(nullptr)
 #if !DISABLE_SOUND
       ,
-      stream(nullptr)
+      stream_(nullptr)
 #endif
       ,
-      initialized(false) {
+      initialized_(false) {
 #if !DISABLE_SOUND
   // Request a small audio buffer for low latency (~5.8ms at 44100Hz).
   // Must be set before opening the audio device.
@@ -42,17 +42,17 @@ DefaultSoundPlayer::DefaultSoundPlayer(Common& c)
 
   SDL_InitSubSystem(SDL_INIT_AUDIO);
 
-  mixer = sfx_mixer_create();
+  mixer_ = SfxMixerCreate();
 
-  const SDL_AudioSpec spec = {SDL_AUDIO_S16, 1, 44100};
-  stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec,
-                                     DefaultSoundPlayer_stream_callback, mixer);
+  const SDL_AudioSpec kSpec = {SDL_AUDIO_S16, 1, 44100};
+  stream_ = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &kSpec,
+                                     DefaultSoundPlayerStreamCallback, mixer_);
 
-  if (stream) {
-    initialized = true;
-    SDL_ResumeAudioStreamDevice(stream);
+  if (stream_) {
+    initialized_ = true;
+    SDL_ResumeAudioStreamDevice(stream_);
   } else {
-    Console::writeWarning(std::string("SDL_OpenAudioDeviceStream returned error: ") +
+    console::WriteWarning(std::string("SDL_OpenAudioDeviceStream returned error: ") +
                           SDL_GetError());
   }
 #endif
@@ -60,44 +60,44 @@ DefaultSoundPlayer::DefaultSoundPlayer(Common& c)
 
 DefaultSoundPlayer::~DefaultSoundPlayer() {
 #if !DISABLE_SOUND
-  if (!initialized) return;
-  initialized = false;
+  if (!initialized_) return;
+  initialized_ = false;
 
-  if (stream) {
-    SDL_DestroyAudioStream(stream);
-    stream = nullptr;
+  if (stream_) {
+    SDL_DestroyAudioStream(stream_);
+    stream_ = nullptr;
   }
   SDL_QuitSubSystem(SDL_INIT_AUDIO);
 #endif
 }
 
-void DefaultSoundPlayer::playImpl(int sound, void* id, int loops) {
+void DefaultSoundPlayer::PlayImpl(int sound, void* id, int loops) {
 #if !DISABLE_SOUND
-  if (!initialized) return;
+  if (!initialized_) return;
 
-  sfx_mixer_add(mixer, m_common->sounds[sound].sound, sfx_mixer_now(mixer), id,
+  SfxMixerAdd(mixer_, m_common_->sounds[sound].sound, SfxMixerNow(mixer_), id,
                 loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
 #endif
 }
 
-bool DefaultSoundPlayer::isPlaying(void* id) {
+bool DefaultSoundPlayer::IsPlaying(void* id) {
 #if !DISABLE_SOUND
-  if (!initialized) return false;
-  return sfx_is_playing(mixer, id) != 0;
+  if (!initialized_) return false;
+  return SfxIsPlaying(mixer_, id) != 0;
 #else
   return false;
 #endif
 }
 
-void DefaultSoundPlayer::stop(void* id) {
+void DefaultSoundPlayer::Stop(void* id) {
 #if !DISABLE_SOUND
   if (speculative) return;
-  if (!initialized) return;
-  sfx_mixer_stop(mixer, id);
+  if (!initialized_) return;
+  SfxMixerStop(mixer_, id);
 #endif
 }
 
-void RecordSoundPlayer::playImpl(int sound, void* id, int loops) {
-  sfx_mixer_add(mixer, m_common.sounds[sound].sound, sfx_mixer_now(mixer), id,
+void RecordSoundPlayer::PlayImpl(int sound, void* id, int loops) {
+  SfxMixerAdd(mixer, m_common_.sounds[sound].sound, SfxMixerNow(mixer), id,
                 loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
 }

--- a/src/game/mixer/player.cpp
+++ b/src/game/mixer/player.cpp
@@ -12,8 +12,7 @@ void SoundPlayer::Play(SoundDefT hook, void* id, int loops) {
 
 #if !DISABLE_SOUND
 static void SDLCALL DefaultSoundPlayerStreamCallback(void* userdata, SDL_AudioStream* stream,
-                                                       int additional_amount,
-                                                       int /*total_amount*/) {
+                                                     int additional_amount, int /*total_amount*/) {
   if (additional_amount > 0) {
     uint8_t* data = (uint8_t*)SDL_stack_alloc(uint8_t, additional_amount);
     if (data) {
@@ -46,7 +45,7 @@ DefaultSoundPlayer::DefaultSoundPlayer(Common& c)
 
   const SDL_AudioSpec kSpec = {SDL_AUDIO_S16, 1, 44100};
   stream_ = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &kSpec,
-                                     DefaultSoundPlayerStreamCallback, mixer_);
+                                      DefaultSoundPlayerStreamCallback, mixer_);
 
   if (stream_) {
     initialized_ = true;
@@ -76,7 +75,7 @@ void DefaultSoundPlayer::PlayImpl(int sound, void* id, int loops) {
   if (!initialized_) return;
 
   SfxMixerAdd(mixer_, m_common_->sounds[sound].sound, SfxMixerNow(mixer_), id,
-                loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
+              loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
 #endif
 }
 
@@ -99,5 +98,5 @@ void DefaultSoundPlayer::Stop(void* id) {
 
 void RecordSoundPlayer::PlayImpl(int sound, void* id, int loops) {
   SfxMixerAdd(mixer, m_common_.sounds[sound].sound, SfxMixerNow(mixer), id,
-                loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
+              loops ? SFX_SOUND_LOOP : SFX_SOUND_NORMAL);
 }

--- a/src/game/mixer/player.hpp
+++ b/src/game/mixer/player.hpp
@@ -12,15 +12,15 @@ struct Common;
 struct SoundPlayer {
   virtual ~SoundPlayer() = default;
 
-  void play(int sound, void* id = 0, int loops = 0) {
+  void Play(int sound, void* id = 0, int loops = 0) {
     if (speculative) return;
-    if (sound >= 0) playImpl(sound, id, loops);
+    if (sound >= 0) PlayImpl(sound, id, loops);
   }
 
-  void play(SOUND_DEF_T hook, void* id = 0, int loops = 0);
+  void Play(SoundDefT hook, void* id = 0, int loops = 0);
 
-  virtual bool isPlaying(void* id) = 0;
-  virtual void stop(void* id) = 0;
+  virtual bool IsPlaying(void* id) = 0;
+  virtual void Stop(void* id) = 0;
 
   // When true, play()/stop() are suppressed but isPlaying() passes
   // through. Set during predicted/resim frames to avoid duplicate
@@ -28,61 +28,64 @@ struct SoundPlayer {
   bool speculative = false;
 
  protected:
-  virtual void playImpl(int sound, void* id, int loops) = 0;
-  virtual Common* common() { return nullptr; }
+  virtual void PlayImpl(int sound, void* id, int loops) = 0;
+  // Returns the active TC's Common bundle, or nullptr if unavailable.
+  // Named GetCommonPtr (not Common) to avoid colliding with the
+  // struct name `Common` after Google-style renaming.
+  virtual Common* GetCommonPtr() { return nullptr; }
 };
 
 struct DefaultSoundPlayer : SoundPlayer {
   DefaultSoundPlayer(Common& common);
   ~DefaultSoundPlayer();
 
-  bool isPlaying(void* id);
-  void stop(void* id);
+  bool IsPlaying(void* id);
+  void Stop(void* id);
 
   // Repoint at a new TC's Common. Called when the user switches TC at
   // runtime — without this the player keeps reading sound samples and
   // soundHook[] from the previous TC.
-  void setCommon(Common& common) { m_common = &common; }
+  void SetCommon(Common& common) { m_common_ = &common; }
 
  protected:
-  void playImpl(int sound, void* id, int loops);
-  Common* common() { return m_common; }
+  void PlayImpl(int sound, void* id, int loops);
+  Common* GetCommonPtr() { return m_common_; }
 
  private:
-  Common* m_common;
-  sfx_mixer* mixer;
+  Common* m_common_;
+  sfx_mixer* mixer_;
 #if !DISABLE_SOUND
-  SDL_AudioStream* stream;
+  SDL_AudioStream* stream_;
 #endif
-  bool initialized;
+  bool initialized_;
 };
 
 struct RecordSoundPlayer : SoundPlayer {
-  RecordSoundPlayer(Common& c, sfx_mixer* mixer) : mixer(mixer), m_common(c) {}
+  RecordSoundPlayer(Common& c, sfx_mixer* mixer) : mixer(mixer), m_common_(c) {}
 
   sfx_mixer* mixer;
 
-  bool isPlaying(void* id) { return sfx_is_playing(mixer, id) != 0; }
+  bool IsPlaying(void* id) { return SfxIsPlaying(mixer, id) != 0; }
 
-  void stop(void* id) {
+  void Stop(void* id) {
     if (speculative) return;
-    sfx_mixer_stop(mixer, id);
+    SfxMixerStop(mixer, id);
   }
 
  protected:
-  void playImpl(int sound, void* id, int loops);
-  Common* common() { return &m_common; }
+  void PlayImpl(int sound, void* id, int loops);
+  Common* GetCommonPtr() { return &m_common_; }
 
  private:
-  Common& m_common;
+  Common& m_common_;
 };
 
 struct NullSoundPlayer : SoundPlayer {
-  bool isPlaying(void* /*id*/) { return false; }
-  void stop(void* /*id*/) {}
+  bool IsPlaying(void* /*id*/) { return false; }
+  void Stop(void* /*id*/) {}
 
  protected:
-  void playImpl(int /*sound*/, void* /*id*/, int /*loops*/) {}
+  void PlayImpl(int /*sound*/, void* /*id*/, int /*loops*/) {}
 };
 
-extern SoundPlayer* g_soundPlayer;
+extern SoundPlayer* g_sound_player;

--- a/src/game/net/iceAgent.cpp
+++ b/src/game/net/iceAgent.cpp
@@ -2,93 +2,93 @@
 
 #include <cstring>
 
-IceAgent::~IceAgent() { stop(); }
+IceAgent::~IceAgent() { Stop(); }
 
-void IceAgent::start(const Config& config) {
+void IceAgent::Start(const Config& config) {
   if (agent_) return;
 
   juice_config_t jcfg{};
   jcfg.concurrency_mode = JUICE_CONCURRENCY_MODE_THREAD;
 
   juice_turn_server_t turn{};
-  if (!config.turnServer.empty()) {
-    turn.host = config.turnServer.c_str();
-    turn.port = config.turnPort;
-    turn.username = config.turnUser.c_str();
-    turn.password = config.turnPassword.c_str();
+  if (!config.turn_server.empty()) {
+    turn.host = config.turn_server.c_str();
+    turn.port = config.turn_port;
+    turn.username = config.turn_user.c_str();
+    turn.password = config.turn_password.c_str();
     jcfg.turn_servers = &turn;
     jcfg.turn_servers_count = 1;
   }
 
-  jcfg.stun_server_host = config.stunServer.c_str();
-  jcfg.stun_server_port = config.stunPort;
+  jcfg.stun_server_host = config.stun_server.c_str();
+  jcfg.stun_server_port = config.stun_port;
 
-  jcfg.cb_state_changed = cbStateChanged;
-  jcfg.cb_candidate = cbCandidate;
-  jcfg.cb_gathering_done = cbGatheringDone;
-  jcfg.cb_recv = cbRecv;
+  jcfg.cb_state_changed = CbStateChanged;
+  jcfg.cb_candidate = CbCandidate;
+  jcfg.cb_gathering_done = CbGatheringDone;
+  jcfg.cb_recv = CbRecv;
   jcfg.user_ptr = this;
 
   agent_ = juice_create(&jcfg);
   juice_gather_candidates(agent_);
 }
 
-void IceAgent::stop() {
+void IceAgent::Stop() {
   if (!agent_) return;
   juice_destroy(agent_);
   agent_ = nullptr;
-  state_ = State::Disconnected;
+  state_ = State::kDisconnected;
 }
 
-std::string IceAgent::localUfrag() const {
+std::string IceAgent::LocalUfrag() const {
   if (!agent_) return {};
   char buf[256];
   if (juice_get_local_description(agent_, buf, sizeof(buf)) == JUICE_ERR_SUCCESS) {
     // Format: "a=ice-ufrag:<ufrag>\r\na=ice-pwd:<pwd>\r\n"
     // Extract ufrag
-    const char* ufragStart = std::strstr(buf, "a=ice-ufrag:");
-    if (!ufragStart) return {};
-    ufragStart += 12;
-    const char* ufragEnd = std::strstr(ufragStart, "\r\n");
-    if (!ufragEnd) ufragEnd = ufragStart + std::strlen(ufragStart);
-    return std::string(ufragStart, ufragEnd);
+    const char* ufrag_start = std::strstr(buf, "a=ice-ufrag:");
+    if (!ufrag_start) return {};
+    ufrag_start += 12;
+    const char* ufrag_end = std::strstr(ufrag_start, "\r\n");
+    if (!ufrag_end) ufrag_end = ufrag_start + std::strlen(ufrag_start);
+    return std::string(ufrag_start, ufrag_end);
   }
   return {};
 }
 
-std::string IceAgent::localPwd() const {
+std::string IceAgent::LocalPwd() const {
   if (!agent_) return {};
   char buf[256];
   if (juice_get_local_description(agent_, buf, sizeof(buf)) == JUICE_ERR_SUCCESS) {
-    const char* pwdStart = std::strstr(buf, "a=ice-pwd:");
-    if (!pwdStart) return {};
-    pwdStart += 10;
-    const char* pwdEnd = std::strstr(pwdStart, "\r\n");
-    if (!pwdEnd) pwdEnd = pwdStart + std::strlen(pwdStart);
-    return std::string(pwdStart, pwdEnd);
+    const char* pwd_start = std::strstr(buf, "a=ice-pwd:");
+    if (!pwd_start) return {};
+    pwd_start += 10;
+    const char* pwd_end = std::strstr(pwd_start, "\r\n");
+    if (!pwd_end) pwd_end = pwd_start + std::strlen(pwd_start);
+    return std::string(pwd_start, pwd_end);
   }
   return {};
 }
 
-void IceAgent::setRemoteCredentials(const std::string& ufrag, const std::string& pwd) {
+void IceAgent::SetRemoteCredentials(const std::string& ufrag, const std::string& pwd) {
   if (!agent_) return;
   std::string desc = "a=ice-ufrag:" + ufrag + "\r\na=ice-pwd:" + pwd + "\r\n";
   juice_set_remote_description(agent_, desc.c_str());
 }
 
-void IceAgent::addRemoteCandidate(const std::string& candidate) {
+void IceAgent::AddRemoteCandidate(const std::string& candidate) {
   if (!agent_) return;
   juice_add_remote_candidate(agent_, candidate.c_str());
 }
 
-void IceAgent::setRemoteGatheringDone() {
+void IceAgent::SetRemoteGatheringDone() {
   if (!agent_) return;
   juice_set_remote_gathering_done(agent_);
 }
 
-IceAgent::State IceAgent::state() const { return state_; }
+IceAgent::State IceAgent::CurrentState() const { return state_; }
 
-void IceAgent::poll() {
+void IceAgent::Poll() {
   std::vector<Event> events;
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -96,75 +96,75 @@ void IceAgent::poll() {
   }
   for (auto& ev : events) {
     switch (ev.type) {
-      case Event::StateChanged:
-        state_ = ev.newState;
-        if (onStateChange) onStateChange(ev.newState);
+      case Event::kStateChanged:
+        state_ = ev.new_state;
+        if (on_state_change) on_state_change(ev.new_state);
         break;
-      case Event::Candidate:
-        if (onLocalCandidate) onLocalCandidate(ev.candidate);
+      case Event::kCandidate:
+        if (on_local_candidate) on_local_candidate(ev.candidate);
         break;
-      case Event::GatheringDone:
-        if (onGatheringDone) onGatheringDone();
+      case Event::kGatheringDone:
+        if (on_gathering_done) on_gathering_done();
         break;
     }
   }
 }
 
-void IceAgent::send(const uint8_t* data, size_t len) {
+void IceAgent::Send(const uint8_t* data, size_t len) {
   if (!agent_) return;
   juice_send(agent_, reinterpret_cast<const char*>(data), len);
 }
 
 // --- Static callbacks (called from libjuice's internal thread) ---
 
-void IceAgent::cbStateChanged(juice_agent_t*, juice_state_t state, void* user_ptr) {
+void IceAgent::CbStateChanged(juice_agent_t*, juice_state_t state, void* user_ptr) {
   auto* self = static_cast<IceAgent*>(user_ptr);
   Event ev;
-  ev.type = Event::StateChanged;
-  ev.newState = mapState(state);
+  ev.type = Event::kStateChanged;
+  ev.new_state = MapState(state);
   std::lock_guard<std::mutex> lock(self->mutex_);
   self->pendingEvents_.push_back(std::move(ev));
 }
 
-void IceAgent::cbCandidate(juice_agent_t*, const char* sdp, void* user_ptr) {
+void IceAgent::CbCandidate(juice_agent_t*, const char* sdp, void* user_ptr) {
   auto* self = static_cast<IceAgent*>(user_ptr);
   Event ev;
-  ev.type = Event::Candidate;
+  ev.type = Event::kCandidate;
   ev.candidate = sdp;
   std::lock_guard<std::mutex> lock(self->mutex_);
   self->pendingEvents_.push_back(std::move(ev));
 }
 
-void IceAgent::cbGatheringDone(juice_agent_t*, void* user_ptr) {
+void IceAgent::CbGatheringDone(juice_agent_t*, void* user_ptr) {
   auto* self = static_cast<IceAgent*>(user_ptr);
   Event ev;
-  ev.type = Event::GatheringDone;
+  ev.type = Event::kGatheringDone;
   std::lock_guard<std::mutex> lock(self->mutex_);
   self->pendingEvents_.push_back(std::move(ev));
 }
 
-void IceAgent::cbRecv(juice_agent_t*, const char* data, size_t size, void* user_ptr) {
+void IceAgent::CbRecv(juice_agent_t*, const char* data, size_t size, void* user_ptr) {
   auto* self = static_cast<IceAgent*>(user_ptr);
-  if (self->onRecv) {
-    self->onRecv(reinterpret_cast<const uint8_t*>(data), size);
+  if (self->on_recv) {
+    self->on_recv(reinterpret_cast<const uint8_t*>(data), size);
   }
 }
 
-IceAgent::State IceAgent::mapState(juice_state_t s) {
+IceAgent::State IceAgent::MapState(juice_state_t s) {
   switch (s) {
     case JUICE_STATE_DISCONNECTED:
-      return State::Disconnected;
+      return State::kDisconnected;
     case JUICE_STATE_GATHERING:
-      return State::Gathering;
+      return State::kGathering;
     case JUICE_STATE_CONNECTING:
-      return State::Connecting;
+      return State::kConnecting;
     case JUICE_STATE_CONNECTED:
-      return State::Connected;
+      return State::kConnected;
     case JUICE_STATE_COMPLETED:
-      return State::Connected;
+      return State::kConnected;
     case JUICE_STATE_FAILED:
-      return State::Failed;
+      return State::kFailed;
     default:
-      return State::New;
+      return State::kNew;
   }
 }

--- a/src/game/net/iceAgent.hpp
+++ b/src/game/net/iceAgent.hpp
@@ -12,15 +12,15 @@
 // event queue. libjuice callbacks fire from an internal thread; IceAgent
 // buffers events and delivers them on the main thread via poll().
 struct IceAgent {
-  enum class State { New, Gathering, Connecting, Connected, Failed, Disconnected };
+  enum class State { kNew, kGathering, kConnecting, kConnected, kFailed, kDisconnected };
 
   struct Config {
-    std::string stunServer = "stun.l.google.com";
-    uint16_t stunPort = 19302;
-    std::string turnServer;
-    uint16_t turnPort = 3478;
-    std::string turnUser;
-    std::string turnPassword;
+    std::string stun_server = "stun.l.google.com";
+    uint16_t stun_port = 19302;
+    std::string turn_server;
+    uint16_t turn_port = 3478;
+    std::string turn_user;
+    std::string turn_password;
   };
 
   IceAgent() = default;
@@ -29,51 +29,51 @@ struct IceAgent {
   IceAgent(const IceAgent&) = delete;
   IceAgent& operator=(const IceAgent&) = delete;
 
-  void start(const Config& config);
-  void stop();
+  void Start(const Config& config);
+  void Stop();
 
-  std::string localUfrag() const;
-  std::string localPwd() const;
+  std::string LocalUfrag() const;
+  std::string LocalPwd() const;
 
-  void setRemoteCredentials(const std::string& ufrag, const std::string& pwd);
-  void addRemoteCandidate(const std::string& candidate);
-  void setRemoteGatheringDone();
+  void SetRemoteCredentials(const std::string& ufrag, const std::string& pwd);
+  void AddRemoteCandidate(const std::string& candidate);
+  void SetRemoteGatheringDone();
 
-  State state() const;
+  State CurrentState() const;
 
   // Drain the internal event queue. Call once per frame from the main thread.
   // Fires onStateChange, onLocalCandidate, onGatheringDone callbacks.
-  void poll();
+  void Poll();
 
   // Send application data through the ICE connection.
-  void send(const uint8_t* data, size_t len);
+  void Send(const uint8_t* data, size_t len);
 
   // Callbacks — fired from poll() on the main thread.
-  std::function<void(State)> onStateChange;
-  std::function<void(const std::string& candidate)> onLocalCandidate;
-  std::function<void()> onGatheringDone;
+  std::function<void(State)> on_state_change;
+  std::function<void(const std::string& candidate)> on_local_candidate;
+  std::function<void()> on_gathering_done;
 
   // Called from libjuice's thread when data arrives. Users of IceAgent
   // should set this to write received data to the bridge socket.
-  std::function<void(const uint8_t* data, size_t len)> onRecv;
+  std::function<void(const uint8_t* data, size_t len)> on_recv;
 
  private:
   struct Event {
-    enum Type { StateChanged, Candidate, GatheringDone };
+    enum Type { kStateChanged, kCandidate, kGatheringDone };
     Type type;
-    State newState{};
+    enum State new_state{};
     std::string candidate;
   };
 
-  static void cbStateChanged(juice_agent_t* agent, juice_state_t state, void* user_ptr);
-  static void cbCandidate(juice_agent_t* agent, const char* sdp, void* user_ptr);
-  static void cbGatheringDone(juice_agent_t* agent, void* user_ptr);
-  static void cbRecv(juice_agent_t* agent, const char* data, size_t size, void* user_ptr);
+  static void CbStateChanged(juice_agent_t* agent, juice_state_t state, void* user_ptr);
+  static void CbCandidate(juice_agent_t* agent, const char* sdp, void* user_ptr);
+  static void CbGatheringDone(juice_agent_t* agent, void* user_ptr);
+  static void CbRecv(juice_agent_t* agent, const char* data, size_t size, void* user_ptr);
 
-  static State mapState(juice_state_t s);
+  static enum State MapState(juice_state_t s);
 
   juice_agent_t* agent_ = nullptr;
-  State state_ = State::New;
+  enum State state_ = State::kNew;
   mutable std::mutex mutex_;
   std::vector<Event> pendingEvents_;
 };

--- a/src/game/net/iceAgent.hpp
+++ b/src/game/net/iceAgent.hpp
@@ -61,7 +61,7 @@ struct IceAgent {
   struct Event {
     enum Type { kStateChanged, kCandidate, kGatheringDone };
     Type type;
-    enum State new_state{};
+    enum State new_state {};
     std::string candidate;
   };
 

--- a/src/game/net/iceBridge.cpp
+++ b/src/game/net/iceBridge.cpp
@@ -22,9 +22,9 @@ using socklen_t = int;
 #define BRIDGE_INVALID_SOCKET(s) ((s) < 0)
 #endif
 
-static constexpr int BRIDGE_BUFSIZE = 256 * 1024;
+static constexpr int kBridgeBufsize = 256 * 1024;
 
-static bool setNonBlocking(int fd) {
+static bool SetNonBlocking(int fd) {
 #ifdef _WIN32
   u_long mode = 1;
   return ioctlsocket(fd, FIONBIO, &mode) == 0;
@@ -35,24 +35,24 @@ static bool setNonBlocking(int fd) {
 #endif
 }
 
-static bool setBufferSizes(int fd) {
-  int sz = BRIDGE_BUFSIZE;
+static bool SetBufferSizes(int fd) {
+  int sz = kBridgeBufsize;
   setsockopt(fd, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&sz), sizeof(sz));
   setsockopt(fd, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&sz), sizeof(sz));
   return true;
 }
 
-IceBridge::~IceBridge() { destroy(); }
+IceBridge::~IceBridge() { Destroy(); }
 
-BridgeSocket IceBridge::create(IceAgent& agent) {
+BridgeSocket IceBridge::Create(IceAgent& agent) {
   agent_ = &agent;
 
   // Create two UDP sockets on localhost — must be AF_INET6 to match ENet's dual-stack sockets
   enetSocket_ = socket(AF_INET6, SOCK_DGRAM, 0);
   bridgeSocket_ = socket(AF_INET6, SOCK_DGRAM, 0);
   if (BRIDGE_INVALID_SOCKET(enetSocket_) || BRIDGE_INVALID_SOCKET(bridgeSocket_)) {
-    destroy();
-    return BRIDGE_INVALID;
+    Destroy();
+    return kBridgeInvalid;
   }
 
   // Disable IPV6_V6ONLY so the sockets accept IPv4-mapped addresses (matching ENet)
@@ -63,42 +63,42 @@ BridgeSocket IceBridge::create(IceAgent& agent) {
              sizeof(off));
 
   // Bind both to IPv6 localhost (::1) with ephemeral ports
-  sockaddr_in6 addrA{};
-  addrA.sin6_family = AF_INET6;
-  addrA.sin6_addr = in6addr_loopback;
-  addrA.sin6_port = 0;
+  sockaddr_in6 addr_a{};
+  addr_a.sin6_family = AF_INET6;
+  addr_a.sin6_addr = in6addr_loopback;
+  addr_a.sin6_port = 0;
 
-  sockaddr_in6 addrB{};
-  addrB.sin6_family = AF_INET6;
-  addrB.sin6_addr = in6addr_loopback;
-  addrB.sin6_port = 0;
+  sockaddr_in6 addr_b{};
+  addr_b.sin6_family = AF_INET6;
+  addr_b.sin6_addr = in6addr_loopback;
+  addr_b.sin6_port = 0;
 
-  if (bind(enetSocket_, reinterpret_cast<sockaddr*>(&addrA), sizeof(addrA)) < 0 ||
-      bind(bridgeSocket_, reinterpret_cast<sockaddr*>(&addrB), sizeof(addrB)) < 0) {
-    destroy();
+  if (bind(enetSocket_, reinterpret_cast<sockaddr*>(&addr_a), sizeof(addr_a)) < 0 ||
+      bind(bridgeSocket_, reinterpret_cast<sockaddr*>(&addr_b), sizeof(addr_b)) < 0) {
+    Destroy();
     return -1;
   }
 
   // Get the assigned addresses
-  socklen_t len = sizeof(addrA);
-  getsockname(enetSocket_, reinterpret_cast<sockaddr*>(&addrA), &len);
-  len = sizeof(addrB);
-  getsockname(bridgeSocket_, reinterpret_cast<sockaddr*>(&addrB), &len);
-  bridgePort_ = ntohs(addrB.sin6_port);
-  enetAddr_ = addrA;
-  bridgeAddr_ = addrB;
+  socklen_t len = sizeof(addr_a);
+  getsockname(enetSocket_, reinterpret_cast<sockaddr*>(&addr_a), &len);
+  len = sizeof(addr_b);
+  getsockname(bridgeSocket_, reinterpret_cast<sockaddr*>(&addr_b), &len);
+  bridgePort_ = ntohs(addr_b.sin6_port);
+  enetAddr_ = addr_a;
+  bridgeAddr_ = addr_b;
 
   // NOT calling connect() — ENet uses sendto() with explicit addresses,
   // which returns EISCONN on Linux if the socket is connected.
 
   // Configure sockets
-  setNonBlocking(enetSocket_);
-  setNonBlocking(bridgeSocket_);
-  setBufferSizes(enetSocket_);
-  setBufferSizes(bridgeSocket_);
+  SetNonBlocking(enetSocket_);
+  SetNonBlocking(bridgeSocket_);
+  SetBufferSizes(enetSocket_);
+  SetBufferSizes(bridgeSocket_);
 
   // Wire IceAgent's onRecv: write incoming data to enetSocket_ via bridgeSocket_
-  agent_->onRecv = [this](const uint8_t* data, size_t len) {
+  agent_->on_recv = [this](const uint8_t* data, size_t len) {
     ::sendto(bridgeSocket_, reinterpret_cast<const char*>(data), len, 0,
              reinterpret_cast<const sockaddr*>(&enetAddr_), sizeof(enetAddr_));
   };
@@ -106,8 +106,8 @@ BridgeSocket IceBridge::create(IceAgent& agent) {
   return enetSocket_;
 }
 
-void IceBridge::poll() {
-  if (bridgeSocket_ == BRIDGE_INVALID || !agent_) return;
+void IceBridge::Poll() {
+  if (bridgeSocket_ == kBridgeInvalid || !agent_) return;
 
   uint8_t buf[2048];
   for (;;) {
@@ -117,21 +117,21 @@ void IceBridge::poll() {
       if (n < 0 && BRIDGE_WOULD_BLOCK) break;
       break;
     }
-    agent_->send(buf, static_cast<size_t>(n));
+    agent_->Send(buf, static_cast<size_t>(n));
   }
 }
 
-void IceBridge::destroy() {
+void IceBridge::Destroy() {
   if (agent_) {
-    agent_->onRecv = nullptr;
+    agent_->on_recv = nullptr;
     agent_ = nullptr;
   }
   // Don't close enetSocket_ — ownership transferred to ENet via enet_host_create.
   // ENet closes it when enet_host_destroy is called.
-  enetSocket_ = BRIDGE_INVALID;
-  if (bridgeSocket_ != BRIDGE_INVALID) {
+  enetSocket_ = kBridgeInvalid;
+  if (bridgeSocket_ != kBridgeInvalid) {
     BRIDGE_CLOSE(bridgeSocket_);
-    bridgeSocket_ = BRIDGE_INVALID;
+    bridgeSocket_ = kBridgeInvalid;
   }
   bridgePort_ = 0;
 }

--- a/src/game/net/iceBridge.hpp
+++ b/src/game/net/iceBridge.hpp
@@ -6,7 +6,7 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 using BridgeSocket = SOCKET;
-static constexpr BridgeSocket BRIDGE_INVALID = INVALID_SOCKET;
+static constexpr BridgeSocket kBridgeInvalid = INVALID_SOCKET;
 #else
 #include <netinet/in.h>
 using BridgeSocket = int;
@@ -32,7 +32,7 @@ struct IceBridge {
   IceBridge& operator=(const IceBridge&) = delete;
 
   // Create the bridge socket pair and wire up the IceAgent's onRecv callback.
-  // Returns the ENet-side socket fd, or BRIDGE_INVALID on error.
+  // Returns the ENet-side socket fd, or kBridgeInvalid on error.
   BridgeSocket Create(IceAgent& agent);
 
   // Poll: read outgoing ENet data from bridge socket → juice_send().

--- a/src/game/net/iceBridge.hpp
+++ b/src/game/net/iceBridge.hpp
@@ -10,7 +10,7 @@ static constexpr BridgeSocket BRIDGE_INVALID = INVALID_SOCKET;
 #else
 #include <netinet/in.h>
 using BridgeSocket = int;
-static constexpr BridgeSocket BRIDGE_INVALID = -1;
+static constexpr BridgeSocket kBridgeInvalid = -1;
 #endif
 
 struct IceAgent;
@@ -33,24 +33,24 @@ struct IceBridge {
 
   // Create the bridge socket pair and wire up the IceAgent's onRecv callback.
   // Returns the ENet-side socket fd, or BRIDGE_INVALID on error.
-  BridgeSocket create(IceAgent& agent);
+  BridgeSocket Create(IceAgent& agent);
 
   // Poll: read outgoing ENet data from bridge socket → juice_send().
   // Call once per frame from the main loop.
-  void poll();
+  void Poll();
 
   // Get the ENet-side socket fd (for replacing host->socket after enet_host_create).
-  BridgeSocket enetSocket() const { return enetSocket_; }
+  BridgeSocket EnetSocket() const { return enetSocket_; }
 
   // Get the port that ENet should "connect" to (the bridge's listening port).
-  uint16_t bridgePort() const { return bridgePort_; }
+  uint16_t BridgePort() const { return bridgePort_; }
 
   // Destroy both sockets.
-  void destroy();
+  void Destroy();
 
  private:
-  BridgeSocket enetSocket_ = BRIDGE_INVALID;
-  BridgeSocket bridgeSocket_ = BRIDGE_INVALID;
+  BridgeSocket enetSocket_ = kBridgeInvalid;
+  BridgeSocket bridgeSocket_ = kBridgeInvalid;
   uint16_t bridgePort_ = 0;
   sockaddr_in6 enetAddr_{};
   sockaddr_in6 bridgeAddr_{};

--- a/src/game/net/localaddr.cpp
+++ b/src/game/net/localaddr.cpp
@@ -21,7 +21,7 @@
 
 #include <cstring>
 
-std::vector<LocalAddress> getLocalAddresses() {
+std::vector<LocalAddress> GetLocalAddresses() {
   std::vector<LocalAddress> result;
 
 #ifdef _WIN32

--- a/src/game/net/localaddr.hpp
+++ b/src/game/net/localaddr.hpp
@@ -5,8 +5,8 @@
 
 struct LocalAddress {
   std::string ip;
-  bool isIPv6;
+  bool is_i_pv6;
 };
 
 // Returns non-loopback local addresses (IPv4 and IPv6 link-local/global)
-std::vector<LocalAddress> getLocalAddresses();
+std::vector<LocalAddress> GetLocalAddresses();

--- a/src/game/net/memoryFs.cpp
+++ b/src/game/net/memoryFs.cpp
@@ -9,20 +9,20 @@
 namespace {
 
 struct FsNodeMemDir : FsNodeImp {
-  std::string path_;
-  MemoryFs* fs_;
+  std::string path;
+  MemoryFs* fs;
 
-  FsNodeMemDir(std::string path, MemoryFs* fs) : path_(std::move(path)), fs_(fs) {}
+  FsNodeMemDir(std::string path, MemoryFs* fs) : path(std::move(path)), fs(fs) {}
 
-  std::string const& fullPath() override { return path_; }
+  std::string const& FullPath() override { return path; }
 
-  DirectoryListing iter() override {
+  DirectoryListing Iter() override {
     // Collect immediate children of this directory
-    std::string prefix = path_.empty() ? "" : path_ + "/";
+    std::string prefix = path.empty() ? "" : path + "/";
     std::vector<NodeName> entries;
     std::set<std::string> seen;
 
-    for (auto& [key, _] : fs_->files) {
+    for (auto& [key, _] : fs->files) {
       if (key.size() <= prefix.size()) continue;
       if (!prefix.empty() && key.compare(0, prefix.size(), prefix) != 0) continue;
 
@@ -30,61 +30,61 @@ struct FsNodeMemDir : FsNodeImp {
       auto rest = key.substr(prefix.size());
       auto slash = rest.find('/');
       std::string name = (slash == std::string::npos) ? rest : rest.substr(0, slash);
-      bool isDir = (slash != std::string::npos);
+      bool is_dir = (slash != std::string::npos);
 
       if (seen.insert(name).second) {
-        entries.push_back(NodeName(name, isDir));
+        entries.push_back(NodeName(name, is_dir));
       }
     }
 
     return DirectoryListing(std::move(entries));
   }
 
-  std::shared_ptr<FsNodeImp> go(std::string const& name) override {
-    std::string childPath = path_.empty() ? name : path_ + "/" + name;
+  std::shared_ptr<FsNodeImp> Go(std::string const& name) override {
+    std::string child_path = path.empty() ? name : path + "/" + name;
 
     // Check if it's a file
-    auto it = fs_->files.find(childPath);
-    if (it != fs_->files.end()) {
+    auto it = fs->files.find(child_path);
+    if (it != fs->files.end()) {
       // It's a file — return a file node
-      return std::make_shared<FsNodeMemDir>(childPath, fs_);
+      return std::make_shared<FsNodeMemDir>(child_path, fs);
     }
 
     // Check if it's a directory (any file starts with childPath + "/")
-    std::string dirPrefix = childPath + "/";
-    for (auto& [key, _] : fs_->files) {
-      if (key.compare(0, dirPrefix.size(), dirPrefix) == 0) {
-        return std::make_shared<FsNodeMemDir>(childPath, fs_);
+    std::string dir_prefix = child_path + "/";
+    for (auto& [key, _] : fs->files) {
+      if (key.compare(0, dir_prefix.size(), dir_prefix) == 0) {
+        return std::make_shared<FsNodeMemDir>(child_path, fs);
       }
     }
 
     // Doesn't exist, but return a node anyway (exists() will return false)
-    return std::make_shared<FsNodeMemDir>(childPath, fs_);
+    return std::make_shared<FsNodeMemDir>(child_path, fs);
   }
 
-  std::unique_ptr<io::Reader> tryToReader() override {
-    auto it = fs_->files.find(path_);
-    if (it == fs_->files.end()) return nullptr;
+  std::unique_ptr<io::Reader> TryToReader() override {
+    auto it = fs->files.find(path);
+    if (it == fs->files.end()) return nullptr;
 
     // The MemoryFs owns the underlying byte buffer (in fs_->files) so we
     // can hand out a MemReader that just points into it.
     return std::make_unique<io::MemReader>(it->second);
   }
 
-  std::unique_ptr<io::Writer> tryToWriter() override { return nullptr; }
+  std::unique_ptr<io::Writer> TryToWriter() override { return nullptr; }
 
-  bool exists() const override {
+  bool Exists() const override {
     // Exists as a file?
-    if (fs_->files.count(path_)) return true;
+    if (fs->files.count(path)) return true;
     // Exists as a directory?
-    std::string prefix = path_ + "/";
-    for (auto& [key, _] : fs_->files) {
+    std::string prefix = path + "/";
+    for (auto& [key, _] : fs->files) {
       if (key.compare(0, prefix.size(), prefix) == 0) return true;
     }
-    return path_.empty();  // Root always exists
+    return path.empty();  // Root always exists
   }
 };
 
 }  // namespace
 
-FsNode MemoryFs::root() { return FsNode(std::make_shared<FsNodeMemDir>("", this)); }
+FsNode MemoryFs::Root() { return FsNode(std::make_shared<FsNodeMemDir>("", this)); }

--- a/src/game/net/memoryFs.hpp
+++ b/src/game/net/memoryFs.hpp
@@ -12,5 +12,5 @@ struct MemoryFs {
   std::map<std::string, std::vector<uint8_t>> files;
 
   // Create an FsNode representing the root of this memory filesystem.
-  FsNode root();
+  FsNode Root();
 };

--- a/src/game/net/netutil.hpp
+++ b/src/game/net/netutil.hpp
@@ -5,7 +5,7 @@
 
 namespace netutil {
 
-inline uint64_t nowMs() {
+inline uint64_t NowMs() {
   return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();

--- a/src/game/net/session.cpp
+++ b/src/game/net/session.cpp
@@ -9,9 +9,9 @@
 #include "tcArchive.hpp"
 
 NetSession::NetSession(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings,
-                       FsNode tcRoot)
-    : role_(Host),
-      sessionState_(Idle),
+                       FsNode tc_root)
+    : role_(kHost),
+      sessionState_(kIdle),
       common_(std::move(common)),
       settings_(std::move(settings)),
       rollbackPtr_(nullptr),
@@ -24,7 +24,7 @@ NetSession::NetSession(std::shared_ptr<Common> common, std::shared_ptr<Settings>
       mapDataReceived_(false),
       localReady_(false),
       remoteReady_(false),
-      tcRoot_(std::move(tcRoot)),
+      tcRoot_(std::move(tc_root)),
       localTcHash_(0),
       tcResolved_(false),
       originalTcName_(settings_->tc),
@@ -32,136 +32,136 @@ NetSession::NetSession(std::shared_ptr<Common> common, std::shared_ptr<Settings>
       desyncDetected_(false),
       desyncFrame_(0) {
   std::memset(&remotePlayerInfo_, 0, sizeof(remotePlayerInfo_));
-  localSettingsHash_ = computeSettingsHash();
-  localTcHash_ = TcArchive::computeHash(tcRoot_);
-  wireCallbacks();
+  localSettingsHash_ = ComputeSettingsHash();
+  localTcHash_ = tc_archive::ComputeHash(tcRoot_);
+  WireCallbacks();
 }
 
-NetSession::~NetSession() { disconnect(); }
+NetSession::~NetSession() { Disconnect(); }
 
-void NetSession::createController(int localIdx) {
+void NetSession::CreateController(int local_idx) {
   // Wire protocol caps inputDelay at kMaxRollback (see setInputDelay).
   // Clamp the settings value too so pre-fill loops below stay in sync
   // with the controller.
-  if (settings_->inputDelay < 0)
-    settings_->inputDelay = 0;
-  else if (settings_->inputDelay > rollback::kMaxRollback)
-    settings_->inputDelay = rollback::kMaxRollback;
-  rollback_ = std::make_unique<RollbackController>(common_, settings_, localIdx);
-  rollback_->setInputDelay(static_cast<uint32_t>(settings_->inputDelay));
+  if (settings_->input_delay < 0)
+    settings_->input_delay = 0;
+  else if (settings_->input_delay > rollback::kMaxRollback)
+    settings_->input_delay = rollback::kMaxRollback;
+  rollback_ = std::make_unique<RollbackController>(common_, settings_, local_idx);
+  rollback_->SetInputDelay(static_cast<uint32_t>(settings_->input_delay));
 }
 
-void NetSession::wireActiveController() {
-  auto checksumCb = [this](uint8_t generation, uint32_t frame, uint32_t checksum) {
-    transport_.sendChecksum(generation, frame, checksum);
-    onLocalChecksum(frame, checksum);
+void NetSession::WireActiveController() {
+  auto checksum_cb = [this](uint8_t generation, uint32_t frame, uint32_t checksum) {
+    transport_.SendChecksum(generation, frame, checksum);
+    OnLocalChecksum(frame, checksum);
   };
-  auto pauseCb = [this]() { transport_.sendPause(); };
-  auto resumeCb = [this]() { transport_.sendResume(); };
-  auto endMatchCb = [this]() { transport_.sendEndMatch(); };
-  auto peerLeftCb = [this]() { transport_.sendPeerLeft(); };
+  auto pause_cb = [this]() { transport_.SendPause(); };
+  auto resume_cb = [this]() { transport_.SendResume(); };
+  auto end_match_cb = [this]() { transport_.SendEndMatch(); };
+  auto peer_left_cb = [this]() { transport_.SendPeerLeft(); };
 
-  rollback_->setInputCallbacks([this](uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                      uint8_t const* inputs, uint32_t localFrame) {
+  rollback_->SetInputCallbacks([this](uint8_t generation, uint32_t base_frame, uint8_t count,
+                                      uint8_t const* inputs, uint32_t local_frame) {
     // localDelta = simFrame - baseFrame at send time. Encoded as
     // uint8_t; range guaranteed by the controller's K-wide window.
-    uint8_t localDelta = static_cast<uint8_t>(localFrame - baseFrame);
-    transport_.sendInputBatch(generation, baseFrame, count, localDelta, inputs);
+    uint8_t local_delta = static_cast<uint8_t>(local_frame - base_frame);
+    transport_.SendInputBatch(generation, base_frame, count, local_delta, inputs);
   });
-  rollback_->setChecksumCallback(checksumCb);
-  rollback_->setPauseCallbacks(pauseCb, resumeCb);
-  rollback_->setEndMatchCallback(endMatchCb);
-  rollback_->setPeerLeftCallback(peerLeftCb);
+  rollback_->SetChecksumCallback(checksum_cb);
+  rollback_->SetPauseCallbacks(pause_cb, resume_cb);
+  rollback_->SetEndMatchCallback(end_match_cb);
+  rollback_->SetPeerLeftCallback(peer_left_cb);
 }
 
-Game& NetSession::activeGame() { return rollback_->game; }
+Game& NetSession::ActiveGame() { return rollback_->game; }
 
-bool NetSession::hostGame(uint16_t port) {
-  if (sessionState_ != Idle) return false;
+bool NetSession::HostGame(uint16_t port) {
+  if (sessionState_ != kIdle) return false;
 
-  role_ = Host;
+  role_ = kHost;
   gameSeed_ = static_cast<uint32_t>(std::time(nullptr));
 
   // Controller is created in tryStartGame once both sides have agreed
   // on settings. Pre-Playing transport callbacks tolerate a null
   // controller — buffered inputs flush on creation.
 
-  if (!transport_.host(port)) {
-    sessionState_ = Failed;
+  if (!transport_.Host(port)) {
+    sessionState_ = kFailed;
     return false;
   }
-  sessionState_ = WaitingForPeer;
+  sessionState_ = kWaitingForPeer;
   return true;
 }
 
-bool NetSession::joinGame(const std::string& address, uint16_t port) {
-  if (sessionState_ != Idle) return false;
+bool NetSession::JoinGame(const std::string& address, uint16_t port) {
+  if (sessionState_ != kIdle) return false;
 
-  role_ = Client;
+  role_ = kClient;
   gameSeed_ = 0;  // Will be set by host's handshake
 
-  if (!transport_.connect(address, port)) {
-    sessionState_ = Failed;
+  if (!transport_.Connect(address, port)) {
+    sessionState_ = kFailed;
     return false;
   }
-  sessionState_ = WaitingForPeer;
+  sessionState_ = kWaitingForPeer;
   return true;
 }
 
-bool NetSession::hostWithTransport(NetTransport&& transport) {
-  if (sessionState_ != Idle) return false;
+bool NetSession::HostWithTransport(NetTransport&& transport) {
+  if (sessionState_ != kIdle) return false;
 
-  role_ = Host;
+  role_ = kHost;
   gameSeed_ = static_cast<uint32_t>(std::time(nullptr));
 
   transport_ = std::move(transport);
-  wireCallbacks();
-  sessionState_ = WaitingForPeer;
+  WireCallbacks();
+  sessionState_ = kWaitingForPeer;
   return true;
 }
 
-bool NetSession::connectWithTransport(NetTransport&& transport, const std::string& peerAddr,
-                                      uint16_t peerPort) {
-  if (sessionState_ != Idle) return false;
+bool NetSession::ConnectWithTransport(NetTransport&& transport, const std::string& peer_addr,
+                                      uint16_t peer_port) {
+  if (sessionState_ != kIdle) return false;
 
-  role_ = Client;
+  role_ = kClient;
   gameSeed_ = 0;
 
   transport_ = std::move(transport);
-  wireCallbacks();
+  WireCallbacks();
 
-  if (!transport_.connectExisting(peerAddr, peerPort)) {
-    sessionState_ = Failed;
+  if (!transport_.ConnectExisting(peer_addr, peer_port)) {
+    sessionState_ = kFailed;
     return false;
   }
 
-  sessionState_ = WaitingForPeer;
+  sessionState_ = kWaitingForPeer;
   return true;
 }
 
-void NetSession::update() {
-  if (sessionState_ == Idle || sessionState_ == Failed || sessionState_ == Disconnected) return;
+void NetSession::Update() {
+  if (sessionState_ == kIdle || sessionState_ == kFailed || sessionState_ == kDisconnected) return;
 
-  transport_.poll();
+  transport_.Poll();
 
-  if (transport_.state() == NetTransport::Failed) {
-    sessionState_ = Failed;
+  if (transport_.State() == NetTransport::kFailed) {
+    sessionState_ = kFailed;
     return;
   }
 
-  if (transport_.state() == NetTransport::Disconnected && sessionState_ != Idle) {
-    sessionState_ = Disconnected;
+  if (transport_.State() == NetTransport::kDisconnected && sessionState_ != kIdle) {
+    sessionState_ = kDisconnected;
     return;
   }
 }
 
-void NetSession::disconnect() {
-  transport_.disconnect();
+void NetSession::Disconnect() {
+  transport_.Disconnect();
   // transport_.disconnect() tears down the ENet host but leaves the
   // std::function callbacks bound to `this`. They stay valid until the
   // next session replaces transport_ via host/connectWithTransport,
   // which calls wireCallbacks() itself.
-  sessionState_ = Idle;
+  sessionState_ = kIdle;
   rollback_.reset();
   rollbackPtr_ = nullptr;
   handshakeReceived_ = false;
@@ -175,50 +175,50 @@ void NetSession::disconnect() {
   prePlayingInputBatches_.clear();
 
   // Restore client's original TC if it was changed during the session
-  if (role_ == Client && tcMemFs_) {
+  if (role_ == kClient && tcMemFs_) {
     settings_->tc = originalTcName_;
-    if (onTcReloaded) onTcReloaded(originalCommon_);
+    if (on_tc_reloaded) on_tc_reloaded(originalCommon_);
     common_ = originalCommon_;
     tcMemFs_.reset();
   }
 }
 
-void NetSession::onConnected() {
-  sessionState_ = Handshaking;
+void NetSession::OnConnected() {
+  sessionState_ = kHandshaking;
 
   // Host sends TC info first so client can verify/request TC data
-  if (role_ == Host) {
-    transport_.sendTcInfo(localTcHash_, settings_->tc);
+  if (role_ == kHost) {
+    transport_.SendTcInfo(localTcHash_, settings_->tc);
     tcResolved_ = true;  // Host always has correct TC
   }
 
   // Both sides send their handshake.
   // Host includes the seed; client sends 0 (host's seed is authoritative).
-  uint32_t seedToSend = (role_ == Host) ? gameSeed_ : 0;
-  transport_.sendHandshake(seedToSend, localSettingsHash_);
+  uint32_t seed_to_send = (role_ == kHost) ? gameSeed_ : 0;
+  transport_.SendHandshake(seed_to_send, localSettingsHash_);
   handshakeSent_ = true;
 
-  sendLocalPlayerInfo();
+  SendLocalPlayerInfo();
 
   // Host sends authoritative match settings
-  if (role_ == Host) {
+  if (role_ == kHost) {
     NetTransport::MatchSettingsData msd{};
     msd.lives = settings_->lives;
-    msd.loadingTime = settings_->loadingTime;
-    msd.gameMode = settings_->gameMode;
+    msd.loading_time = settings_->loading_time;
+    msd.game_mode = settings_->game_mode;
     msd.blood = settings_->blood;
-    msd.maxBonuses = settings_->maxBonuses;
-    msd.timeToLose = settings_->timeToLose;
-    msd.flagsToWin = settings_->flagsToWin;
-    msd.loadChange = settings_->loadChange ? 1 : 0;
-    for (int i = 0; i < 40; ++i) msd.weapTable[i] = settings_->weapTable[i];
-    msd.regenerateLevel = settings_->regenerateLevel ? 1 : 0;
+    msd.max_bonuses = settings_->max_bonuses;
+    msd.time_to_lose = settings_->time_to_lose;
+    msd.flags_to_win = settings_->flags_to_win;
+    msd.load_change = settings_->load_change ? 1 : 0;
+    for (int i = 0; i < 40; ++i) msd.weap_table[i] = settings_->weap_table[i];
+    msd.regenerate_level = settings_->regenerate_level ? 1 : 0;
     msd.shadow = settings_->shadow ? 1 : 0;
-    msd.namesOnBonuses = settings_->namesOnBonuses ? 1 : 0;
-    msd.bloodParticleMax = settings_->bloodParticleMax;
-    msd.zoneTimeout = settings_->zoneTimeout;
-    msd.inputDelay = settings_->inputDelay;
-    transport_.sendMatchSettings(msd);
+    msd.names_on_bonuses = settings_->names_on_bonuses ? 1 : 0;
+    msd.blood_particle_max = settings_->blood_particle_max;
+    msd.zone_timeout = settings_->zone_timeout;
+    msd.input_delay = settings_->input_delay;
+    transport_.SendMatchSettings(msd);
     matchSettingsReceived_ = true;  // Host already has correct settings
     mapDataReceived_ = true;        // Host generates locally
   }
@@ -226,18 +226,18 @@ void NetSession::onConnected() {
   // Check if we can start (all data received)
   if (handshakeReceived_ && playerInfoReceived_ && matchSettingsReceived_ && mapDataReceived_ &&
       tcResolved_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::onDisconnected() { sessionState_ = Disconnected; }
+void NetSession::OnDisconnected() { sessionState_ = kDisconnected; }
 
-void NetSession::onHandshake(uint32_t seed, uint32_t settingsHash) {
+void NetSession::OnHandshake(uint32_t seed, uint32_t settings_hash) {
   // Client uses the host's seed
-  if (role_ == Client) {
+  if (role_ == kClient) {
     gameSeed_ = seed;
   }
 
-  if (sessionState_ == Rematch) {
+  if (sessionState_ == kRematch) {
     // During rematch, handshake signals the host is starting the game.
     // Client needs to wait for map data before creating the controller.
     handshakeReceived_ = true;
@@ -248,274 +248,274 @@ void NetSession::onHandshake(uint32_t seed, uint32_t settingsHash) {
 
   if (handshakeSent_ && playerInfoReceived_ && matchSettingsReceived_ && mapDataReceived_ &&
       tcResolved_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::onRemoteInputBatch(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                    uint8_t const* inputs, uint32_t remoteLocalFrame) {
+void NetSession::OnRemoteInputBatch(uint8_t generation, uint32_t base_frame, uint8_t count,
+                                    uint8_t const* inputs, uint32_t remote_local_frame) {
   if (rollbackPtr_) {
-    rollbackPtr_->injectRemoteBatch(generation, baseFrame, count, inputs, remoteLocalFrame);
+    rollbackPtr_->InjectRemoteBatch(generation, base_frame, count, inputs, remote_local_frame);
     return;
   }
 
-  if (prePlayingInputBatches_.size() >= MAX_PRE_PLAYING_BATCHES) return;
+  if (prePlayingInputBatches_.size() >= kMaxPrePlayingBatches) return;
   if (count > rollback::kMaxRollback + 1) return;
   PendingInputBatch b{};
   b.generation = generation;
-  b.baseFrame = baseFrame;
+  b.base_frame = base_frame;
   b.count = count;
   for (uint8_t i = 0; i < count; ++i) b.inputs[i] = inputs[i];
-  b.remoteLocalFrame = remoteLocalFrame;
+  b.remote_local_frame = remote_local_frame;
   prePlayingInputBatches_.push_back(b);
 }
 
-void NetSession::onPlayerInfo(const NetTransport::PlayerInfo& info) {
+void NetSession::OnPlayerInfo(const NetTransport::PlayerInfo& info) {
   remotePlayerInfo_ = info;
   playerInfoReceived_ = true;
 
   // During Rematch, PlayerInfo is re-sent so startRematch{,Client}() can
   // pick up the peer's latest weapons. The rematch start is driven by
   // toggleReady / onHandshake, not by this packet.
-  if (sessionState_ == Rematch) return;
+  if (sessionState_ == kRematch) return;
 
   if (handshakeSent_ && handshakeReceived_ && matchSettingsReceived_ && mapDataReceived_ &&
       tcResolved_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::onMatchSettings(const NetTransport::MatchSettingsData& data) {
+void NetSession::OnMatchSettings(const NetTransport::MatchSettingsData& data) {
   // Client applies host's authoritative settings
-  if (role_ == Client) {
+  if (role_ == kClient) {
     settings_->lives = data.lives;
-    settings_->loadingTime = data.loadingTime;
-    settings_->gameMode = data.gameMode;
+    settings_->loading_time = data.loading_time;
+    settings_->game_mode = data.game_mode;
     settings_->blood = data.blood;
-    settings_->maxBonuses = data.maxBonuses;
-    settings_->timeToLose = data.timeToLose;
-    settings_->flagsToWin = data.flagsToWin;
-    settings_->loadChange = data.loadChange != 0;
-    for (int i = 0; i < 40; ++i) settings_->weapTable[i] = data.weapTable[i];
-    settings_->regenerateLevel = data.regenerateLevel != 0;
+    settings_->max_bonuses = data.max_bonuses;
+    settings_->time_to_lose = data.time_to_lose;
+    settings_->flags_to_win = data.flags_to_win;
+    settings_->load_change = data.load_change != 0;
+    for (int i = 0; i < 40; ++i) settings_->weap_table[i] = data.weap_table[i];
+    settings_->regenerate_level = data.regenerate_level != 0;
     settings_->shadow = data.shadow != 0;
-    settings_->namesOnBonuses = data.namesOnBonuses != 0;
-    settings_->bloodParticleMax = data.bloodParticleMax;
-    settings_->zoneTimeout = data.zoneTimeout;
+    settings_->names_on_bonuses = data.names_on_bonuses != 0;
+    settings_->blood_particle_max = data.blood_particle_max;
+    settings_->zone_timeout = data.zone_timeout;
     // inputDelay is host-authoritative.
-    settings_->inputDelay = data.inputDelay;
+    settings_->input_delay = data.input_delay;
   }
 
   matchSettingsReceived_ = true;
 
   if (handshakeSent_ && handshakeReceived_ && playerInfoReceived_ && mapDataReceived_ &&
       tcResolved_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::onMapData(const void* data, size_t len) {
-  if (role_ != Client) return;
+void NetSession::OnMapData(const void* data, size_t len) {
+  if (role_ != kClient) return;
 
   // Reject oversized map data to prevent memory exhaustion
-  static constexpr size_t MAX_MAP_DATA = 10 * 1024 * 1024;  // 10 MB
-  if (len > MAX_MAP_DATA) return;
+  static constexpr size_t kMaxMapData = 10 * 1024 * 1024;  // 10 MB
+  if (len > kMaxMapData) return;
 
   receivedMapData_.assign(static_cast<const uint8_t*>(data),
                           static_cast<const uint8_t*>(data) + len);
   mapDataReceived_ = true;
 
-  if (sessionState_ == Rematch && handshakeReceived_) {
+  if (sessionState_ == kRematch && handshakeReceived_) {
     // We have the seed and map — start the client-side rematch
-    startRematchClient();
+    StartRematchClient();
     return;
   }
 
   if (handshakeSent_ && handshakeReceived_ && playerInfoReceived_ && matchSettingsReceived_ &&
       tcResolved_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::onPause() {
-  if (rollbackPtr_) rollbackPtr_->setRemotePaused(true);
+void NetSession::OnPause() {
+  if (rollbackPtr_) rollbackPtr_->SetRemotePaused(true);
 }
 
-void NetSession::onResume() {
-  if (rollbackPtr_) rollbackPtr_->setRemotePaused(false);
+void NetSession::OnResume() {
+  if (rollbackPtr_) rollbackPtr_->SetRemotePaused(false);
 }
 
-void NetSession::onRemoteEndMatch() {
-  if (rollbackPtr_) rollbackPtr_->endMatch();
+void NetSession::OnRemoteEndMatch() {
+  if (rollbackPtr_) rollbackPtr_->EndMatch();
 }
 
-void NetSession::onRemotePeerLeft() {
-  if (rollbackPtr_) rollbackPtr_->peerLeft();
+void NetSession::OnRemotePeerLeft() {
+  if (rollbackPtr_) rollbackPtr_->PeerLeft();
 }
 
-void NetSession::sendPause() { transport_.sendPause(); }
+void NetSession::SendPause() { transport_.SendPause(); }
 
-void NetSession::sendResume() { transport_.sendResume(); }
+void NetSession::SendResume() { transport_.SendResume(); }
 
-void NetSession::wireCallbacks() {
-  transport_.onConnected = [this]() { onConnected(); };
-  transport_.onDisconnected = [this]() { onDisconnected(); };
-  transport_.onHandshake = [this](uint32_t seed, uint32_t hash) { onHandshake(seed, hash); };
-  transport_.onRemoteInputBatch = [this](uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                         uint8_t const* inputs, uint32_t remoteLocalFrame) {
-    onRemoteInputBatch(generation, baseFrame, count, inputs, remoteLocalFrame);
+void NetSession::WireCallbacks() {
+  transport_.on_connected = [this]() { OnConnected(); };
+  transport_.on_disconnected = [this]() { OnDisconnected(); };
+  transport_.on_handshake = [this](uint32_t seed, uint32_t hash) { OnHandshake(seed, hash); };
+  transport_.on_remote_input_batch = [this](uint8_t generation, uint32_t base_frame, uint8_t count,
+                                         uint8_t const* inputs, uint32_t remote_local_frame) {
+    OnRemoteInputBatch(generation, base_frame, count, inputs, remote_local_frame);
   };
-  transport_.onPlayerInfo = [this](const NetTransport::PlayerInfo& info) { onPlayerInfo(info); };
-  transport_.onMatchSettings = [this](const NetTransport::MatchSettingsData& data) {
-    onMatchSettings(data);
+  transport_.on_player_info = [this](const NetTransport::PlayerInfo& info) { OnPlayerInfo(info); };
+  transport_.on_match_settings = [this](const NetTransport::MatchSettingsData& data) {
+    OnMatchSettings(data);
   };
-  transport_.onMapData = [this](const void* data, size_t len) { onMapData(data, len); };
-  transport_.onPause = [this]() { onPause(); };
-  transport_.onResume = [this]() { onResume(); };
-  transport_.onEndMatch = [this]() { onRemoteEndMatch(); };
-  transport_.onPeerLeft = [this]() { onRemotePeerLeft(); };
-  transport_.onChecksum = [this](uint8_t generation, uint32_t frame, uint32_t checksum) {
-    onChecksum(generation, frame, checksum);
+  transport_.on_map_data = [this](const void* data, size_t len) { OnMapData(data, len); };
+  transport_.on_pause = [this]() { OnPause(); };
+  transport_.on_resume = [this]() { OnResume(); };
+  transport_.on_end_match = [this]() { OnRemoteEndMatch(); };
+  transport_.on_peer_left = [this]() { OnRemotePeerLeft(); };
+  transport_.on_checksum = [this](uint8_t generation, uint32_t frame, uint32_t checksum) {
+    OnChecksum(generation, frame, checksum);
   };
-  transport_.onRematchReady = [this](bool ready) { onRematchReady(ready); };
-  transport_.onRematchLevel = [this](bool random, std::string file) {
-    onRematchLevel(random, std::move(file));
+  transport_.on_rematch_ready = [this](bool ready) { OnRematchReady(ready); };
+  transport_.on_rematch_level = [this](bool random, std::string file) {
+    OnRematchLevel(random, std::move(file));
   };
-  transport_.onTcInfo = [this](uint32_t hash, std::string name) {
-    onTcInfo(hash, std::move(name));
+  transport_.on_tc_info = [this](uint32_t hash, std::string name) {
+    OnTcInfo(hash, std::move(name));
   };
-  transport_.onTcResponse = [this](bool needData) { onTcResponse(needData); };
-  transport_.onTcData = [this](const void* data, size_t len) { onTcData(data, len); };
+  transport_.on_tc_response = [this](bool need_data) { OnTcResponse(need_data); };
+  transport_.on_tc_data = [this](const void* data, size_t len) { OnTcData(data, len); };
 }
 
-void NetSession::onTcInfo(uint32_t hash, std::string name) {
+void NetSession::OnTcInfo(uint32_t hash, std::string name) {
   // Client receives TC info from host
-  if (role_ != Client) return;
+  if (role_ != kClient) return;
 
   if (name == settings_->tc && hash == localTcHash_) {
     // Same TC, no transfer needed
-    transport_.sendTcResponse(false);
+    transport_.SendTcResponse(false);
     tcResolved_ = true;
 
     if (handshakeSent_ && handshakeReceived_ && playerInfoReceived_ && matchSettingsReceived_ &&
         mapDataReceived_)
-      tryStartGame();
+      TryStartGame();
   } else {
     // Different TC — request the data
     settings_->tc = name;
-    transport_.sendTcResponse(true);
+    transport_.SendTcResponse(true);
   }
 }
 
-void NetSession::onTcResponse(bool needData) {
+void NetSession::OnTcResponse(bool need_data) {
   // Host receives client's response about TC
-  if (role_ != Host) return;
+  if (role_ != kHost) return;
 
-  if (needData) {
+  if (need_data) {
     // Client needs the TC archive — pack and send it
-    auto archive = TcArchive::pack(tcRoot_);
-    transport_.sendTcData(archive.data(), archive.size());
+    auto archive = tc_archive::Pack(tcRoot_);
+    transport_.SendTcData(archive.data(), archive.size());
   }
   // If !needData, the client already has the TC — nothing more to do
 }
 
-void NetSession::onTcData(const void* data, size_t len) {
+void NetSession::OnTcData(const void* data, size_t len) {
   // Client receives TC archive from host
-  if (role_ != Client) return;
+  if (role_ != kClient) return;
 
   // Reject oversized TC data
-  static constexpr size_t MAX_TC_DATA = 50 * 1024 * 1024;  // 50 MB
-  if (len > MAX_TC_DATA) return;
+  static constexpr size_t kMaxTcData = 50 * 1024 * 1024;  // 50 MB
+  if (len > kMaxTcData) return;
 
-  auto files = TcArchive::unpack(static_cast<const uint8_t*>(data), len);
+  auto files = tc_archive::Unpack(static_cast<const uint8_t*>(data), len);
   if (files.empty()) return;
 
   // Load TC from memory (no disk writes — platform-agnostic)
-  auto memFs = std::make_shared<MemoryFs>();
+  auto mem_fs = std::make_shared<MemoryFs>();
   for (auto& file : files) {
-    memFs->files[file.name] = std::move(file.data);
+    mem_fs->files[file.name] = std::move(file.data);
   }
 
   // Keep the MemoryFs alive by storing it in the session
-  tcMemFs_ = memFs;
+  tcMemFs_ = mem_fs;
 
   // Reload Common from the in-memory TC
-  auto newCommon = std::make_shared<Common>();
-  newCommon->load(memFs->root());
+  auto new_common = std::make_shared<Common>();
+  new_common->load(mem_fs->Root());
 
-  common_ = newCommon;
+  common_ = new_common;
 
-  if (onTcReloaded) onTcReloaded(newCommon);
+  if (on_tc_reloaded) on_tc_reloaded(new_common);
 
   tcResolved_ = true;
 
   if (handshakeSent_ && handshakeReceived_ && playerInfoReceived_ && matchSettingsReceived_ &&
       mapDataReceived_)
-    tryStartGame();
+    TryStartGame();
 }
 
-void NetSession::applyRemotePlayerInfo(int remoteIdx) {
-  Worm* remoteWorm = activeGame().wormByIdx(remoteIdx);
+void NetSession::ApplyRemotePlayerInfo(int remote_idx) {
+  Worm* remote_worm = ActiveGame().WormByIdx(remote_idx);
   // Create a distinct copy so we don't mutate the saved player profile
-  auto remoteWs = std::make_shared<WormSettings>(*remoteWorm->settings);
-  for (int i = 0; i < 5; ++i) remoteWs->weapons[i] = remotePlayerInfo_.weapons[i];
-  remoteWs->color = remotePlayerInfo_.color;
-  for (int i = 0; i < 3; ++i) remoteWs->rgb[i] = remotePlayerInfo_.rgb[i];
-  remoteWs->name.assign(remotePlayerInfo_.name,
+  auto remote_ws = std::make_shared<WormSettings>(*remote_worm->settings);
+  for (int i = 0; i < 5; ++i) remote_ws->weapons[i] = remotePlayerInfo_.weapons[i];
+  remote_ws->color = remotePlayerInfo_.color;
+  for (int i = 0; i < 3; ++i) remote_ws->rgb[i] = remotePlayerInfo_.rgb[i];
+  remote_ws->name.assign(remotePlayerInfo_.name,
                         strnlen(remotePlayerInfo_.name, sizeof(remotePlayerInfo_.name)));
-  remoteWorm->settings = remoteWs;
+  remote_worm->settings = remote_ws;
 }
 
-void NetSession::prefillRemoteInput() {
+void NetSession::PrefillRemoteInput() {
   // Pre-fill exactly inputDelay frames of empty remote input. These are
   // the frames whose remote input the remote peer literally cannot have
   // recorded yet (with inputDelay=D, the remote first records its
   // localInputs[D] at simFrame=0). Pre-filling further would overwrite
   // frames the remote *will* fill in — injectRemoteInput drops frames
   // <= confirmedSimFrame_, so the rollback path couldn't correct later.
-  uint32_t preFillCount = static_cast<uint32_t>(settings_->inputDelay);
-  for (uint32_t i = 0; i < preFillCount; ++i) rollback_->injectRemoteInput(i, 0);
+  uint32_t pre_fill_count = static_cast<uint32_t>(settings_->input_delay);
+  for (uint32_t i = 0; i < pre_fill_count; ++i) rollback_->InjectRemoteInput(i, 0);
 }
 
-void NetSession::beginPlaying(int localIdx, bool isRematch) {
-  int remoteIdx = 1 - localIdx;
-  createController(localIdx);
-  applyRemotePlayerInfo(remoteIdx);
-  activeGame().rand.seed(gameSeed_);
+void NetSession::BeginPlaying(int local_idx, bool is_rematch) {
+  int remote_idx = 1 - local_idx;
+  CreateController(local_idx);
+  ApplyRemotePlayerInfo(remote_idx);
+  ActiveGame().rand.Seed(gameSeed_);
 
-  if (role_ == Host) {
-    generateAndSendMap();
-    rollback_->setLevelPreloaded();
+  if (role_ == kHost) {
+    GenerateAndSendMap();
+    rollback_->SetLevelPreloaded();
   } else {
-    rollback_->loadLevelFromData(receivedMapData_);
+    rollback_->LoadLevelFromData(receivedMapData_);
     receivedMapData_.clear();
   }
 
-  wireActiveController();
-  prefillRemoteInput();
+  WireActiveController();
+  PrefillRemoteInput();
   rollbackPtr_ = rollback_.get();
 
   for (auto const& b : prePlayingInputBatches_) {
-    rollbackPtr_->injectRemoteBatch(b.generation, b.baseFrame, b.count, b.inputs.data(),
-                                    b.remoteLocalFrame);
+    rollbackPtr_->InjectRemoteBatch(b.generation, b.base_frame, b.count, b.inputs.data(),
+                                    b.remote_local_frame);
   }
   prePlayingInputBatches_.clear();
 
-  if (isRematch) {
+  if (is_rematch) {
     localReady_ = false;
     remoteReady_ = false;
     // Client clears handshakeReceived_ so the next rematch's seed can land.
-    if (role_ == Client) handshakeReceived_ = false;
+    if (role_ == kClient) handshakeReceived_ = false;
   }
 
-  sessionState_ = Playing;
+  sessionState_ = kPlaying;
 }
 
-void NetSession::tryStartGame() {
-  if (sessionState_ == Playing) return;
-  beginPlaying((role_ == Host) ? 0 : 1, /*isRematch=*/false);
+void NetSession::TryStartGame() {
+  if (sessionState_ == kPlaying) return;
+  BeginPlaying((role_ == kHost) ? 0 : 1, /*isRematch=*/false);
 }
 
-void NetSession::enterRematch() {
-  if (sessionState_ != Playing) return;
+void NetSession::EnterRematch() {
+  if (sessionState_ != kPlaying) return;
 
-  sessionState_ = Rematch;
+  sessionState_ = kRematch;
   localReady_ = false;
   remoteReady_ = false;
 
@@ -524,94 +524,94 @@ void NetSession::enterRematch() {
   rollbackPtr_ = nullptr;
 
   // Reset per-game handshake flags for the next round
-  mapDataReceived_ = (role_ == Host);  // host generates locally
+  mapDataReceived_ = (role_ == kHost);  // host generates locally
   receivedMapData_.clear();
 
   // Refresh the peer's view of our weapons. Without this, startRematch
   // {,Client}() would reapply the connect-time profile and each peer
   // would see the other's pre-match weapons in round 2's weapon select.
-  sendLocalPlayerInfo();
+  SendLocalPlayerInfo();
 }
 
-void NetSession::sendLocalPlayerInfo() {
-  auto& netWs = settings_->wormSettings[Settings::NetworkPlayerIdx];
+void NetSession::SendLocalPlayerInfo() {
+  auto& net_ws = settings_->worm_settings[Settings::kNetworkPlayerIdx];
   NetTransport::PlayerInfo info{};
-  for (int i = 0; i < 5; ++i) info.weapons[i] = netWs->weapons[i];
-  info.color = netWs->color;
-  for (int i = 0; i < 3; ++i) info.rgb[i] = netWs->rgb[i];
-  std::strncpy(info.name, netWs->name.c_str(), sizeof(info.name) - 1);
+  for (int i = 0; i < 5; ++i) info.weapons[i] = net_ws->weapons[i];
+  info.color = net_ws->color;
+  for (int i = 0; i < 3; ++i) info.rgb[i] = net_ws->rgb[i];
+  std::strncpy(info.name, net_ws->name.c_str(), sizeof(info.name) - 1);
   info.name[sizeof(info.name) - 1] = '\0';
-  transport_.sendPlayerInfo(info);
+  transport_.SendPlayerInfo(info);
 }
 
-void NetSession::toggleReady() {
-  if (sessionState_ != Rematch) return;
+void NetSession::ToggleReady() {
+  if (sessionState_ != kRematch) return;
 
   localReady_ = !localReady_;
-  transport_.sendRematchReady(localReady_);
+  transport_.SendRematchReady(localReady_);
 
   // Only host initiates the rematch start
-  if (role_ == Host && localReady_ && remoteReady_) startRematch();
+  if (role_ == kHost && localReady_ && remoteReady_) StartRematch();
 }
 
-void NetSession::setRematchLevel(bool randomLevel, const std::string& levelFile) {
-  if (sessionState_ != Rematch || role_ != Host) return;
+void NetSession::SetRematchLevel(bool random_level, const std::string& level_file) {
+  if (sessionState_ != kRematch || role_ != kHost) return;
 
-  settings_->randomLevel = randomLevel;
-  settings_->levelFile = levelFile;
+  settings_->random_level = random_level;
+  settings_->level_file = level_file;
 
-  transport_.sendRematchLevel(randomLevel, levelFile);
+  transport_.SendRematchLevel(random_level, level_file);
 
   // Reset ready states when level changes
   if (localReady_) {
     localReady_ = false;
-    transport_.sendRematchReady(false);
+    transport_.SendRematchReady(false);
   }
   if (remoteReady_) remoteReady_ = false;
 }
 
-void NetSession::onRematchReady(bool ready) {
-  if (sessionState_ != Rematch) return;
+void NetSession::OnRematchReady(bool ready) {
+  if (sessionState_ != kRematch) return;
 
   remoteReady_ = ready;
 
   // Only host initiates the rematch start
-  if (role_ == Host && localReady_ && remoteReady_) startRematch();
+  if (role_ == kHost && localReady_ && remoteReady_) StartRematch();
 }
 
-void NetSession::onRematchLevel(bool randomLevel, std::string levelFile) {
-  if (sessionState_ != Rematch || role_ != Client) return;
+void NetSession::OnRematchLevel(bool random_level, std::string level_file) {
+  if (sessionState_ != kRematch || role_ != kClient) return;
 
-  settings_->randomLevel = randomLevel;
-  settings_->levelFile = std::move(levelFile);
+  settings_->random_level = random_level;
+  settings_->level_file = std::move(level_file);
 
   // Reset ready states when level changes
   localReady_ = false;
   remoteReady_ = false;
 }
 
-void NetSession::startRematch() {
+void NetSession::StartRematch() {
   // Only the host calls this directly. The client starts via onHandshake+onMapData.
-  if (sessionState_ != Rematch || role_ != Host) return;
+  if (sessionState_ != kRematch || role_ != kHost) return;
 
   // Generate a new seed and send it before beginPlaying generates the map
   gameSeed_ = static_cast<uint32_t>(std::time(nullptr));
-  transport_.sendHandshake(gameSeed_, 0);
+  transport_.SendHandshake(gameSeed_, 0);
 
-  beginPlaying(/*localIdx=*/0, /*isRematch=*/true);
+  BeginPlaying(/*localIdx=*/0, /*isRematch=*/true);
 }
 
-void NetSession::startRematchClient() {
+void NetSession::StartRematchClient() {
   // Called on the client side when handshake (seed) + map data are both received
-  if (sessionState_ != Rematch || role_ != Client) return;
+  if (sessionState_ != kRematch || role_ != kClient) return;
 
-  beginPlaying(/*localIdx=*/1, /*isRematch=*/true);
+  BeginPlaying(/*localIdx=*/1, /*isRematch=*/true);
 }
 
-void NetSession::generateAndSendMap() {
+void NetSession::GenerateAndSendMap() {
   // Generate the level on the host
-  Game& g = activeGame();
-  g.level.generateFromSettings(*g.common, *g.settings, g.rand);
+  Game& g = ActiveGame();
+  g.level.GenerateFromSettings(*g.common, *g.settings, g.rand);
 
   Level& level = g.level;
 
@@ -619,37 +619,37 @@ void NetSession::generateAndSendMap() {
   //          + rand_last(4) + pixel_data(w*h) + palette(768)
   uint16_t w = static_cast<uint16_t>(level.width);
   uint16_t h = static_cast<uint16_t>(level.height);
-  std::string randState = g.rand.serialize();
-  uint32_t randStateLen = static_cast<uint32_t>(randState.size());
-  uint32_t randLast = g.rand.last;
-  size_t pixelDataSize = static_cast<size_t>(w) * h;
-  size_t rawSize = 4 + 4 + randStateLen + 4 + pixelDataSize + 768;
+  std::string rand_state = g.rand.serialize();
+  uint32_t rand_state_len = static_cast<uint32_t>(rand_state.size());
+  uint32_t rand_last = g.rand.last;
+  size_t pixel_data_size = static_cast<size_t>(w) * h;
+  size_t raw_size = 4 + 4 + rand_state_len + 4 + pixel_data_size + 768;
 
-  std::vector<uint8_t> raw(rawSize);
+  std::vector<uint8_t> raw(raw_size);
   std::memcpy(raw.data(), &w, 2);
   std::memcpy(raw.data() + 2, &h, 2);
-  std::memcpy(raw.data() + 4, &randStateLen, 4);
-  std::memcpy(raw.data() + 8, randState.data(), randStateLen);
-  std::memcpy(raw.data() + 8 + randStateLen, &randLast, 4);
-  size_t pixelsOffset = 8 + randStateLen + 4;
-  std::memcpy(raw.data() + pixelsOffset, level.data.data(), pixelDataSize);
+  std::memcpy(raw.data() + 4, &rand_state_len, 4);
+  std::memcpy(raw.data() + 8, rand_state.data(), rand_state_len);
+  std::memcpy(raw.data() + 8 + rand_state_len, &rand_last, 4);
+  size_t pixels_offset = 8 + rand_state_len + 4;
+  std::memcpy(raw.data() + pixels_offset, level.data.data(), pixel_data_size);
 
   // Palette
-  uint8_t* palPtr = raw.data() + pixelsOffset + pixelDataSize;
+  uint8_t* pal_ptr = raw.data() + pixels_offset + pixel_data_size;
   for (int i = 0; i < 256; ++i) {
-    palPtr[i * 3 + 0] = level.origpal.entries[i].r;
-    palPtr[i * 3 + 1] = level.origpal.entries[i].g;
-    palPtr[i * 3 + 2] = level.origpal.entries[i].b;
+    pal_ptr[i * 3 + 0] = level.origpal.entries[i].r;
+    pal_ptr[i * 3 + 1] = level.origpal.entries[i].g;
+    pal_ptr[i * 3 + 2] = level.origpal.entries[i].b;
   }
 
   // Compress with miniz
-  mz_ulong compBound = mz_compressBound(static_cast<mz_ulong>(rawSize));
-  std::vector<uint8_t> compressed(compBound);
-  mz_ulong compSize = compBound;
+  mz_ulong comp_bound = mz_compressBound(static_cast<mz_ulong>(raw_size));
+  std::vector<uint8_t> compressed(comp_bound);
+  mz_ulong comp_size = comp_bound;
   int status =
-      mz_compress(compressed.data(), &compSize, raw.data(), static_cast<mz_ulong>(rawSize));
+      mz_compress(compressed.data(), &comp_size, raw.data(), static_cast<mz_ulong>(raw_size));
   if (status == MZ_OK) {
-    compressed.resize(compSize);
+    compressed.resize(comp_size);
   } else {
     // Fallback: send uncompressed
     compressed = std::move(raw);
@@ -658,20 +658,20 @@ void NetSession::generateAndSendMap() {
   // Send: compressed flag(1) + uncompressedSize(4) + data
   std::vector<uint8_t> packet(1 + 4 + compressed.size());
   packet[0] = (status == MZ_OK) ? 1 : 0;
-  uint32_t rawSize32 = static_cast<uint32_t>(rawSize);
-  std::memcpy(packet.data() + 1, &rawSize32, 4);
+  uint32_t raw_size32 = static_cast<uint32_t>(raw_size);
+  std::memcpy(packet.data() + 1, &raw_size32, 4);
   std::memcpy(packet.data() + 5, compressed.data(), compressed.size());
 
-  transport_.sendMapData(packet.data(), packet.size());
+  transport_.SendMapData(packet.data(), packet.size());
 }
 
-std::unique_ptr<Controller> NetSession::releaseController() {
+std::unique_ptr<Controller> NetSession::ReleaseController() {
   // Return the controller as a polymorphic Controller. The session keeps
   // its typed raw pointer for inject/pause/end dispatch.
   return std::move(rollback_);
 }
 
-uint32_t NetSession::computeSettingsHash() const {
+uint32_t NetSession::ComputeSettingsHash() const {
   // Hash the gameplay-relevant settings to detect mismatches.
   // Uses a simple FNV-1a hash over the key fields.
   uint32_t hash = 2166136261u;
@@ -683,18 +683,18 @@ uint32_t NetSession::computeSettingsHash() const {
   };
 
   mix(settings_->lives);
-  mix(settings_->loadChange ? 1u : 0u);
-  mix(settings_->maxBonuses);
+  mix(settings_->load_change ? 1u : 0u);
+  mix(settings_->max_bonuses);
   mix(settings_->blood);
-  mix(settings_->timeToLose);
-  mix(settings_->flagsToWin);
-  mix(static_cast<uint32_t>(settings_->gameMode));
-  mix(settings_->loadingTime);
-  mix(settings_->regenerateLevel ? 1u : 0u);
+  mix(settings_->time_to_lose);
+  mix(settings_->flags_to_win);
+  mix(static_cast<uint32_t>(settings_->game_mode));
+  mix(settings_->loading_time);
+  mix(settings_->regenerate_level ? 1u : 0u);
   mix(settings_->shadow ? 1u : 0u);
-  mix(settings_->namesOnBonuses ? 1u : 0u);
-  mix(static_cast<uint32_t>(settings_->bloodParticleMax));
-  mix(static_cast<uint32_t>(settings_->zoneTimeout));
+  mix(settings_->names_on_bonuses ? 1u : 0u);
+  mix(static_cast<uint32_t>(settings_->blood_particle_max));
+  mix(static_cast<uint32_t>(settings_->zone_timeout));
 
   return hash;
 }
@@ -704,7 +704,7 @@ namespace {
 // checksums sent locally and received from the peer. If both stay 0
 // the desync detector is silent because no data is flowing, not
 // because state matches.
-bool checksumLogEnabled() {
+bool ChecksumLogEnabled() {
   static int v = -1;
   if (v < 0) {
     char const* e = std::getenv("OPENLIERO_CHECKSUM_LOG");
@@ -713,8 +713,8 @@ bool checksumLogEnabled() {
   return v != 0;
 }
 
-void maybeLog(char const* who, uint64_t& counter, uint32_t frame, uint32_t checksum) {
-  if (!checksumLogEnabled()) return;
+void MaybeLog(char const* who, uint64_t& counter, uint32_t frame, uint32_t checksum) {
+  if (!ChecksumLogEnabled()) return;
   ++counter;
   if (counter % 70 == 0) {  // ~1 second at 70 Hz
     std::fprintf(stderr, "[checksum %s] count=%llu frame=%u value=%08x\n", who,
@@ -723,40 +723,40 @@ void maybeLog(char const* who, uint64_t& counter, uint32_t frame, uint32_t check
 }
 }  // namespace
 
-void NetSession::onChecksum(uint8_t generation, uint32_t frame, uint32_t remoteChecksum) {
-  if (desyncDetected_ || sessionState_ != Playing || !rollbackPtr_) return;
+void NetSession::OnChecksum(uint8_t generation, uint32_t frame, uint32_t remote_checksum) {
+  if (desyncDetected_ || sessionState_ != kPlaying || !rollbackPtr_) return;
 
   // Drop pre-transition checksums: they describe the peer's old
   // simFrame numbering and would compare against a WS-phase slot that
   // no longer exists in our ring.
-  if (generation != rollbackPtr_->generation()) return;
+  if (generation != rollbackPtr_->Generation()) return;
 
-  static uint64_t remoteCount = 0;
-  maybeLog("remote", remoteCount, frame, remoteChecksum);
+  static uint64_t remote_count = 0;
+  MaybeLog("remote", remote_count, frame, remote_checksum);
 
   // Look up our stored local checksum for this exact frame
-  size_t slot = frame % CHECKSUM_BUFFER_SIZE;
+  size_t slot = frame % kChecksumBufferSize;
   if (checksumBuffer_[slot].valid && checksumBuffer_[slot].frame == frame) {
-    if (checksumBuffer_[slot].checksum != remoteChecksum) {
+    if (checksumBuffer_[slot].checksum != remote_checksum) {
       desyncDetected_ = true;
       desyncFrame_ = frame;
       fprintf(stderr, "DESYNC DETECTED at frame %u! local=%08x remote=%08x\n", frame,
-              checksumBuffer_[slot].checksum, remoteChecksum);
+              checksumBuffer_[slot].checksum, remote_checksum);
     }
   } else {
     // We haven't processed this frame yet — store for later comparison
-    if (pendingRemoteCount_ < CHECKSUM_BUFFER_SIZE) {
-      pendingRemoteChecksums_[pendingRemoteCount_++] = {frame, remoteChecksum};
+    if (pendingRemoteCount_ < kChecksumBufferSize) {
+      pendingRemoteChecksums_[pendingRemoteCount_++] = {frame, remote_checksum};
     }
   }
 }
 
-void NetSession::onLocalChecksum(uint32_t frame, uint32_t checksum) {
-  static uint64_t localCount = 0;
-  maybeLog("local", localCount, frame, checksum);
+void NetSession::OnLocalChecksum(uint32_t frame, uint32_t checksum) {
+  static uint64_t local_count = 0;
+  MaybeLog("local", local_count, frame, checksum);
 
   // Store in ring buffer
-  size_t slot = frame % CHECKSUM_BUFFER_SIZE;
+  size_t slot = frame % kChecksumBufferSize;
   checksumBuffer_[slot] = {frame, checksum, true};
 
   // Check pending remote checksums

--- a/src/game/net/session.cpp
+++ b/src/game/net/session.cpp
@@ -144,12 +144,12 @@ void NetSession::Update() {
 
   transport_.Poll();
 
-  if (transport_.State() == NetTransport::kFailed) {
+  if (transport_.CurrentState() == NetTransport::kFailed) {
     sessionState_ = kFailed;
     return;
   }
 
-  if (transport_.State() == NetTransport::kDisconnected && sessionState_ != kIdle) {
+  if (transport_.CurrentState() == NetTransport::kDisconnected && sessionState_ != kIdle) {
     sessionState_ = kDisconnected;
     return;
   }

--- a/src/game/net/session.cpp
+++ b/src/game/net/session.cpp
@@ -358,7 +358,7 @@ void NetSession::WireCallbacks() {
   transport_.on_disconnected = [this]() { OnDisconnected(); };
   transport_.on_handshake = [this](uint32_t seed, uint32_t hash) { OnHandshake(seed, hash); };
   transport_.on_remote_input_batch = [this](uint8_t generation, uint32_t base_frame, uint8_t count,
-                                         uint8_t const* inputs, uint32_t remote_local_frame) {
+                                            uint8_t const* inputs, uint32_t remote_local_frame) {
     OnRemoteInputBatch(generation, base_frame, count, inputs, remote_local_frame);
   };
   transport_.on_player_info = [this](const NetTransport::PlayerInfo& info) { OnPlayerInfo(info); };
@@ -458,7 +458,7 @@ void NetSession::ApplyRemotePlayerInfo(int remote_idx) {
   remote_ws->color = remotePlayerInfo_.color;
   for (int i = 0; i < 3; ++i) remote_ws->rgb[i] = remotePlayerInfo_.rgb[i];
   remote_ws->name.assign(remotePlayerInfo_.name,
-                        strnlen(remotePlayerInfo_.name, sizeof(remotePlayerInfo_.name)));
+                         strnlen(remotePlayerInfo_.name, sizeof(remotePlayerInfo_.name)));
   remote_worm->settings = remote_ws;
 }
 

--- a/src/game/net/session.hpp
+++ b/src/game/net/session.hpp
@@ -17,134 +17,134 @@
 // Wires RollbackController and NetTransport together. Manages the
 // connection lifecycle: connect → handshake → play → disconnect.
 struct NetSession {
-  enum Role { Host, Client };
+  enum Role { kHost, kClient };
   enum SessionState {
-    Idle,            // Not started
-    WaitingForPeer,  // Listening (host) or connecting (client)
-    Handshaking,     // Connected, exchanging handshakes
-    Playing,         // Game running
-    Rematch,         // Post-game rematch screen
-    Disconnected,    // Peer left
-    Failed,          // Connection failed
+    kIdle,            // Not started
+    kWaitingForPeer,  // Listening (host) or connecting (client)
+    kHandshaking,     // Connected, exchanging handshakes
+    kPlaying,         // Game running
+    kRematch,         // Post-game rematch screen
+    kDisconnected,    // Peer left
+    kFailed,          // Connection failed
   };
 
-  NetSession(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings, FsNode tcRoot);
+  NetSession(std::shared_ptr<Common> common, std::shared_ptr<Settings> settings, FsNode tc_root);
   ~NetSession();
 
   // Start as host. Listens on the given port.
-  bool hostGame(uint16_t port);
+  bool HostGame(uint16_t port);
 
   // Start as client. Connects to host at address:port.
-  bool joinGame(const std::string& address, uint16_t port);
+  bool JoinGame(const std::string& address, uint16_t port);
 
   // Start with an existing transport (already connected or listening).
   // Used after ICE succeeds to hand the bridge-backed transport to the session.
   // For host: transport is already listening, peer will connect.
   // For client: initiates ENet connect to peerAddr:peerPort through existing host.
-  bool hostWithTransport(NetTransport&& transport);
-  bool connectWithTransport(NetTransport&& transport, const std::string& peerAddr,
-                            uint16_t peerPort);
+  bool HostWithTransport(NetTransport&& transport);
+  bool ConnectWithTransport(NetTransport&& transport, const std::string& peer_addr,
+                            uint16_t peer_port);
 
   // Call once per frame from the game loop.
   // Polls network, manages state transitions.
-  void update();
+  void Update();
 
   // Disconnect and clean up.
-  void disconnect();
+  void Disconnect();
 
-  SessionState sessionState() const { return sessionState_; }
+  SessionState State() const { return sessionState_; }
 
-  RollbackController* rollbackController() { return rollbackPtr_; }
+  RollbackController* Rollback() { return rollbackPtr_; }
 
   // Release ownership of the controller (for handing to Gfx). The
   // session keeps a raw pointer for injecting remote inputs.
-  std::unique_ptr<Controller> releaseController();
+  std::unique_ptr<Controller> ReleaseController();
 
   // Send pause/resume to remote peer
-  void sendPause();
-  void sendResume();
+  void SendPause();
+  void SendResume();
 
   // Transition from Playing to Rematch state (keeps connection alive)
-  void enterRematch();
+  void EnterRematch();
 
   // Toggle local player's ready state and notify peer
-  void toggleReady();
+  void ToggleReady();
 
   // Change the level selection (host only) and notify peer
-  void setRematchLevel(bool randomLevel, const std::string& levelFile);
+  void SetRematchLevel(bool random_level, const std::string& level_file);
 
   // Start the rematch game (called when both players are ready)
-  void startRematch();
+  void StartRematch();
 
   // Rematch state accessors
-  bool localReady() const { return localReady_; }
-  bool remoteReady() const { return remoteReady_; }
-  bool isHost() const { return role_ == Host; }
+  bool LocalReady() const { return localReady_; }
+  bool RemoteReady() const { return remoteReady_; }
+  bool IsHost() const { return role_ == kHost; }
 
   // Desync detection
-  bool desyncDetected() const { return desyncDetected_; }
-  uint32_t desyncFrame() const { return desyncFrame_; }
+  bool DesyncDetected() const { return desyncDetected_; }
+  uint32_t DesyncFrame() const { return desyncFrame_; }
 
   // TC sync: called when client needs to reload Common with new TC data.
   // The callback receives the new Common. Caller must update gfx.common.
-  std::function<void(std::shared_ptr<Common>)> onTcReloaded;
+  std::function<void(std::shared_ptr<Common>)> on_tc_reloaded;
 
   // Access the transport (for testing)
-  NetTransport& transport() { return transport_; }
+  NetTransport& Transport() { return transport_; }
 
  private:
-  void onConnected();
-  void onDisconnected();
-  void onHandshake(uint32_t seed, uint32_t settingsHash);
-  void onPlayerInfo(const NetTransport::PlayerInfo& info);
-  void onMatchSettings(const NetTransport::MatchSettingsData& data);
-  void onMapData(const void* data, size_t len);
-  void onPause();
-  void onResume();
-  void onRemoteEndMatch();
-  void onRemotePeerLeft();
-  void onRematchReady(bool ready);
-  void onRematchLevel(bool randomLevel, std::string levelFile);
-  void onRemoteInputBatch(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                          uint8_t const* inputs, uint32_t remoteLocalFrame);
-  void onTcInfo(uint32_t hash, std::string name);
-  void onTcResponse(bool needData);
-  void onTcData(const void* data, size_t len);
-  void wireCallbacks();
-  void tryStartGame();
-  void startRematchClient();
+  void OnConnected();
+  void OnDisconnected();
+  void OnHandshake(uint32_t seed, uint32_t settings_hash);
+  void OnPlayerInfo(const NetTransport::PlayerInfo& info);
+  void OnMatchSettings(const NetTransport::MatchSettingsData& data);
+  void OnMapData(const void* data, size_t len);
+  void OnPause();
+  void OnResume();
+  void OnRemoteEndMatch();
+  void OnRemotePeerLeft();
+  void OnRematchReady(bool ready);
+  void OnRematchLevel(bool random_level, std::string level_file);
+  void OnRemoteInputBatch(uint8_t generation, uint32_t base_frame, uint8_t count,
+                          uint8_t const* inputs, uint32_t remote_local_frame);
+  void OnTcInfo(uint32_t hash, std::string name);
+  void OnTcResponse(bool need_data);
+  void OnTcData(const void* data, size_t len);
+  void WireCallbacks();
+  void TryStartGame();
+  void StartRematchClient();
   // Shared body of tryStartGame / startRematch / startRematchClient:
   // create controller, apply remote player info, seed RNG, prepare or
   // load the level, wire callbacks, pre-fill remote input, and enter
   // Playing. The host-rematch handshake send is not included here; the
   // caller does that before invoking.
-  void beginPlaying(int localIdx, bool isRematch);
-  void applyRemotePlayerInfo(int remoteIdx);
-  void prefillRemoteInput();
-  void generateAndSendMap();
-  uint32_t computeSettingsHash() const;
+  void BeginPlaying(int local_idx, bool is_rematch);
+  void ApplyRemotePlayerInfo(int remote_idx);
+  void PrefillRemoteInput();
+  void GenerateAndSendMap();
+  uint32_t ComputeSettingsHash() const;
 
   // Build the rollback controller and wire its transport callbacks.
   // Shared by all game-start paths.
-  void createController(int localIdx);
-  void wireActiveController();
+  void CreateController(int local_idx);
+  void WireActiveController();
 
   // Send a PlayerInfo packet derived from wormSettings[NetworkPlayerIdx].
   // Called on initial connect and again on rematch (where the prior
   // round's WeaponSelection has mutated weapons[] in place via the
   // shared shared_ptr).
-  void sendLocalPlayerInfo();
+  void SendLocalPlayerInfo();
 
-  Game& activeGame();
+  Game& ActiveGame();
 
   Role role_;
-  SessionState sessionState_;
+  enum SessionState sessionState_;
   NetTransport transport_;
   std::unique_ptr<RollbackController> rollback_;
   std::shared_ptr<Common> common_;
   std::shared_ptr<Settings> settings_;
 
-  RollbackController* rollbackPtr_;  // non-owning
+  struct RollbackController* rollbackPtr_;  // non-owning
 
   uint32_t gameSeed_;
   uint32_t localSettingsHash_;
@@ -173,23 +173,23 @@ struct NetSession {
   // Desync detection
   bool desyncDetected_;
   uint32_t desyncFrame_;
-  void onChecksum(uint8_t generation, uint32_t frame, uint32_t checksum);
-  void onLocalChecksum(uint32_t frame, uint32_t checksum);
+  void OnChecksum(uint8_t generation, uint32_t frame, uint32_t checksum);
+  void OnLocalChecksum(uint32_t frame, uint32_t checksum);
 
   // Ring buffer of local checksums for frame-accurate comparison
-  static constexpr size_t CHECKSUM_BUFFER_SIZE = 128;
+  static constexpr size_t kChecksumBufferSize = 128;
   struct FrameChecksum {
     uint32_t frame;
     uint32_t checksum;
     bool valid;
   };
-  FrameChecksum checksumBuffer_[CHECKSUM_BUFFER_SIZE] = {};
+  FrameChecksum checksumBuffer_[kChecksumBufferSize] = {};
   // Pending remote checksums waiting for local frame to catch up
   struct PendingRemote {
     uint32_t frame;
     uint32_t checksum;
   };
-  PendingRemote pendingRemoteChecksums_[CHECKSUM_BUFFER_SIZE] = {};
+  PendingRemote pendingRemoteChecksums_[kChecksumBufferSize] = {};
   size_t pendingRemoteCount_ = 0;
 
   // Held until beginPlaying wires up rollbackPtr_; otherwise the
@@ -198,13 +198,13 @@ struct NetSession {
   // before they can be re-sent.
   struct PendingInputBatch {
     uint8_t generation;
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
-    uint32_t remoteLocalFrame;
+    uint32_t remote_local_frame;
   };
-  static constexpr size_t MAX_PRE_PLAYING_BATCHES = 256;
+  static constexpr size_t kMaxPrePlayingBatches = 256;
   std::vector<PendingInputBatch> prePlayingInputBatches_;
 
-  static constexpr uint16_t DEFAULT_PORT = 19532;
+  static constexpr uint16_t kDefaultPort = 19532;
 };

--- a/src/game/net/signaling.cpp
+++ b/src/game/net/signaling.cpp
@@ -11,41 +11,41 @@
 #include <arpa/inet.h>
 #endif
 
-using netutil::nowMs;
+using netutil::NowMs;
 
 namespace proto {
-constexpr uint8_t CreateRoom = 0x01;
-constexpr uint8_t JoinRoom = 0x02;
-constexpr uint8_t ReportAddr = 0x03;
-constexpr uint8_t PunchOK = 0x04;
-constexpr uint8_t PunchFail = 0x05;
-constexpr uint8_t Keepalive = 0x06;
-constexpr uint8_t IceCredentials = 0x07;
-constexpr uint8_t IceCandidate = 0x08;
-constexpr uint8_t IceGatherDone = 0x09;
+constexpr uint8_t kCreateRoom = 0x01;
+constexpr uint8_t kJoinRoom = 0x02;
+constexpr uint8_t kReportAddr = 0x03;
+constexpr uint8_t kPunchOk = 0x04;
+constexpr uint8_t kPunchFail = 0x05;
+constexpr uint8_t kKeepalive = 0x06;
+constexpr uint8_t kIceCredentials = 0x07;
+constexpr uint8_t kIceCandidate = 0x08;
+constexpr uint8_t kIceGatherDone = 0x09;
 
-constexpr uint8_t RoomCreated = 0x81;
-constexpr uint8_t PeerJoined = 0x82;
-constexpr uint8_t PeerAddr = 0x83;
-constexpr uint8_t StartPunch = 0x84;
-constexpr uint8_t UseRelay = 0x85;
-constexpr uint8_t RoomExpired = 0x86;
-constexpr uint8_t PeerCredentials = 0x87;
-constexpr uint8_t PeerCandidate = 0x88;
-constexpr uint8_t PeerGatherDone = 0x89;
-constexpr uint8_t Error = 0x8F;
+constexpr uint8_t kRoomCreated = 0x81;
+constexpr uint8_t kPeerJoined = 0x82;
+constexpr uint8_t kPeerAddr = 0x83;
+constexpr uint8_t kStartPunch = 0x84;
+constexpr uint8_t kUseRelay = 0x85;
+constexpr uint8_t kRoomExpired = 0x86;
+constexpr uint8_t kPeerCredentials = 0x87;
+constexpr uint8_t kPeerCandidate = 0x88;
+constexpr uint8_t kPeerGatherDone = 0x89;
+constexpr uint8_t kError = 0x8F;
 
-constexpr int RoomCodeLen = 6;
-constexpr uint8_t AddrIPv4 = 4;
-constexpr uint8_t AddrIPv6 = 6;
+constexpr int kRoomCodeLen = 6;
+constexpr uint8_t kAddrIPv4 = 4;
+constexpr uint8_t kAddrIPv6 = 6;
 }  // namespace proto
 
 SignalingClient::SignalingClient()
-    : sock_(ENET_SOCKET_NULL), state_(Idle), serverPort_(0), relayPort_(0) {}
+    : sock_(ENET_SOCKET_NULL), state_(kIdle), serverPort_(0), relayPort_(0) {}
 
-SignalingClient::~SignalingClient() { disconnect(); }
+SignalingClient::~SignalingClient() { Disconnect(); }
 
-bool SignalingClient::connect(const std::string& serverAddr, uint16_t serverPort) {
+bool SignalingClient::Connect(const std::string& server_addr, uint16_t server_port) {
   enet_initialize();
 
   ENetSocket sock = enet_socket_create(ENET_SOCKET_TYPE_DATAGRAM);
@@ -56,38 +56,38 @@ bool SignalingClient::connect(const std::string& serverAddr, uint16_t serverPort
 
   enet_socket_set_option(sock, ENET_SOCKOPT_IPV6_V6ONLY, 0);
 
-  ENetAddress anyAddr = {};
-  anyAddr.port = 0;
-  memset(&anyAddr.host, 0, sizeof(anyAddr.host));
-  enet_socket_bind(sock, &anyAddr);
+  ENetAddress any_addr = {};
+  any_addr.port = 0;
+  memset(&any_addr.host, 0, sizeof(any_addr.host));
+  enet_socket_bind(sock, &any_addr);
 
   ENetAddress resolved = {};
-  resolved.port = serverPort;
-  if (enet_address_set_host(&resolved, serverAddr.c_str()) != 0) {
-    fprintf(stderr, "[signaling] ERROR: failed to resolve '%s'\n", serverAddr.c_str());
+  resolved.port = server_port;
+  if (enet_address_set_host(&resolved, server_addr.c_str()) != 0) {
+    fprintf(stderr, "[signaling] ERROR: failed to resolve '%s'\n", server_addr.c_str());
     enet_socket_destroy(sock);
     return false;
   }
 
   sock_ = sock;
-  serverAddr_ = serverAddr;
-  serverPort_ = serverPort;
+  serverAddr_ = server_addr;
+  serverPort_ = server_port;
   resolvedAddr_ = resolved;
   return true;
 }
 
-void SignalingClient::disconnect() {
+void SignalingClient::Disconnect() {
   if (sock_ != ENET_SOCKET_NULL) {
     enet_socket_destroy(sock_);
     sock_ = ENET_SOCKET_NULL;
   }
-  state_ = Idle;
+  state_ = kIdle;
   roomCode_.clear();
   peerCandidates_.clear();
   relayPort_ = 0;
 }
 
-void SignalingClient::send(const void* data, size_t len) {
+void SignalingClient::Send(const void* data, size_t len) {
   if (sock_ == ENET_SOCKET_NULL) return;
   ENetBuffer buf;
   buf.data = const_cast<void*>(data);
@@ -95,267 +95,267 @@ void SignalingClient::send(const void* data, size_t len) {
   enet_socket_send(sock_, &resolvedAddr_, &buf, 1);
 }
 
-bool SignalingClient::createRoom(const std::string& serverAddr, uint16_t serverPort) {
-  if (!connect(serverAddr, serverPort)) return false;
-  uint8_t msg[1 + proto::RoomCodeLen] = {};
-  msg[0] = proto::CreateRoom;
-  send(msg, sizeof(msg));
-  state_ = Creating;
-  lastSendMs_ = nowMs();
+bool SignalingClient::CreateRoom(const std::string& server_addr, uint16_t server_port) {
+  if (!Connect(server_addr, server_port)) return false;
+  uint8_t msg[1 + proto::kRoomCodeLen] = {};
+  msg[0] = proto::kCreateRoom;
+  Send(msg, sizeof(msg));
+  state_ = kCreating;
+  lastSendMs_ = NowMs();
   retryCount_ = 0;
   return true;
 }
 
-bool SignalingClient::joinRoom(const std::string& serverAddr, uint16_t serverPort,
-                               const std::string& roomCode) {
-  if (!connect(serverAddr, serverPort)) return false;
-  if (roomCode.size() != proto::RoomCodeLen) return false;
+bool SignalingClient::JoinRoom(const std::string& server_addr, uint16_t server_port,
+                               const std::string& room_code) {
+  if (!Connect(server_addr, server_port)) return false;
+  if (room_code.size() != proto::kRoomCodeLen) return false;
 
-  uint8_t msg[1 + proto::RoomCodeLen];
-  msg[0] = proto::JoinRoom;
-  std::memcpy(msg + 1, roomCode.data(), proto::RoomCodeLen);
-  send(msg, sizeof(msg));
-  roomCode_ = roomCode;
-  state_ = Joining;
-  lastSendMs_ = nowMs();
+  uint8_t msg[1 + proto::kRoomCodeLen];
+  msg[0] = proto::kJoinRoom;
+  std::memcpy(msg + 1, room_code.data(), proto::kRoomCodeLen);
+  Send(msg, sizeof(msg));
+  roomCode_ = room_code;
+  state_ = kJoining;
+  lastSendMs_ = NowMs();
   retryCount_ = 0;
   return true;
 }
 
-void SignalingClient::reportAddress(uint8_t addrType, const std::string& ip, uint16_t port) {
-  int ipLen = (addrType == proto::AddrIPv4) ? 4 : 16;
-  std::vector<uint8_t> msg(1 + proto::RoomCodeLen + 1 + 2 + ipLen);
-  msg[0] = proto::ReportAddr;
-  std::memcpy(msg.data() + 1, roomCode_.data(), proto::RoomCodeLen);
-  msg[1 + proto::RoomCodeLen] = addrType;
-  msg[1 + proto::RoomCodeLen + 1] = (uint8_t)(port >> 8);
-  msg[1 + proto::RoomCodeLen + 2] = (uint8_t)(port & 0xFF);
+void SignalingClient::ReportAddress(uint8_t addr_type, const std::string& ip, uint16_t port) {
+  int ip_len = (addr_type == proto::kAddrIPv4) ? 4 : 16;
+  std::vector<uint8_t> msg(1 + proto::kRoomCodeLen + 1 + 2 + ip_len);
+  msg[0] = proto::kReportAddr;
+  std::memcpy(msg.data() + 1, roomCode_.data(), proto::kRoomCodeLen);
+  msg[1 + proto::kRoomCodeLen] = addr_type;
+  msg[1 + proto::kRoomCodeLen + 1] = (uint8_t)(port >> 8);
+  msg[1 + proto::kRoomCodeLen + 2] = (uint8_t)(port & 0xFF);
 
-  uint8_t ipBytes[16] = {};
-  if (addrType == proto::AddrIPv4)
-    inet_pton(AF_INET, ip.c_str(), ipBytes);
+  uint8_t ip_bytes[16] = {};
+  if (addr_type == proto::kAddrIPv4)
+    inet_pton(AF_INET, ip.c_str(), ip_bytes);
   else
-    inet_pton(AF_INET6, ip.c_str(), ipBytes);
-  std::memcpy(msg.data() + 1 + proto::RoomCodeLen + 3, ipBytes, ipLen);
-  send(msg.data(), msg.size());
+    inet_pton(AF_INET6, ip.c_str(), ip_bytes);
+  std::memcpy(msg.data() + 1 + proto::kRoomCodeLen + 3, ip_bytes, ip_len);
+  Send(msg.data(), msg.size());
 }
 
-void SignalingClient::reportPunchOK() {
-  uint8_t msg[1 + proto::RoomCodeLen];
-  msg[0] = proto::PunchOK;
-  std::memcpy(msg + 1, roomCode_.data(), proto::RoomCodeLen);
-  send(msg, sizeof(msg));
-  state_ = Done;
+void SignalingClient::ReportPunchOk() {
+  uint8_t msg[1 + proto::kRoomCodeLen];
+  msg[0] = proto::kPunchOk;
+  std::memcpy(msg + 1, roomCode_.data(), proto::kRoomCodeLen);
+  Send(msg, sizeof(msg));
+  state_ = kDone;
 }
 
-void SignalingClient::reportPunchFail() {
-  uint8_t msg[1 + proto::RoomCodeLen];
-  msg[0] = proto::PunchFail;
-  std::memcpy(msg + 1, roomCode_.data(), proto::RoomCodeLen);
-  send(msg, sizeof(msg));
+void SignalingClient::ReportPunchFail() {
+  uint8_t msg[1 + proto::kRoomCodeLen];
+  msg[0] = proto::kPunchFail;
+  std::memcpy(msg + 1, roomCode_.data(), proto::kRoomCodeLen);
+  Send(msg, sizeof(msg));
 }
 
-void SignalingClient::sendIceCredentials(const std::string& ufrag, const std::string& pwd) {
+void SignalingClient::SendIceCredentials(const std::string& ufrag, const std::string& pwd) {
   // Format: [0x07] + [6: room code] + [1: ufrag_len] + [N: ufrag] + [1: pwd_len] + [N: pwd]
-  std::vector<uint8_t> msg(1 + proto::RoomCodeLen + 1 + ufrag.size() + 1 + pwd.size());
+  std::vector<uint8_t> msg(1 + proto::kRoomCodeLen + 1 + ufrag.size() + 1 + pwd.size());
   size_t off = 0;
-  msg[off++] = proto::IceCredentials;
-  std::memcpy(msg.data() + off, roomCode_.data(), proto::RoomCodeLen);
-  off += proto::RoomCodeLen;
+  msg[off++] = proto::kIceCredentials;
+  std::memcpy(msg.data() + off, roomCode_.data(), proto::kRoomCodeLen);
+  off += proto::kRoomCodeLen;
   msg[off++] = (uint8_t)ufrag.size();
   std::memcpy(msg.data() + off, ufrag.data(), ufrag.size());
   off += ufrag.size();
   msg[off++] = (uint8_t)pwd.size();
   std::memcpy(msg.data() + off, pwd.data(), pwd.size());
-  send(msg.data(), msg.size());
+  Send(msg.data(), msg.size());
 }
 
-void SignalingClient::sendIceCandidate(const std::string& sdpCandidate) {
+void SignalingClient::SendIceCandidate(const std::string& sdp_candidate) {
   // Format: [0x08] + [6: room code] + [2: candidate_len BE] + [N: candidate]
-  std::vector<uint8_t> msg(1 + proto::RoomCodeLen + 2 + sdpCandidate.size());
+  std::vector<uint8_t> msg(1 + proto::kRoomCodeLen + 2 + sdp_candidate.size());
   size_t off = 0;
-  msg[off++] = proto::IceCandidate;
-  std::memcpy(msg.data() + off, roomCode_.data(), proto::RoomCodeLen);
-  off += proto::RoomCodeLen;
-  uint16_t candLen = (uint16_t)sdpCandidate.size();
-  msg[off++] = (uint8_t)(candLen >> 8);
-  msg[off++] = (uint8_t)(candLen & 0xFF);
-  std::memcpy(msg.data() + off, sdpCandidate.data(), sdpCandidate.size());
-  send(msg.data(), msg.size());
+  msg[off++] = proto::kIceCandidate;
+  std::memcpy(msg.data() + off, roomCode_.data(), proto::kRoomCodeLen);
+  off += proto::kRoomCodeLen;
+  uint16_t cand_len = (uint16_t)sdp_candidate.size();
+  msg[off++] = (uint8_t)(cand_len >> 8);
+  msg[off++] = (uint8_t)(cand_len & 0xFF);
+  std::memcpy(msg.data() + off, sdp_candidate.data(), sdp_candidate.size());
+  Send(msg.data(), msg.size());
 }
 
-void SignalingClient::sendIceGatherDone() {
+void SignalingClient::SendIceGatherDone() {
   // Format: [0x09] + [6: room code]
-  uint8_t msg[1 + proto::RoomCodeLen];
-  msg[0] = proto::IceGatherDone;
-  std::memcpy(msg + 1, roomCode_.data(), proto::RoomCodeLen);
-  send(msg, sizeof(msg));
+  uint8_t msg[1 + proto::kRoomCodeLen];
+  msg[0] = proto::kIceGatherDone;
+  std::memcpy(msg + 1, roomCode_.data(), proto::kRoomCodeLen);
+  Send(msg, sizeof(msg));
 }
 
-void SignalingClient::sendKeepalive() {
-  uint8_t msg[1 + proto::RoomCodeLen];
-  msg[0] = proto::Keepalive;
-  std::memcpy(msg + 1, roomCode_.data(), proto::RoomCodeLen);
-  send(msg, sizeof(msg));
+void SignalingClient::SendKeepalive() {
+  uint8_t msg[1 + proto::kRoomCodeLen];
+  msg[0] = proto::kKeepalive;
+  std::memcpy(msg + 1, roomCode_.data(), proto::kRoomCodeLen);
+  Send(msg, sizeof(msg));
 }
 
-void SignalingClient::poll() {
+void SignalingClient::Poll() {
   if (sock_ == ENET_SOCKET_NULL) return;
 
   // Retry unacknowledged messages
-  if ((state_ == Creating || state_ == Joining) && retryCount_ < kMaxRetries) {
-    uint64_t elapsed = nowMs() - lastSendMs_;
+  if ((state_ == kCreating || state_ == kJoining) && retryCount_ < kMaxRetries) {
+    uint64_t elapsed = NowMs() - lastSendMs_;
     if (elapsed >= (uint64_t)kRetryIntervalMs) {
       retryCount_++;
-      uint8_t msg[1 + proto::RoomCodeLen] = {};
-      msg[0] = (state_ == Creating) ? proto::CreateRoom : proto::JoinRoom;
-      if (state_ == Joining) std::memcpy(msg + 1, roomCode_.data(), proto::RoomCodeLen);
-      send(msg, sizeof(msg));
-      lastSendMs_ = nowMs();
+      uint8_t msg[1 + proto::kRoomCodeLen] = {};
+      msg[0] = (state_ == kCreating) ? proto::kCreateRoom : proto::kJoinRoom;
+      if (state_ == kJoining) std::memcpy(msg + 1, roomCode_.data(), proto::kRoomCodeLen);
+      Send(msg, sizeof(msg));
+      lastSendMs_ = NowMs();
     }
   }
 
   // Drain all available packets from the socket
-  uint8_t recvData[2048];
-  ENetBuffer recvBuf;
-  recvBuf.data = recvData;
-  recvBuf.dataLength = sizeof(recvData);
+  uint8_t recv_data[2048];
+  ENetBuffer recv_buf;
+  recv_buf.data = recv_data;
+  recv_buf.dataLength = sizeof(recv_data);
 
   for (;;) {
-    enet_uint32 waitCondition = ENET_SOCKET_WAIT_RECEIVE;
-    if (enet_socket_wait(sock_, &waitCondition, 0) != 0) break;
-    if (!(waitCondition & ENET_SOCKET_WAIT_RECEIVE)) break;
+    enet_uint32 wait_condition = ENET_SOCKET_WAIT_RECEIVE;
+    if (enet_socket_wait(sock_, &wait_condition, 0) != 0) break;
+    if (!(wait_condition & ENET_SOCKET_WAIT_RECEIVE)) break;
 
-    ENetAddress fromAddr = {};
-    int recvLen = enet_socket_receive(sock_, &fromAddr, &recvBuf, 1);
-    if (recvLen <= 0) break;
+    ENetAddress from_addr = {};
+    int recv_len = enet_socket_receive(sock_, &from_addr, &recv_buf, 1);
+    if (recv_len <= 0) break;
 
-    handleMessage(recvData, (size_t)recvLen);
+    HandleMessage(recv_data, (size_t)recv_len);
   }
 }
 
-void SignalingClient::handleMessage(const uint8_t* data, size_t len) {
+void SignalingClient::HandleMessage(const uint8_t* data, size_t len) {
   if (len < 1) return;
   uint8_t type = data[0];
 
   switch (type) {
-    case proto::RoomCreated: {
-      if (len < 1 + proto::RoomCodeLen) break;
-      roomCode_ = std::string((const char*)data + 1, proto::RoomCodeLen);
+    case proto::kRoomCreated: {
+      if (len < 1 + proto::kRoomCodeLen) break;
+      roomCode_ = std::string((const char*)data + 1, proto::kRoomCodeLen);
       // Parse optional TURN credentials: [1: turn_user_len] + [N: turn_user] + [1: turn_pass_len] +
       // [N: turn_pass]
-      size_t off = 1 + proto::RoomCodeLen;
+      size_t off = 1 + proto::kRoomCodeLen;
       if (off + 1 <= len) {
-        uint8_t userLen = data[off++];
-        if (off + userLen + 1 <= len) {
-          turnUser_ = std::string((const char*)data + off, userLen);
-          off += userLen;
-          uint8_t passLen = data[off++];
-          if (off + passLen <= len) {
-            turnPassword_ = std::string((const char*)data + off, passLen);
+        uint8_t user_len = data[off++];
+        if (off + user_len + 1 <= len) {
+          turnUser_ = std::string((const char*)data + off, user_len);
+          off += user_len;
+          uint8_t pass_len = data[off++];
+          if (off + pass_len <= len) {
+            turnPassword_ = std::string((const char*)data + off, pass_len);
           }
         }
       }
-      state_ = Hosting;
-      if (onRoomCreated) onRoomCreated(roomCode_);
+      state_ = kHosting;
+      if (on_room_created) on_room_created(roomCode_);
       break;
     }
-    case proto::PeerJoined: {
+    case proto::kPeerJoined: {
       // Parse optional TURN credentials
-      size_t off = 1 + proto::RoomCodeLen;
+      size_t off = 1 + proto::kRoomCodeLen;
       if (off + 1 <= len) {
-        uint8_t userLen = data[off++];
-        if (off + userLen + 1 <= len) {
-          turnUser_ = std::string((const char*)data + off, userLen);
-          off += userLen;
-          uint8_t passLen = data[off++];
-          if (off + passLen <= len) {
-            turnPassword_ = std::string((const char*)data + off, passLen);
+        uint8_t user_len = data[off++];
+        if (off + user_len + 1 <= len) {
+          turnUser_ = std::string((const char*)data + off, user_len);
+          off += user_len;
+          uint8_t pass_len = data[off++];
+          if (off + pass_len <= len) {
+            turnPassword_ = std::string((const char*)data + off, pass_len);
           }
         }
       }
-      if (state_ == Joining) {
-        state_ = WaitingForPeer;
-        if (onJoinAcked) onJoinAcked();
+      if (state_ == kJoining) {
+        state_ = kWaitingForPeer;
+        if (on_join_acked) on_join_acked();
       } else {
-        if (onPeerJoined) onPeerJoined();
+        if (on_peer_joined) on_peer_joined();
       }
       break;
     }
-    case proto::PeerAddr: {
-      if (len < 1 + proto::RoomCodeLen + 1 + 2 + 4) break;
-      uint8_t addrType = data[1 + proto::RoomCodeLen];
+    case proto::kPeerAddr: {
+      if (len < 1 + proto::kRoomCodeLen + 1 + 2 + 4) break;
+      uint8_t addr_type = data[1 + proto::kRoomCodeLen];
       uint16_t port =
-          (uint16_t)(data[1 + proto::RoomCodeLen + 1] << 8 | data[1 + proto::RoomCodeLen + 2]);
-      int ipLen = (addrType == proto::AddrIPv4) ? 4 : 16;
-      if ((int)len < 1 + proto::RoomCodeLen + 3 + ipLen) break;
+          (uint16_t)(data[1 + proto::kRoomCodeLen + 1] << 8 | data[1 + proto::kRoomCodeLen + 2]);
+      int ip_len = (addr_type == proto::kAddrIPv4) ? 4 : 16;
+      if ((int)len < 1 + proto::kRoomCodeLen + 3 + ip_len) break;
 
-      char ipStr[INET6_ADDRSTRLEN] = {};
-      if (addrType == proto::AddrIPv4)
-        inet_ntop(AF_INET, data + 1 + proto::RoomCodeLen + 3, ipStr, sizeof(ipStr));
+      char ip_str[INET6_ADDRSTRLEN] = {};
+      if (addr_type == proto::kAddrIPv4)
+        inet_ntop(AF_INET, data + 1 + proto::kRoomCodeLen + 3, ip_str, sizeof(ip_str));
       else
-        inet_ntop(AF_INET6, data + 1 + proto::RoomCodeLen + 3, ipStr, sizeof(ipStr));
+        inet_ntop(AF_INET6, data + 1 + proto::kRoomCodeLen + 3, ip_str, sizeof(ip_str));
 
-      PeerCandidate cand{addrType, ipStr, port};
+      PeerCandidate cand{addr_type, ip_str, port};
       peerCandidates_.push_back(cand);
-      if (onPeerAddr) onPeerAddr(cand);
+      if (on_peer_addr) on_peer_addr(cand);
       break;
     }
-    case proto::StartPunch: {
-      state_ = Punching;
-      if (onStartPunch) onStartPunch();
+    case proto::kStartPunch: {
+      state_ = kPunching;
+      if (on_start_punch) on_start_punch();
       break;
     }
-    case proto::UseRelay: {
-      if (len < 1 + proto::RoomCodeLen + 2 + 8) break;
-      relayPort_ = (uint16_t)(data[1 + proto::RoomCodeLen] << 8 | data[1 + proto::RoomCodeLen + 1]);
-      relayToken_.assign(data + 1 + proto::RoomCodeLen + 2, data + 1 + proto::RoomCodeLen + 2 + 8);
-      state_ = Relaying;
-      if (onUseRelay) onUseRelay(relayPort_);
+    case proto::kUseRelay: {
+      if (len < 1 + proto::kRoomCodeLen + 2 + 8) break;
+      relayPort_ = (uint16_t)(data[1 + proto::kRoomCodeLen] << 8 | data[1 + proto::kRoomCodeLen + 1]);
+      relayToken_.assign(data + 1 + proto::kRoomCodeLen + 2, data + 1 + proto::kRoomCodeLen + 2 + 8);
+      state_ = kRelaying;
+      if (on_use_relay) on_use_relay(relayPort_);
       break;
     }
-    case proto::RoomExpired: {
+    case proto::kRoomExpired: {
       fprintf(stderr, "[signaling] room expired\n");
-      state_ = Failed;
-      if (onRoomExpired) onRoomExpired();
+      state_ = kFailed;
+      if (on_room_expired) on_room_expired();
       break;
     }
-    case proto::Error: {
+    case proto::kError: {
       std::string msg;
       if (len > 2) msg = std::string((const char*)data + 2, len - 2);
       fprintf(stderr, "[signaling] ERROR from server: %s\n", msg.c_str());
-      state_ = Failed;
-      if (onError) onError(msg);
+      state_ = kFailed;
+      if (on_error) on_error(msg);
       break;
     }
-    case proto::PeerCredentials: {
+    case proto::kPeerCredentials: {
       // Format: [0x87] + [6: room code] + [1: ufrag_len] + [N: ufrag] + [1: pwd_len] + [N: pwd]
-      size_t off = 1 + proto::RoomCodeLen;
+      size_t off = 1 + proto::kRoomCodeLen;
       if (off + 1 > len) break;
-      uint8_t ufragLen = data[off++];
-      if (off + ufragLen + 1 > len) break;
-      std::string ufrag((const char*)data + off, ufragLen);
-      off += ufragLen;
-      uint8_t pwdLen = data[off++];
-      if (off + pwdLen > len) break;
-      std::string pwd((const char*)data + off, pwdLen);
-      state_ = IceExchanging;
-      if (onPeerCredentials) onPeerCredentials(ufrag, pwd);
+      uint8_t ufrag_len = data[off++];
+      if (off + ufrag_len + 1 > len) break;
+      std::string ufrag((const char*)data + off, ufrag_len);
+      off += ufrag_len;
+      uint8_t pwd_len = data[off++];
+      if (off + pwd_len > len) break;
+      std::string pwd((const char*)data + off, pwd_len);
+      state_ = kIceExchanging;
+      if (on_peer_credentials) on_peer_credentials(ufrag, pwd);
       break;
     }
-    case proto::PeerCandidate: {
+    case proto::kPeerCandidate: {
       // Format: [0x88] + [6: room code] + [2: candidate_len BE] + [N: candidate]
-      size_t off = 1 + proto::RoomCodeLen;
+      size_t off = 1 + proto::kRoomCodeLen;
       if (off + 2 > len) break;
-      uint16_t candLen = (uint16_t)(data[off] << 8 | data[off + 1]);
+      uint16_t cand_len = (uint16_t)(data[off] << 8 | data[off + 1]);
       off += 2;
-      if (off + candLen > len) break;
-      std::string candidate((const char*)data + off, candLen);
-      if (onPeerCandidate) onPeerCandidate(candidate);
+      if (off + cand_len > len) break;
+      std::string candidate((const char*)data + off, cand_len);
+      if (on_peer_candidate) on_peer_candidate(candidate);
       break;
     }
-    case proto::PeerGatherDone: {
-      if (onPeerGatherDone) onPeerGatherDone();
+    case proto::kPeerGatherDone: {
+      if (on_peer_gather_done) on_peer_gather_done();
       break;
     }
     default:

--- a/src/game/net/signaling.cpp
+++ b/src/game/net/signaling.cpp
@@ -308,8 +308,10 @@ void SignalingClient::HandleMessage(const uint8_t* data, size_t len) {
     }
     case proto::kUseRelay: {
       if (len < 1 + proto::kRoomCodeLen + 2 + 8) break;
-      relayPort_ = (uint16_t)(data[1 + proto::kRoomCodeLen] << 8 | data[1 + proto::kRoomCodeLen + 1]);
-      relayToken_.assign(data + 1 + proto::kRoomCodeLen + 2, data + 1 + proto::kRoomCodeLen + 2 + 8);
+      relayPort_ =
+          (uint16_t)(data[1 + proto::kRoomCodeLen] << 8 | data[1 + proto::kRoomCodeLen + 1]);
+      relayToken_.assign(data + 1 + proto::kRoomCodeLen + 2,
+                         data + 1 + proto::kRoomCodeLen + 2 + 8);
       state_ = kRelaying;
       if (on_use_relay) on_use_relay(relayPort_);
       break;

--- a/src/game/net/signaling.hpp
+++ b/src/game/net/signaling.hpp
@@ -20,72 +20,72 @@ struct PeerCandidate {
 class SignalingClient {
  public:
   enum State {
-    Idle,
-    Creating,
-    Hosting,
-    Joining,
-    WaitingForPeer,
-    Punching,  // legacy
-    Relaying,  // legacy
-    IceExchanging,
-    Failed,
-    Done,
+    kIdle,
+    kCreating,
+    kHosting,
+    kJoining,
+    kWaitingForPeer,
+    kPunching,  // legacy
+    kRelaying,  // legacy
+    kIceExchanging,
+    kFailed,
+    kDone,
   };
 
   SignalingClient();
   ~SignalingClient();
 
-  bool createRoom(const std::string& serverAddr, uint16_t serverPort);
-  bool joinRoom(const std::string& serverAddr, uint16_t serverPort, const std::string& roomCode);
+  bool CreateRoom(const std::string& server_addr, uint16_t server_port);
+  bool JoinRoom(const std::string& server_addr, uint16_t server_port, const std::string& room_code);
 
   // Legacy hole-punch methods (kept for transition)
-  void reportAddress(uint8_t addrType, const std::string& ip, uint16_t port);
-  void reportPunchOK();
-  void reportPunchFail();
+  void ReportAddress(uint8_t addr_type, const std::string& ip, uint16_t port);
+  void ReportPunchOk();
+  void ReportPunchFail();
 
   // ICE signaling methods
-  void sendIceCredentials(const std::string& ufrag, const std::string& pwd);
-  void sendIceCandidate(const std::string& sdpCandidate);
-  void sendIceGatherDone();
+  void SendIceCredentials(const std::string& ufrag, const std::string& pwd);
+  void SendIceCandidate(const std::string& sdp_candidate);
+  void SendIceGatherDone();
 
-  void sendKeepalive();
-  void poll();
-  void disconnect();
+  void SendKeepalive();
+  void Poll();
+  void Disconnect();
 
-  State state() const { return state_; }
-  const std::string& roomCode() const { return roomCode_; }
-  const std::vector<PeerCandidate>& peerCandidates() const { return peerCandidates_; }
-  uint16_t relayPort() const { return relayPort_; }
-  const std::vector<uint8_t>& relayToken() const { return relayToken_; }
+  State State() const { return state_; }
+  const std::string& RoomCode() const { return roomCode_; }
+  const std::vector<PeerCandidate>& PeerCandidates() const { return peerCandidates_; }
+  uint16_t RelayPort() const { return relayPort_; }
+  const std::vector<uint8_t>& RelayToken() const { return relayToken_; }
 
   // TURN credentials received from the server
-  const std::string& turnUser() const { return turnUser_; }
-  const std::string& turnPassword() const { return turnPassword_; }
+  const std::string& TurnUser() const { return turnUser_; }
+  const std::string& TurnPassword() const { return turnPassword_; }
 
   // Legacy callbacks
-  std::function<void(const std::string& code)> onRoomCreated;
-  std::function<void()> onPeerJoined;
-  std::function<void()> onJoinAcked;
-  std::function<void(const PeerCandidate&)> onPeerAddr;
-  std::function<void()> onStartPunch;
-  std::function<void(uint16_t relayPort)> onUseRelay;
+  std::function<void(const std::string& code)> on_room_created;
+  std::function<void()> on_peer_joined;
+  std::function<void()> on_join_acked;
+  std::function<void(const PeerCandidate&)> on_peer_addr;
+  std::function<void()> on_start_punch;
+  std::function<void(uint16_t relay_port)> on_use_relay;
 
   // ICE callbacks
-  std::function<void(const std::string& ufrag, const std::string& pwd)> onPeerCredentials;
-  std::function<void(const std::string& sdpCandidate)> onPeerCandidate;
-  std::function<void()> onPeerGatherDone;
+  std::function<void(const std::string& ufrag, const std::string& pwd)> on_peer_credentials;
+  std::function<void(const std::string& sdp_candidate)> on_peer_candidate;
+  std::function<void()> on_peer_gather_done;
 
   // Common callbacks
-  std::function<void(const std::string& msg)> onError;
-  std::function<void()> onRoomExpired;
+  std::function<void(const std::string& msg)> on_error;
+  std::function<void()> on_room_expired;
 
  private:
-  bool connect(const std::string& serverAddr, uint16_t serverPort);
-  void send(const void* data, size_t len);
-  void handleMessage(const uint8_t* data, size_t len);
+  bool Connect(const std::string& server_addr, uint16_t server_port);
+  void Send(const void* data, size_t len);
+  void HandleMessage(const uint8_t* data, size_t len);
 
   ENetSocket sock_;
-  State state_;
+  enum State state_;
   std::string roomCode_;
   std::string serverAddr_;
   uint16_t serverPort_;

--- a/src/game/net/stun.cpp
+++ b/src/game/net/stun.cpp
@@ -13,86 +13,86 @@
 #include <arpa/inet.h>
 #endif
 
-using netutil::nowMs;
+using netutil::NowMs;
 
-static constexpr const char* STUN_SERVER_IPV4 = "74.125.250.129";
-static constexpr const char* STUN_SERVER_IPV6 = "2001:4860:4864:5:8000::1";
-static constexpr uint16_t STUN_PORT = 19302;
-static constexpr int STUN_TIMEOUT_MS = 2000;
-static constexpr int STUN_RETRIES = 2;
+static constexpr const char* kStunServerIpV4 = "74.125.250.129";
+static constexpr const char* kStunServerIpV6 = "2001:4860:4864:5:8000::1";
+static constexpr uint16_t kStunPort = 19302;
+static constexpr int kStunTimeoutMs = 2000;
+static constexpr int kStunRetries = 2;
 
 // --- stun namespace helpers ---
 
-stun::Header stun::buildRequest() {
+stun::Header stun::BuildRequest() {
   Header req = {};
-  req.type = htons(BINDING_REQUEST);
+  req.type = htons(kBindingRequest);
   req.length = 0;
-  req.magicCookie = htonl(MAGIC_COOKIE);
+  req.magic_cookie = htonl(kMagicCookie);
 
   std::random_device rd;
-  for (int i = 0; i < 12; i++) req.transactionId[i] = (uint8_t)(rd() & 0xFF);
+  for (int i = 0; i < 12; i++) req.transaction_id[i] = (uint8_t)(rd() & 0xFF);
 
   return req;
 }
 
-bool stun::isResponse(const uint8_t* data, size_t len, const Header& req) {
+bool stun::IsResponse(const uint8_t* data, size_t len, const Header& req) {
   if (len < sizeof(Header)) return false;
   auto* resp = (const Header*)data;
-  if (ntohs(resp->type) != BINDING_RESPONSE) return false;
-  if (ntohl(resp->magicCookie) != MAGIC_COOKIE) return false;
-  return std::memcmp(resp->transactionId, req.transactionId, 12) == 0;
+  if (ntohs(resp->type) != kBindingResponse) return false;
+  if (ntohl(resp->magic_cookie) != kMagicCookie) return false;
+  return std::memcmp(resp->transaction_id, req.transaction_id, 12) == 0;
 }
 
-StunMappedAddress stun::parseResponse(const uint8_t* data, size_t len, const stun::Header& req) {
+StunMappedAddress stun::ParseResponse(const uint8_t* data, size_t len, const stun::Header& req) {
   if (len < sizeof(stun::Header)) return {};
 
   auto* resp = (const stun::Header*)data;
-  if (ntohs(resp->type) != stun::BINDING_RESPONSE) return {};
-  if (ntohl(resp->magicCookie) != stun::MAGIC_COOKIE) return {};
-  if (std::memcmp(resp->transactionId, req.transactionId, 12) != 0) return {};
+  if (ntohs(resp->type) != stun::kBindingResponse) return {};
+  if (ntohl(resp->magic_cookie) != stun::kMagicCookie) return {};
+  if (std::memcmp(resp->transaction_id, req.transaction_id, 12) != 0) return {};
 
-  uint16_t attrTotalLen = ntohs(resp->length);
-  if (sizeof(stun::Header) + attrTotalLen > len) return {};
+  uint16_t attr_total_len = ntohs(resp->length);
+  if (sizeof(stun::Header) + attr_total_len > len) return {};
 
   const uint8_t* attrs = data + sizeof(stun::Header);
   size_t offset = 0;
 
-  StunMappedAddress xorResult;
-  StunMappedAddress plainResult;
+  StunMappedAddress xor_result;
+  StunMappedAddress plain_result;
 
-  while (offset + 4 <= attrTotalLen) {
-    uint16_t attrType = (uint16_t)(attrs[offset] << 8 | attrs[offset + 1]);
-    uint16_t attrLen = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
+  while (offset + 4 <= attr_total_len) {
+    uint16_t attr_type = (uint16_t)(attrs[offset] << 8 | attrs[offset + 1]);
+    uint16_t attr_len = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
     offset += 4;
 
-    if (offset + attrLen > attrTotalLen) break;
+    if (offset + attr_len > attr_total_len) break;
 
-    if (attrType == stun::ATTR_XOR_MAPPED_ADDRESS && attrLen >= 8) {
+    if (attr_type == stun::kAttrXorMappedAddress && attr_len >= 8) {
       uint8_t family = attrs[offset + 1];
-      uint16_t xorPort = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
-      uint16_t mappedPort = xorPort ^ (uint16_t)(stun::MAGIC_COOKIE >> 16);
+      uint16_t xor_port = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
+      uint16_t mapped_port = xor_port ^ (uint16_t)(stun::kMagicCookie >> 16);
 
-      if (family == 0x01 && attrLen >= 8) {
-        uint32_t xorAddr;
-        std::memcpy(&xorAddr, attrs + offset + 4, 4);
-        uint32_t addr = ntohl(xorAddr) ^ stun::MAGIC_COOKIE;
+      if (family == 0x01 && attr_len >= 8) {
+        uint32_t xor_addr;
+        std::memcpy(&xor_addr, attrs + offset + 4, 4);
+        uint32_t addr = ntohl(xor_addr) ^ stun::kMagicCookie;
         char buf[64];
         snprintf(buf, sizeof(buf), "%u.%u.%u.%u", (addr >> 24) & 0xFF, (addr >> 16) & 0xFF,
                  (addr >> 8) & 0xFF, addr & 0xFF);
-        xorResult = {buf, mappedPort};
-      } else if (family == 0x02 && attrLen >= 20) {
-        uint8_t addrBytes[16];
-        std::memcpy(addrBytes, attrs + offset + 4, 16);
-        uint32_t cookie = htonl(stun::MAGIC_COOKIE);
-        for (int i = 0; i < 4; i++) addrBytes[i] ^= ((uint8_t*)&cookie)[i];
-        for (int i = 0; i < 12; i++) addrBytes[4 + i] ^= req.transactionId[i];
+        xor_result = {buf, mapped_port};
+      } else if (family == 0x02 && attr_len >= 20) {
+        uint8_t addr_bytes[16];
+        std::memcpy(addr_bytes, attrs + offset + 4, 16);
+        uint32_t cookie = htonl(stun::kMagicCookie);
+        for (int i = 0; i < 4; i++) addr_bytes[i] ^= ((uint8_t*)&cookie)[i];
+        for (int i = 0; i < 12; i++) addr_bytes[4 + i] ^= req.transaction_id[i];
         char buf[INET6_ADDRSTRLEN];
-        inet_ntop(AF_INET6, addrBytes, buf, sizeof(buf));
-        xorResult = {buf, mappedPort};
+        inet_ntop(AF_INET6, addr_bytes, buf, sizeof(buf));
+        xor_result = {buf, mapped_port};
       }
-    } else if (attrType == stun::ATTR_MAPPED_ADDRESS && attrLen >= 8) {
+    } else if (attr_type == stun::kAttrMappedAddress && attr_len >= 8) {
       uint8_t family = attrs[offset + 1];
-      uint16_t mappedPort = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
+      uint16_t mapped_port = (uint16_t)(attrs[offset + 2] << 8 | attrs[offset + 3]);
 
       if (family == 0x01) {
         uint32_t addr;
@@ -101,100 +101,100 @@ StunMappedAddress stun::parseResponse(const uint8_t* data, size_t len, const stu
         char buf[64];
         snprintf(buf, sizeof(buf), "%u.%u.%u.%u", (addr >> 24) & 0xFF, (addr >> 16) & 0xFF,
                  (addr >> 8) & 0xFF, addr & 0xFF);
-        plainResult = {buf, mappedPort};
+        plain_result = {buf, mapped_port};
       }
     }
 
-    offset += (attrLen + 3) & ~3u;
+    offset += (attr_len + 3) & ~3u;
   }
 
-  if (!xorResult.ip.empty()) return xorResult;
-  return plainResult;
+  if (!xor_result.ip.empty()) return xor_result;
+  return plain_result;
 }
 
 // --- StunQuery (background thread, own socket) ---
 
-void StunQuery::start() {
+void StunQuery::Start() {
   if (started_.exchange(true)) return;
-  thread_ = std::thread(&StunQuery::run, this);
+  thread_ = std::thread(&StunQuery::Run, this);
 }
 
-void StunQuery::start(uint16_t localPort) {
+void StunQuery::Start(uint16_t local_port) {
   if (started_.exchange(true)) return;
-  localPort_ = localPort;
-  thread_ = std::thread(&StunQuery::run, this);
+  localPort_ = local_port;
+  thread_ = std::thread(&StunQuery::Run, this);
 }
 
 StunQuery::~StunQuery() {
   if (thread_.joinable()) thread_.join();
 }
 
-StunResult StunQuery::result() const {
+StunResult StunQuery::Result() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return result_;
 }
 
-StunMappedAddress StunQuery::queryServer(const char* serverAddr, uint16_t port,
-                                         uint16_t localPort) {
+StunMappedAddress StunQuery::QueryServer(const char* server_addr, uint16_t port,
+                                         uint16_t local_port) {
   enet_initialize();
 
   ENetSocket sock = enet_socket_create(ENET_SOCKET_TYPE_DATAGRAM);
   if (sock == ENET_SOCKET_NULL) return {};
 
-  if (localPort != 0) {
+  if (local_port != 0) {
     enet_socket_set_option(sock, ENET_SOCKOPT_REUSEADDR, 1);
-    ENetAddress localAddr = {};
-    localAddr.port = localPort;
-    memset(&localAddr.host, 0, sizeof(localAddr.host));
-    enet_socket_bind(sock, &localAddr);
+    ENetAddress local_addr = {};
+    local_addr.port = local_port;
+    memset(&local_addr.host, 0, sizeof(local_addr.host));
+    enet_socket_bind(sock, &local_addr);
   }
 
   ENetAddress addr = {};
   addr.port = port;
-  if (enet_address_set_host(&addr, serverAddr) != 0) {
+  if (enet_address_set_host(&addr, server_addr) != 0) {
     enet_socket_destroy(sock);
     return {};
   }
 
-  stun::Header req = stun::buildRequest();
+  stun::Header req = stun::BuildRequest();
 
-  ENetBuffer sendBuf;
-  sendBuf.data = &req;
-  sendBuf.dataLength = sizeof(req);
+  ENetBuffer send_buf;
+  send_buf.data = &req;
+  send_buf.dataLength = sizeof(req);
 
-  uint8_t recvData[512];
-  ENetBuffer recvBuf;
-  recvBuf.data = recvData;
-  recvBuf.dataLength = sizeof(recvData);
+  uint8_t recv_data[512];
+  ENetBuffer recv_buf;
+  recv_buf.data = recv_data;
+  recv_buf.dataLength = sizeof(recv_data);
 
   StunMappedAddress result;
-  for (int attempt = 0; attempt < STUN_RETRIES && result.ip.empty(); ++attempt) {
-    int sent = enet_socket_send(sock, &addr, &sendBuf, 1);
+  for (int attempt = 0; attempt < kStunRetries && result.ip.empty(); ++attempt) {
+    int sent = enet_socket_send(sock, &addr, &send_buf, 1);
     if (sent < 0) break;
 
-    enet_uint32 waitCondition = ENET_SOCKET_WAIT_RECEIVE;
-    if (enet_socket_wait(sock, &waitCondition, STUN_TIMEOUT_MS) != 0) continue;
-    if (!(waitCondition & ENET_SOCKET_WAIT_RECEIVE)) continue;
+    enet_uint32 wait_condition = ENET_SOCKET_WAIT_RECEIVE;
+    if (enet_socket_wait(sock, &wait_condition, kStunTimeoutMs) != 0) continue;
+    if (!(wait_condition & ENET_SOCKET_WAIT_RECEIVE)) continue;
 
-    ENetAddress fromAddr = {};
-    int recvLen = enet_socket_receive(sock, &fromAddr, &recvBuf, 1);
-    if (recvLen < (int)sizeof(stun::Header)) continue;
+    ENetAddress from_addr = {};
+    int recv_len = enet_socket_receive(sock, &from_addr, &recv_buf, 1);
+    if (recv_len < (int)sizeof(stun::Header)) continue;
 
-    result = stun::parseResponse(recvData, (size_t)recvLen, req);
+    result = stun::ParseResponse(recv_data, (size_t)recv_len, req);
   }
 
   enet_socket_destroy(sock);
   return result;
 }
 
-void StunQuery::run() {
+void StunQuery::Run() {
   StunResult res;
-  auto v4 = queryServer(STUN_SERVER_IPV4, STUN_PORT, localPort_);
+  auto v4 = QueryServer(kStunServerIpV4, kStunPort, localPort_);
   res.ipv4 = v4.ip;
-  res.ipv4Port = v4.port;
-  auto v6 = queryServer(STUN_SERVER_IPV6, STUN_PORT, localPort_);
+  res.ipv4_port = v4.port;
+  auto v6 = QueryServer(kStunServerIpV6, kStunPort, localPort_);
   res.ipv6 = v6.ip;
-  res.ipv6Port = v6.port;
+  res.ipv6_port = v6.port;
 
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/game/net/stun.hpp
+++ b/src/game/net/stun.hpp
@@ -8,9 +8,9 @@
 
 struct StunResult {
   std::string ipv4;
-  uint16_t ipv4Port = 0;
+  uint16_t ipv4_port = 0;
   std::string ipv6;
-  uint16_t ipv6Port = 0;
+  uint16_t ipv6_port = 0;
 };
 
 struct StunMappedAddress {
@@ -20,46 +20,46 @@ struct StunMappedAddress {
 
 // STUN protocol constants (RFC 5389)
 namespace stun {
-constexpr uint16_t BINDING_REQUEST = 0x0001;
-constexpr uint16_t BINDING_RESPONSE = 0x0101;
-constexpr uint32_t MAGIC_COOKIE = 0x2112A442;
-constexpr uint16_t ATTR_XOR_MAPPED_ADDRESS = 0x0020;
-constexpr uint16_t ATTR_MAPPED_ADDRESS = 0x0001;
+constexpr uint16_t kBindingRequest = 0x0001;
+constexpr uint16_t kBindingResponse = 0x0101;
+constexpr uint32_t kMagicCookie = 0x2112A442;
+constexpr uint16_t kAttrXorMappedAddress = 0x0020;
+constexpr uint16_t kAttrMappedAddress = 0x0001;
 
 struct Header {
   uint16_t type;
   uint16_t length;
-  uint32_t magicCookie;
-  uint8_t transactionId[12];
+  uint32_t magic_cookie;
+  uint8_t transaction_id[12];
 };
 static_assert(sizeof(Header) == 20);
 
 // Parse a STUN Binding Response, extracting the mapped address.
-StunMappedAddress parseResponse(const uint8_t* data, size_t len, const Header& req);
+StunMappedAddress ParseResponse(const uint8_t* data, size_t len, const Header& req);
 
 // Build a STUN Binding Request. Fills in txnId with random bytes.
-Header buildRequest();
+Header BuildRequest();
 
 // Check if a packet is a STUN Binding Response matching our transaction ID.
-bool isResponse(const uint8_t* data, size_t len, const Header& req);
+bool IsResponse(const uint8_t* data, size_t len, const Header& req);
 }  // namespace stun
 
 // Async STUN query using a background thread and its own socket.
 // Use this for initial discovery when no ENet host exists yet.
 class StunQuery {
  public:
-  void start();
-  void start(uint16_t localPort);
+  void Start();
+  void Start(uint16_t local_port);
 
-  StunResult result() const;
-  bool done() const { return done_.load(); }
+  StunResult Result() const;
+  bool Done() const { return done_.load(); }
 
   ~StunQuery();
 
  private:
-  static StunMappedAddress queryServer(const char* serverAddr, uint16_t port,
-                                       uint16_t localPort = 0);
-  void run();
+  static StunMappedAddress QueryServer(const char* server_addr, uint16_t port,
+                                       uint16_t local_port = 0);
+  void Run();
 
   std::thread thread_;
   std::atomic<bool> done_{false};

--- a/src/game/net/tcArchive.cpp
+++ b/src/game/net/tcArchive.cpp
@@ -6,32 +6,32 @@
 
 #include "../filesystem.hpp"
 
-namespace TcArchive {
+namespace tc_archive {
 
 namespace {
 
 // Recursively collect all files under a directory, with relative paths.
-void collectFiles(FsNode node, const std::string& prefix,
+void CollectFiles(FsNode node, const std::string& prefix,
                   std::vector<std::pair<std::string, std::vector<uint8_t>>>& out) {
-  DirectoryListing listing = node.iter();
+  DirectoryListing listing = node.Iter();
   for (auto& entry : listing) {
     FsNode child = node / entry.name;
-    std::string relPath = prefix.empty() ? entry.name : prefix + "/" + entry.name;
+    std::string rel_path = prefix.empty() ? entry.name : prefix + "/" + entry.name;
 
-    if (entry.isDir) {
-      collectFiles(child, relPath, out);
+    if (entry.is_dir) {
+      CollectFiles(child, rel_path, out);
     } else {
       try {
-        auto r_ptr = child.toReader();
+        auto r_ptr = child.ToReader();
         io::Reader& r = *r_ptr;
         std::vector<uint8_t> data;
         uint8_t buf[4096];
         for (;;) {
-          std::size_t got = r.try_get(buf, sizeof(buf));
+          std::size_t got = r.TryGet(buf, sizeof(buf));
           if (got == 0) break;
           data.insert(data.end(), buf, buf + got);
         }
-        out.emplace_back(relPath, std::move(data));
+        out.emplace_back(rel_path, std::move(data));
       } catch (...) {
         // Skip files that can't be read
       }
@@ -41,9 +41,9 @@ void collectFiles(FsNode node, const std::string& prefix,
 
 }  // namespace
 
-uint32_t computeHash(FsNode root) {
+uint32_t ComputeHash(FsNode root) {
   std::vector<std::pair<std::string, std::vector<uint8_t>>> files;
-  collectFiles(root, "", files);
+  CollectFiles(root, "", files);
 
   // Sort by filename for deterministic ordering
   std::sort(files.begin(), files.end(),
@@ -64,9 +64,9 @@ uint32_t computeHash(FsNode root) {
   return hash;
 }
 
-std::vector<uint8_t> pack(FsNode root) {
+std::vector<uint8_t> Pack(FsNode root) {
   std::vector<std::pair<std::string, std::vector<uint8_t>>> files;
-  collectFiles(root, "", files);
+  CollectFiles(root, "", files);
 
   // Sort for deterministic ordering
   std::sort(files.begin(), files.end(),
@@ -74,36 +74,36 @@ std::vector<uint8_t> pack(FsNode root) {
 
   // Build raw archive: [numFiles(4)] + per file [nameLen(2) | name | dataLen(4) | data]
   std::vector<uint8_t> raw;
-  uint32_t numFiles = static_cast<uint32_t>(files.size());
+  uint32_t num_files = static_cast<uint32_t>(files.size());
   raw.resize(4);
-  std::memcpy(raw.data(), &numFiles, 4);
+  std::memcpy(raw.data(), &num_files, 4);
 
   for (auto& [name, data] : files) {
     if (name.size() > UINT16_MAX) continue;  // Skip files with names too long to encode
-    uint16_t nameLen = static_cast<uint16_t>(name.size());
-    uint32_t dataLen = static_cast<uint32_t>(data.size());
+    uint16_t name_len = static_cast<uint16_t>(name.size());
+    uint32_t data_len = static_cast<uint32_t>(data.size());
 
     size_t offset = raw.size();
-    raw.resize(offset + 2 + nameLen + 4 + dataLen);
+    raw.resize(offset + 2 + name_len + 4 + data_len);
 
-    std::memcpy(raw.data() + offset, &nameLen, 2);
-    std::memcpy(raw.data() + offset + 2, name.data(), nameLen);
-    std::memcpy(raw.data() + offset + 2 + nameLen, &dataLen, 4);
-    std::memcpy(raw.data() + offset + 2 + nameLen + 4, data.data(), dataLen);
+    std::memcpy(raw.data() + offset, &name_len, 2);
+    std::memcpy(raw.data() + offset + 2, name.data(), name_len);
+    std::memcpy(raw.data() + offset + 2 + name_len, &data_len, 4);
+    std::memcpy(raw.data() + offset + 2 + name_len + 4, data.data(), data_len);
   }
 
   // Compress
-  mz_ulong compBound = mz_compressBound(static_cast<mz_ulong>(raw.size()));
-  std::vector<uint8_t> compressed(compBound + 5);  // 1 byte flag + 4 byte uncompressed size
+  mz_ulong comp_bound = mz_compressBound(static_cast<mz_ulong>(raw.size()));
+  std::vector<uint8_t> compressed(comp_bound + 5);  // 1 byte flag + 4 byte uncompressed size
   compressed[0] = 1;                               // compressed flag
-  uint32_t rawSize = static_cast<uint32_t>(raw.size());
-  std::memcpy(compressed.data() + 1, &rawSize, 4);
+  uint32_t raw_size = static_cast<uint32_t>(raw.size());
+  std::memcpy(compressed.data() + 1, &raw_size, 4);
 
-  mz_ulong compSize = compBound;
+  mz_ulong comp_size = comp_bound;
   int status =
-      mz_compress(compressed.data() + 5, &compSize, raw.data(), static_cast<mz_ulong>(raw.size()));
+      mz_compress(compressed.data() + 5, &comp_size, raw.data(), static_cast<mz_ulong>(raw.size()));
   if (status == MZ_OK) {
-    compressed.resize(5 + compSize);
+    compressed.resize(5 + comp_size);
   } else {
     // Fallback: send uncompressed
     compressed.resize(5 + raw.size());
@@ -114,54 +114,54 @@ std::vector<uint8_t> pack(FsNode root) {
   return compressed;
 }
 
-std::vector<FileEntry> unpack(const uint8_t* data, size_t len) {
+std::vector<FileEntry> Unpack(const uint8_t* data, size_t len) {
   std::vector<FileEntry> result;
   if (len < 5) return result;
 
-  bool isCompressed = data[0] != 0;
-  uint32_t rawSize;
-  std::memcpy(&rawSize, data + 1, 4);
+  bool is_compressed = data[0] != 0;
+  uint32_t raw_size;
+  std::memcpy(&raw_size, data + 1, 4);
 
   // Prevent decompression bombs: limit uncompressed size to 64 MB
-  static constexpr uint32_t MaxUncompressedSize = 64 * 1024 * 1024;
-  if (rawSize > MaxUncompressedSize) return result;
+  static constexpr uint32_t kMaxUncompressedSize = 64 * 1024 * 1024;
+  if (raw_size > kMaxUncompressedSize) return result;
 
   std::vector<uint8_t> raw;
-  if (isCompressed) {
-    raw.resize(rawSize);
-    mz_ulong destLen = rawSize;
-    int status = mz_uncompress(raw.data(), &destLen, data + 5, static_cast<mz_ulong>(len - 5));
+  if (is_compressed) {
+    raw.resize(raw_size);
+    mz_ulong dest_len = raw_size;
+    int status = mz_uncompress(raw.data(), &dest_len, data + 5, static_cast<mz_ulong>(len - 5));
     if (status != MZ_OK) return result;
   } else {
-    if (len - 5 < rawSize) return result;
-    raw.assign(data + 5, data + 5 + rawSize);
+    if (len - 5 < raw_size) return result;
+    raw.assign(data + 5, data + 5 + raw_size);
   }
 
   // Parse archive
   if (raw.size() < 4) return result;
-  uint32_t numFiles;
-  std::memcpy(&numFiles, raw.data(), 4);
+  uint32_t num_files;
+  std::memcpy(&num_files, raw.data(), 4);
 
   size_t offset = 4;
-  for (uint32_t i = 0; i < numFiles; ++i) {
+  for (uint32_t i = 0; i < num_files; ++i) {
     if (offset + 2 > raw.size()) break;
-    uint16_t nameLen;
-    std::memcpy(&nameLen, raw.data() + offset, 2);
+    uint16_t name_len;
+    std::memcpy(&name_len, raw.data() + offset, 2);
     offset += 2;
 
-    if (offset + nameLen + 4 > raw.size()) break;
-    std::string name(reinterpret_cast<const char*>(raw.data() + offset), nameLen);
-    offset += nameLen;
+    if (offset + name_len + 4 > raw.size()) break;
+    std::string name(reinterpret_cast<const char*>(raw.data() + offset), name_len);
+    offset += name_len;
 
-    uint32_t dataLen;
-    std::memcpy(&dataLen, raw.data() + offset, 4);
+    uint32_t data_len;
+    std::memcpy(&data_len, raw.data() + offset, 4);
     offset += 4;
 
-    if (offset + dataLen > raw.size()) break;
-    std::vector<uint8_t> fileData(raw.data() + offset, raw.data() + offset + dataLen);
-    offset += dataLen;
+    if (offset + data_len > raw.size()) break;
+    std::vector<uint8_t> file_data(raw.data() + offset, raw.data() + offset + data_len);
+    offset += data_len;
 
-    result.push_back({std::move(name), std::move(fileData)});
+    result.push_back({std::move(name), std::move(file_data)});
   }
 
   return result;

--- a/src/game/net/tcArchive.cpp
+++ b/src/game/net/tcArchive.cpp
@@ -95,7 +95,7 @@ std::vector<uint8_t> Pack(FsNode root) {
   // Compress
   mz_ulong comp_bound = mz_compressBound(static_cast<mz_ulong>(raw.size()));
   std::vector<uint8_t> compressed(comp_bound + 5);  // 1 byte flag + 4 byte uncompressed size
-  compressed[0] = 1;                               // compressed flag
+  compressed[0] = 1;                                // compressed flag
   uint32_t raw_size = static_cast<uint32_t>(raw.size());
   std::memcpy(compressed.data() + 1, &raw_size, 4);
 
@@ -167,4 +167,4 @@ std::vector<FileEntry> Unpack(const uint8_t* data, size_t len) {
   return result;
 }
 
-}  // namespace TcArchive
+}  // namespace tc_archive

--- a/src/game/net/tcArchive.hpp
+++ b/src/game/net/tcArchive.hpp
@@ -28,4 +28,4 @@ struct FileEntry {
 };
 std::vector<FileEntry> Unpack(const uint8_t* data, size_t len);
 
-}  // namespace TcArchive
+}  // namespace tc_archive

--- a/src/game/net/tcArchive.hpp
+++ b/src/game/net/tcArchive.hpp
@@ -7,18 +7,18 @@
 struct FsNode;
 
 // Utilities for TC (total conversion) hashing and archive transfer.
-namespace TcArchive {
+namespace tc_archive {
 
 // Compute a deterministic hash of a TC directory.
 // Walks all files recursively in sorted filename order,
 // hashing their contents with FNV-1a.
-uint32_t computeHash(FsNode root);
+uint32_t ComputeHash(FsNode root);
 
 // Pack a TC directory into a compressed archive blob.
 // Archive format: [numFiles(4)] then for each file:
 //   [nameLen(2) | name(nameLen) | dataLen(4) | data(dataLen)]
 // The entire payload is compressed with miniz.
-std::vector<uint8_t> pack(FsNode root);
+std::vector<uint8_t> Pack(FsNode root);
 
 // Unpack a compressed TC archive into a flat file map.
 // Returns a list of (relative path, file data) pairs.
@@ -26,6 +26,6 @@ struct FileEntry {
   std::string name;
   std::vector<uint8_t> data;
 };
-std::vector<FileEntry> unpack(const uint8_t* data, size_t len);
+std::vector<FileEntry> Unpack(const uint8_t* data, size_t len);
 
 }  // namespace TcArchive

--- a/src/game/net/transport.cpp
+++ b/src/game/net/transport.cpp
@@ -15,40 +15,40 @@
 #include <arpa/inet.h>
 #endif
 
-static void writeU32(uint8_t* p, uint32_t v) { std::memcpy(p, &v, 4); }
-static void writeI32(uint8_t* p, int32_t v) { std::memcpy(p, &v, 4); }
-static uint32_t readU32(const uint8_t* p) {
+static void WriteU32(uint8_t* p, uint32_t v) { std::memcpy(p, &v, 4); }
+static void WriteI32(uint8_t* p, int32_t v) { std::memcpy(p, &v, 4); }
+static uint32_t ReadU32(const uint8_t* p) {
   uint32_t v;
   std::memcpy(&v, p, 4);
   return v;
 }
-static int32_t readI32(const uint8_t* p) {
+static int32_t ReadI32(const uint8_t* p) {
   int32_t v;
   std::memcpy(&v, p, 4);
   return v;
 }
 
-static constexpr int NUM_CHANNELS = 3;
-static constexpr int CHANNEL_RELIABLE = 0;
-static constexpr int CHANNEL_UNRELIABLE = 1;
-static constexpr int CHANNEL_INPUT_BATCH = 2;
+static constexpr int kNumChannels = 3;
+static constexpr int kChannelReliable = 0;
+static constexpr int kChannelUnreliable = 1;
+static constexpr int kChannelInputBatch = 2;
 
 // Single active transport pointer. Only one ENet host exists per process.
-static std::atomic<NetTransport*> sActiveTransport{nullptr};
+static std::atomic<NetTransport*> s_active_transport{nullptr};
 
-static void registerTransport(_ENetHost*, NetTransport* t) {
-  sActiveTransport.store(t, std::memory_order_release);
+static void RegisterTransport(_ENetHost*, NetTransport* t) {
+  s_active_transport.store(t, std::memory_order_release);
 }
 
-static void unregisterTransport(_ENetHost*) {
-  sActiveTransport.store(nullptr, std::memory_order_release);
+static void UnregisterTransport(_ENetHost*) {
+  s_active_transport.store(nullptr, std::memory_order_release);
 }
 
-static NetTransport* getTransportFromHost(_ENetHost*) {
-  return sActiveTransport.load(std::memory_order_acquire);
+static NetTransport* GetTransportFromHost(_ENetHost*) {
+  return s_active_transport.load(std::memory_order_acquire);
 }
 
-NetTransport::NetTransport() : enetHost_(nullptr), peer_(nullptr), state_(Disconnected) {
+NetTransport::NetTransport() : enetHost_(nullptr), peer_(nullptr), state_(kDisconnected) {
   enet_initialize();
 }
 
@@ -59,101 +59,101 @@ NetTransport::NetTransport(NetTransport&& other) noexcept
       iceBridge_(std::move(other.iceBridge_)),
       iceAgent_(std::move(other.iceAgent_)) {
   if (enetHost_) {
-    registerTransport(enetHost_, this);
+    RegisterTransport(enetHost_, this);
   }
   other.enetHost_ = nullptr;
   other.peer_ = nullptr;
-  other.state_ = Disconnected;
+  other.state_ = kDisconnected;
 }
 
 NetTransport& NetTransport::operator=(NetTransport&& other) noexcept {
   if (this != &other) {
-    disconnect();
+    Disconnect();
     enetHost_ = other.enetHost_;
     peer_ = other.peer_;
     state_ = other.state_;
     iceBridge_ = std::move(other.iceBridge_);
     iceAgent_ = std::move(other.iceAgent_);
     if (enetHost_) {
-      registerTransport(enetHost_, this);
+      RegisterTransport(enetHost_, this);
     }
     other.enetHost_ = nullptr;
     other.peer_ = nullptr;
-    other.state_ = Disconnected;
+    other.state_ = kDisconnected;
   }
   return *this;
 }
 
 NetTransport::~NetTransport() {
-  disconnect();
+  Disconnect();
   enet_deinitialize();
 }
 
-void NetTransport::disconnect() {
+void NetTransport::Disconnect() {
   if (peer_) {
     enet_peer_disconnect_now(peer_, 0);
     peer_ = nullptr;
   }
   if (enetHost_) {
-    unregisterTransport(enetHost_);
+    UnregisterTransport(enetHost_);
     enet_host_destroy(enetHost_);
     enetHost_ = nullptr;
   }
-  state_ = Disconnected;
+  state_ = kDisconnected;
 }
 
-uint16_t NetTransport::listeningPort() const { return enetHost_ ? enetHost_->address.port : 0; }
+uint16_t NetTransport::ListeningPort() const { return enetHost_ ? enetHost_->address.port : 0; }
 
-bool NetTransport::createHost(uint16_t port) {
+bool NetTransport::CreateHost(uint16_t port) {
   ENetAddress address = {};
   address.port = port;
 
-  enetHost_ = enet_host_create(&address, 1, NUM_CHANNELS, 0, 0);
+  enetHost_ = enet_host_create(&address, 1, kNumChannels, 0, 0);
   if (!enetHost_) return false;
 
-  setupIntercept();
+  SetupIntercept();
   return true;
 }
 
-void NetTransport::setupIntercept() {
+void NetTransport::SetupIntercept() {
   if (!enetHost_) return;
-  registerTransport(enetHost_, this);
-  enet_host_set_intercept(enetHost_, &NetTransport::interceptCallback);
+  RegisterTransport(enetHost_, this);
+  enet_host_set_intercept(enetHost_, &NetTransport::InterceptCallback);
 }
 
-int NetTransport::interceptCallback(_ENetHost* host, void* /*event*/) {
-  NetTransport* self = getTransportFromHost(host);
+int NetTransport::InterceptCallback(_ENetHost* host, void* /*event*/) {
+  NetTransport* self = GetTransportFromHost(host);
   if (!self) return 0;
 
   uint8_t* data = host->receivedData;
   size_t len = host->receivedDataLength;
 
   // Let user-provided handler try (e.g., STUN responses)
-  if (self->onInterceptedPacket && self->onInterceptedPacket(data, len)) {
+  if (self->on_intercepted_packet && self->on_intercepted_packet(data, len)) {
     return 1;
   }
 
   return 0;  // Not consumed — let ENet process it
 }
 
-bool NetTransport::host(uint16_t port) {
+bool NetTransport::Host(uint16_t port) {
   if (enetHost_) return false;
 
-  if (!createHost(port)) {
-    state_ = Failed;
+  if (!CreateHost(port)) {
+    state_ = kFailed;
     return false;
   }
 
-  state_ = Listening;
+  state_ = kListening;
   return true;
 }
 
-bool NetTransport::connect(const std::string& address, uint16_t port) {
+bool NetTransport::Connect(const std::string& address, uint16_t port) {
   if (enetHost_) return false;
 
   // Create host on ephemeral port
-  if (!createHost(0)) {
-    state_ = Failed;
+  if (!CreateHost(0)) {
+    state_ = kFailed;
     return false;
   }
 
@@ -162,86 +162,86 @@ bool NetTransport::connect(const std::string& address, uint16_t port) {
   if (enet_address_set_host(&addr, address.c_str()) != 0) {
     enet_host_destroy(enetHost_);
     enetHost_ = nullptr;
-    state_ = Failed;
+    state_ = kFailed;
     return false;
   }
 
-  peer_ = enet_host_connect(enetHost_, &addr, NUM_CHANNELS, 0);
+  peer_ = enet_host_connect(enetHost_, &addr, kNumChannels, 0);
   if (!peer_) {
     enet_host_destroy(enetHost_);
     enetHost_ = nullptr;
-    state_ = Failed;
+    state_ = kFailed;
     return false;
   }
 
-  state_ = Connecting;
+  state_ = kConnecting;
   return true;
 }
 
-bool NetTransport::connectExisting(const std::string& address, uint16_t port) {
+bool NetTransport::ConnectExisting(const std::string& address, uint16_t port) {
   if (!enetHost_) return false;
   if (peer_) return false;
 
   ENetAddress addr = {};
   addr.port = port;
   if (enet_address_set_host(&addr, address.c_str()) != 0) {
-    state_ = Failed;
+    state_ = kFailed;
     return false;
   }
 
-  peer_ = enet_host_connect(enetHost_, &addr, NUM_CHANNELS, 0);
+  peer_ = enet_host_connect(enetHost_, &addr, kNumChannels, 0);
   if (!peer_) {
-    state_ = Failed;
+    state_ = kFailed;
     return false;
   }
 
-  state_ = Connecting;
+  state_ = kConnecting;
   return true;
 }
 
-bool NetTransport::createHostOnBridgeSocket(BridgeSocket bridgeSocket) {
+bool NetTransport::CreateHostOnBridgeSocket(BridgeSocket bridge_socket) {
   if (enetHost_) return false;
 
   // Create ENet host with no address (won't bind a new socket)
-  enetHost_ = enet_host_create(nullptr, 1, NUM_CHANNELS, 0, 0);
+  enetHost_ = enet_host_create(nullptr, 1, kNumChannels, 0, 0);
   if (!enetHost_) return false;
 
   // Replace ENet's auto-created socket with the bridge socket
   enet_socket_destroy(enetHost_->socket);
-  enetHost_->socket = (ENetSocket)bridgeSocket;
+  enetHost_->socket = (ENetSocket)bridge_socket;
 
-  setupIntercept();
-  state_ = Listening;
+  SetupIntercept();
+  state_ = kListening;
   return true;
 }
 
-void NetTransport::attachIce(std::unique_ptr<IceBridge> bridge, std::unique_ptr<IceAgent> agent) {
+void NetTransport::AttachIce(std::unique_ptr<IceBridge> bridge, std::unique_ptr<IceAgent> agent) {
   iceBridge_ = std::move(bridge);
   iceAgent_ = std::move(agent);
 }
 
 // --- Poll ---
 
-bool NetTransport::poll() {
+bool NetTransport::Poll() {
   if (!enetHost_) return false;
 
-  if (iceAgent_) iceAgent_->poll();
+  if (iceAgent_) iceAgent_->Poll();
 
   ENetEvent event;
   while (enet_host_service(enetHost_, &event, 0) > 0) {
     switch (event.type) {
       case ENET_EVENT_TYPE_CONNECT:
         peer_ = event.peer;
-        state_ = Connected;
-        if (onConnected) onConnected();
+        state_ = kConnected;
+        if (on_connected) on_connected();
         break;
 
       case ENET_EVENT_TYPE_RECEIVE: {
         uint8_t* data = event.packet->data;
         size_t len = event.packet->dataLength;
 
-        static constexpr size_t MaxPacketSize = 10 * 1024 * 1024;
-        if (len > MaxPacketSize) {
+        static constexpr size_t kMaxPacketSize = 10 * 1024 * 1024;
+        if (len > kMaxPacketSize) {
           enet_packet_destroy(event.packet);
           break;
         }
@@ -250,66 +250,66 @@ bool NetTransport::poll() {
         // so we can tell whether checksum packets are reaching the wire
         // at all (vs being lost in the ICE bridge or never sent).
         if (len >= 1) {
-          static const bool logEnabled = []() {
+          static const bool kLogEnabled = []() {
             char const* e = std::getenv("OPENLIERO_CHECKSUM_LOG");
             return e && *e && *e != '0';
           }();
-          if (logEnabled) {
-            static uint64_t cntInput = 0, cntBatch = 0, cntChecksum = 0, cntOther = 0;
+          if (kLogEnabled) {
+            static uint64_t cnt_input = 0, cnt_batch = 0, cnt_checksum = 0, cnt_other = 0;
             switch (data[0]) {
-              case PacketInput:
-                ++cntInput;
+              case kPacketInput:
+                ++cnt_input;
                 break;
-              case PacketInputBatch:
-                ++cntBatch;
+              case kPacketInputBatch:
+                ++cnt_batch;
                 break;
-              case PacketChecksum:
-                ++cntChecksum;
+              case kPacketChecksum:
+                ++cnt_checksum;
                 break;
               default:
-                ++cntOther;
+                ++cnt_other;
                 break;
             }
-            uint64_t total = cntInput + cntBatch + cntChecksum + cntOther;
+            uint64_t total = cnt_input + cnt_batch + cnt_checksum + cnt_other;
             if (total > 0 && total % 140 == 0) {
               std::fprintf(stderr,
                            "[transport rx] input=%llu batch=%llu "
                            "checksum=%llu other=%llu\n",
-                           (unsigned long long)cntInput, (unsigned long long)cntBatch,
-                           (unsigned long long)cntChecksum, (unsigned long long)cntOther);
+                           (unsigned long long)cnt_input, (unsigned long long)cnt_batch,
+                           (unsigned long long)cnt_checksum, (unsigned long long)cnt_other);
             }
           }
         }
 
         if (len >= 1) {
           switch (data[0]) {
-            case PacketInput:
-              if (len == 6 && onRemoteInput) {
+            case kPacketInput:
+              if (len == 6 && on_remote_input) {
                 uint32_t frame;
                 std::memcpy(&frame, data + 1, 4);
-                onRemoteInput(frame, data[5]);
+                on_remote_input(frame, data[5]);
               }
               break;
-            case PacketInputBatch:
+            case kPacketInputBatch:
               // [type:1][gen:1][baseFrame:u32 LE][count:u8][localDelta:u8]
               // [input[count]:u8]. Validate that localDelta is in range
               // (< count) and that the payload length matches count
               // exactly — anything else is malformed or a version drift.
-              if (len >= 8 && onRemoteInputBatch) {
+              if (len >= 8 && on_remote_input_batch) {
                 uint8_t gen = data[1];
-                uint32_t baseFrame;
-                std::memcpy(&baseFrame, data + 2, 4);
+                uint32_t base_frame;
+                std::memcpy(&base_frame, data + 2, 4);
                 uint8_t count = data[6];
-                uint8_t localDelta = data[7];
+                uint8_t local_delta = data[7];
                 if (count == 0 || len != size_t{8} + count) break;
-                if (localDelta >= count) break;
-                uint32_t remoteLocalFrame = baseFrame + localDelta;
-                onRemoteInputBatch(gen, baseFrame, count, data + 8, remoteLocalFrame);
+                if (local_delta >= count) break;
+                uint32_t remote_local_frame = base_frame + local_delta;
+                on_remote_input_batch(gen, base_frame, count, data + 8, remote_local_frame);
               }
               break;
-            case PacketHandshake:
+            case kPacketHandshake:
               // [type:1][version:1][seed:4][hash:4] = 10 B.
-              if (len == 10 && onHandshake) {
+              if (len == 10 && on_handshake) {
                 if (data[1] != kProtocolVersion) {
                   // Loud on stderr: a silent drop here surfaces as the
                   // session sitting in Handshaking forever, which is
@@ -326,109 +326,109 @@ bool NetTransport::poll() {
                 uint32_t seed, hash;
                 std::memcpy(&seed, data + 2, 4);
                 std::memcpy(&hash, data + 6, 4);
-                onHandshake(seed, hash);
+                on_handshake(seed, hash);
               }
               break;
-            case PacketChecksum:
+            case kPacketChecksum:
               // [type:1][gen:1][frame:u32 LE][checksum:u32 LE] = 10 B.
-              if (len == 10 && onChecksum) {
+              if (len == 10 && on_checksum) {
                 uint8_t gen = data[1];
                 uint32_t frame, checksum;
                 std::memcpy(&frame, data + 2, 4);
                 std::memcpy(&checksum, data + 6, 4);
-                onChecksum(gen, frame, checksum);
+                on_checksum(gen, frame, checksum);
               }
               break;
-            case PacketPlayerInfo:
-              if (len == 1 + kPlayerInfoWireSize && onPlayerInfo) {
+            case kPacketPlayerInfo:
+              if (len == 1 + kPlayerInfoWireSize && on_player_info) {
                 PlayerInfo info{};
                 const uint8_t* p = data + 1;
-                for (int i = 0; i < 5; ++i, p += 4) info.weapons[i] = readU32(p);
-                info.color = readI32(p);
+                for (int i = 0; i < 5; ++i, p += 4) info.weapons[i] = ReadU32(p);
+                info.color = ReadI32(p);
                 p += 4;
-                for (int i = 0; i < 3; ++i, p += 4) info.rgb[i] = readI32(p);
+                for (int i = 0; i < 3; ++i, p += 4) info.rgb[i] = ReadI32(p);
                 std::memcpy(info.name, p, 24);
-                onPlayerInfo(info);
+                on_player_info(info);
               }
               break;
-            case PacketMatchSettings:
-              if (len == 1 + kMatchSettingsWireSize && onMatchSettings) {
+            case kPacketMatchSettings:
+              if (len == 1 + kMatchSettingsWireSize && on_match_settings) {
                 MatchSettingsData msd{};
                 const uint8_t* p = data + 1;
-                msd.lives = readI32(p);
+                msd.lives = ReadI32(p);
                 p += 4;
-                msd.loadingTime = readI32(p);
+                msd.loading_time = ReadI32(p);
                 p += 4;
-                msd.gameMode = readU32(p);
+                msd.game_mode = ReadU32(p);
                 p += 4;
-                msd.blood = readI32(p);
+                msd.blood = ReadI32(p);
                 p += 4;
-                msd.maxBonuses = readI32(p);
+                msd.max_bonuses = ReadI32(p);
                 p += 4;
-                msd.timeToLose = readI32(p);
+                msd.time_to_lose = ReadI32(p);
                 p += 4;
-                msd.flagsToWin = readI32(p);
+                msd.flags_to_win = ReadI32(p);
                 p += 4;
-                msd.loadChange = *p++;
-                for (int i = 0; i < 40; ++i, p += 4) msd.weapTable[i] = readU32(p);
-                msd.regenerateLevel = *p++;
+                msd.load_change = *p++;
+                for (int i = 0; i < 40; ++i, p += 4) msd.weap_table[i] = ReadU32(p);
+                msd.regenerate_level = *p++;
                 msd.shadow = *p++;
-                msd.namesOnBonuses = *p++;
-                msd.bloodParticleMax = readI32(p);
+                msd.names_on_bonuses = *p++;
+                msd.blood_particle_max = ReadI32(p);
                 p += 4;
-                msd.zoneTimeout = readI32(p);
+                msd.zone_timeout = ReadI32(p);
                 p += 4;
-                msd.inputDelay = readI32(p);
-                onMatchSettings(msd);
+                msd.input_delay = ReadI32(p);
+                on_match_settings(msd);
               }
               break;
-            case PacketMapData:
-              if (len > 5 && onMapData) {
-                onMapData(data + 1, len - 1);
+            case kPacketMapData:
+              if (len > 5 && on_map_data) {
+                on_map_data(data + 1, len - 1);
               }
               break;
-            case PacketPause:
-              if (onPause) onPause();
+            case kPacketPause:
+              if (on_pause) on_pause();
               break;
-            case PacketResume:
-              if (onResume) onResume();
+            case kPacketResume:
+              if (on_resume) on_resume();
               break;
-            case PacketRematchReady:
-              if (len == 2 && onRematchReady) {
-                onRematchReady(data[1] != 0);
+            case kPacketRematchReady:
+              if (len == 2 && on_rematch_ready) {
+                on_rematch_ready(data[1] != 0);
               }
               break;
-            case PacketRematchLevel:
-              if (len >= 2 && onRematchLevel) {
+            case kPacketRematchLevel:
+              if (len >= 2 && on_rematch_level) {
                 bool random = data[1] != 0;
                 std::string file;
                 if (len > 2) file.assign(reinterpret_cast<const char*>(data + 2), len - 2);
-                onRematchLevel(random, std::move(file));
+                on_rematch_level(random, std::move(file));
               }
               break;
-            case PacketEndMatch:
-              if (onEndMatch) onEndMatch();
+            case kPacketEndMatch:
+              if (on_end_match) on_end_match();
               break;
-            case PacketPeerLeft:
-              if (onPeerLeft) onPeerLeft();
+            case kPacketPeerLeft:
+              if (on_peer_left) on_peer_left();
               break;
-            case PacketTcInfo:
-              if (len >= 5 && onTcInfo) {
+            case kPacketTcInfo:
+              if (len >= 5 && on_tc_info) {
                 uint32_t hash;
                 std::memcpy(&hash, data + 1, 4);
                 std::string name;
                 if (len > 5) name.assign(reinterpret_cast<const char*>(data + 5), len - 5);
-                onTcInfo(hash, std::move(name));
+                on_tc_info(hash, std::move(name));
               }
               break;
-            case PacketTcResponse:
-              if (len == 2 && onTcResponse) {
-                onTcResponse(data[1] != 0);
+            case kPacketTcResponse:
+              if (len == 2 && on_tc_response) {
+                on_tc_response(data[1] != 0);
               }
               break;
-            case PacketTcData:
-              if (len > 1 && onTcData) {
-                onTcData(data + 1, len - 1);
+            case kPacketTcData:
+              if (len > 1 && on_tc_data) {
+                on_tc_data(data + 1, len - 1);
               }
               break;
           }
@@ -441,8 +441,8 @@ bool NetTransport::poll() {
       case ENET_EVENT_TYPE_DISCONNECT:
       case ENET_EVENT_TYPE_DISCONNECT_TIMEOUT:
         peer_ = nullptr;
-        state_ = Disconnected;
-        if (onDisconnected) onDisconnected();
+        state_ = kDisconnected;
+        if (on_disconnected) on_disconnected();
         return false;
 
       case ENET_EVENT_TYPE_NONE:
@@ -452,24 +452,24 @@ bool NetTransport::poll() {
 
   // Forward ENet outgoing packets through ICE bridge AFTER enet_host_service
   // (ENet sends during service, bridge picks up and forwards to libjuice)
-  if (iceBridge_) iceBridge_->poll();
+  if (iceBridge_) iceBridge_->Poll();
 
-  return state_ == Connected || state_ == Listening || state_ == Connecting;
+  return state_ == kConnected || state_ == kListening || state_ == kConnecting;
 }
 
 // --- Send helpers ---
 
-void NetTransport::sendInput(uint32_t frame, uint8_t input) {
+void NetTransport::SendInput(uint32_t frame, uint8_t input) {
   uint8_t buf[6];
-  buf[0] = PacketInput;
+  buf[0] = kPacketInput;
   std::memcpy(buf + 1, &frame, 4);
   buf[5] = input;
-  sendPacket(buf, sizeof(buf));
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendInputBatch(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                  uint8_t localDelta, uint8_t const* inputs) {
-  if (!peer_ || count == 0 || localDelta >= count) return;
+void NetTransport::SendInputBatch(uint8_t generation, uint32_t base_frame, uint8_t count,
+                                  uint8_t local_delta, uint8_t const* inputs) {
+  if (!peer_ || count == 0 || local_delta >= count) return;
   // Cap to a defensive maximum so a misuse can't blow the stack
   // buffer. Rollback uses count = kMaxRollback + 1 (= 8); accept
   // anything up to 64 for headroom.
@@ -477,11 +477,11 @@ void NetTransport::sendInputBatch(uint8_t generation, uint32_t baseFrame, uint8_
   if (count > kMaxCount) return;
 
   uint8_t buf[8 + kMaxCount];
-  buf[0] = PacketInputBatch;
+  buf[0] = kPacketInputBatch;
   buf[1] = generation;
-  std::memcpy(buf + 2, &baseFrame, 4);
+  std::memcpy(buf + 2, &base_frame, 4);
   buf[6] = count;
-  buf[7] = localDelta;
+  buf[7] = local_delta;
   std::memcpy(buf + 8, inputs, count);
 
   size_t len = size_t{8} + count;
@@ -489,148 +489,148 @@ void NetTransport::sendInputBatch(uint8_t generation, uint32_t baseFrame, uint8_
   // delivered after a newer one. injectRemoteInput already dedups.
   ENetPacket* packet = enet_packet_create(buf, len, ENET_PACKET_FLAG_UNSEQUENCED);
   if (!packet) return;
-  if (enet_peer_send(peer_, CHANNEL_INPUT_BATCH, packet) < 0) enet_packet_destroy(packet);
+  if (enet_peer_send(peer_, kChannelInputBatch, packet) < 0) enet_packet_destroy(packet);
 }
 
-void NetTransport::sendChecksum(uint8_t generation, uint32_t frame, uint32_t checksum) {
+void NetTransport::SendChecksum(uint8_t generation, uint32_t frame, uint32_t checksum) {
   uint8_t buf[10];
-  buf[0] = PacketChecksum;
+  buf[0] = kPacketChecksum;
   buf[1] = generation;
   std::memcpy(buf + 2, &frame, 4);
   std::memcpy(buf + 6, &checksum, 4);
 
   if (!peer_) return;
   ENetPacket* packet = enet_packet_create(buf, sizeof(buf), ENET_PACKET_FLAG_UNSEQUENCED);
-  if (packet) enet_peer_send(peer_, CHANNEL_UNRELIABLE, packet);
+  if (packet) enet_peer_send(peer_, kChannelUnreliable, packet);
 }
 
-void NetTransport::sendHandshake(uint32_t seed, uint32_t settingsHash) {
+void NetTransport::SendHandshake(uint32_t seed, uint32_t settings_hash) {
   uint8_t buf[10];
-  buf[0] = PacketHandshake;
+  buf[0] = kPacketHandshake;
   buf[1] = kProtocolVersion;
   std::memcpy(buf + 2, &seed, 4);
-  std::memcpy(buf + 6, &settingsHash, 4);
-  sendPacket(buf, sizeof(buf));
+  std::memcpy(buf + 6, &settings_hash, 4);
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendPlayerInfo(const PlayerInfo& info) {
+void NetTransport::SendPlayerInfo(const PlayerInfo& info) {
   uint8_t buf[1 + kPlayerInfoWireSize];
-  buf[0] = PacketPlayerInfo;
+  buf[0] = kPacketPlayerInfo;
   uint8_t* p = buf + 1;
-  for (int i = 0; i < 5; ++i, p += 4) writeU32(p, info.weapons[i]);
-  writeI32(p, info.color);
+  for (int i = 0; i < 5; ++i, p += 4) WriteU32(p, info.weapons[i]);
+  WriteI32(p, info.color);
   p += 4;
-  for (int i = 0; i < 3; ++i, p += 4) writeI32(p, info.rgb[i]);
+  for (int i = 0; i < 3; ++i, p += 4) WriteI32(p, info.rgb[i]);
   std::memcpy(p, info.name, 24);
-  sendPacket(buf, sizeof(buf));
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendMatchSettings(const MatchSettingsData& data) {
+void NetTransport::SendMatchSettings(const MatchSettingsData& data) {
   uint8_t buf[1 + kMatchSettingsWireSize];
-  buf[0] = PacketMatchSettings;
+  buf[0] = kPacketMatchSettings;
   uint8_t* p = buf + 1;
-  writeI32(p, data.lives);
+  WriteI32(p, data.lives);
   p += 4;
-  writeI32(p, data.loadingTime);
+  WriteI32(p, data.loading_time);
   p += 4;
-  writeU32(p, data.gameMode);
+  WriteU32(p, data.game_mode);
   p += 4;
-  writeI32(p, data.blood);
+  WriteI32(p, data.blood);
   p += 4;
-  writeI32(p, data.maxBonuses);
+  WriteI32(p, data.max_bonuses);
   p += 4;
-  writeI32(p, data.timeToLose);
+  WriteI32(p, data.time_to_lose);
   p += 4;
-  writeI32(p, data.flagsToWin);
+  WriteI32(p, data.flags_to_win);
   p += 4;
-  *p++ = data.loadChange;
-  for (int i = 0; i < 40; ++i, p += 4) writeU32(p, data.weapTable[i]);
-  *p++ = data.regenerateLevel;
+  *p++ = data.load_change;
+  for (int i = 0; i < 40; ++i, p += 4) WriteU32(p, data.weap_table[i]);
+  *p++ = data.regenerate_level;
   *p++ = data.shadow;
-  *p++ = data.namesOnBonuses;
-  writeI32(p, data.bloodParticleMax);
+  *p++ = data.names_on_bonuses;
+  WriteI32(p, data.blood_particle_max);
   p += 4;
-  writeI32(p, data.zoneTimeout);
+  WriteI32(p, data.zone_timeout);
   p += 4;
-  writeI32(p, data.inputDelay);
-  sendPacket(buf, sizeof(buf));
+  WriteI32(p, data.input_delay);
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendMapData(const void* data, size_t len) {
+void NetTransport::SendMapData(const void* data, size_t len) {
   std::vector<uint8_t> buf(1 + len);
-  buf[0] = PacketMapData;
+  buf[0] = kPacketMapData;
   std::memcpy(buf.data() + 1, data, len);
 
   if (!peer_) return;
   ENetPacket* packet = enet_packet_create(buf.data(), buf.size(), ENET_PACKET_FLAG_RELIABLE);
   if (!packet) return;
-  if (enet_peer_send(peer_, CHANNEL_RELIABLE, packet) < 0) enet_packet_destroy(packet);
+  if (enet_peer_send(peer_, kChannelReliable, packet) < 0) enet_packet_destroy(packet);
 }
 
-void NetTransport::sendPause() {
-  uint8_t buf[1] = {PacketPause};
-  sendPacket(buf, sizeof(buf));
+void NetTransport::SendPause() {
+  uint8_t buf[1] = {kPacketPause};
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendResume() {
-  uint8_t buf[1] = {PacketResume};
-  sendPacket(buf, sizeof(buf));
+void NetTransport::SendResume() {
+  uint8_t buf[1] = {kPacketResume};
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendRematchReady(bool ready) {
+void NetTransport::SendRematchReady(bool ready) {
   uint8_t buf[2];
-  buf[0] = PacketRematchReady;
+  buf[0] = kPacketRematchReady;
   buf[1] = ready ? 1 : 0;
-  sendPacket(buf, sizeof(buf));
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendRematchLevel(bool randomLevel, const std::string& levelFile) {
-  std::vector<uint8_t> buf(2 + levelFile.size());
-  buf[0] = PacketRematchLevel;
-  buf[1] = randomLevel ? 1 : 0;
-  if (!levelFile.empty()) std::memcpy(buf.data() + 2, levelFile.data(), levelFile.size());
-  sendPacket(buf.data(), buf.size());
+void NetTransport::SendRematchLevel(bool random_level, const std::string& level_file) {
+  std::vector<uint8_t> buf(2 + level_file.size());
+  buf[0] = kPacketRematchLevel;
+  buf[1] = random_level ? 1 : 0;
+  if (!level_file.empty()) std::memcpy(buf.data() + 2, level_file.data(), level_file.size());
+  SendPacket(buf.data(), buf.size());
 }
 
-void NetTransport::sendEndMatch() {
-  uint8_t buf[1] = {PacketEndMatch};
-  sendPacket(buf, sizeof(buf));
+void NetTransport::SendEndMatch() {
+  uint8_t buf[1] = {kPacketEndMatch};
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendPeerLeft() {
-  uint8_t buf[1] = {PacketPeerLeft};
-  sendPacket(buf, sizeof(buf));
+void NetTransport::SendPeerLeft() {
+  uint8_t buf[1] = {kPacketPeerLeft};
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendTcInfo(uint32_t hash, const std::string& name) {
+void NetTransport::SendTcInfo(uint32_t hash, const std::string& name) {
   std::vector<uint8_t> buf(1 + 4 + name.size());
-  buf[0] = PacketTcInfo;
+  buf[0] = kPacketTcInfo;
   std::memcpy(buf.data() + 1, &hash, 4);
   std::memcpy(buf.data() + 5, name.data(), name.size());
-  sendPacket(buf.data(), buf.size());
+  SendPacket(buf.data(), buf.size());
 }
 
-void NetTransport::sendTcResponse(bool needData) {
+void NetTransport::SendTcResponse(bool need_data) {
   uint8_t buf[2];
-  buf[0] = PacketTcResponse;
-  buf[1] = needData ? 1 : 0;
-  sendPacket(buf, sizeof(buf));
+  buf[0] = kPacketTcResponse;
+  buf[1] = need_data ? 1 : 0;
+  SendPacket(buf, sizeof(buf));
 }
 
-void NetTransport::sendTcData(const void* data, size_t len) {
+void NetTransport::SendTcData(const void* data, size_t len) {
   std::vector<uint8_t> buf(1 + len);
-  buf[0] = PacketTcData;
+  buf[0] = kPacketTcData;
   std::memcpy(buf.data() + 1, data, len);
 
   if (!peer_) return;
   ENetPacket* packet = enet_packet_create(buf.data(), buf.size(), ENET_PACKET_FLAG_RELIABLE);
   if (!packet) return;
-  if (enet_peer_send(peer_, CHANNEL_RELIABLE, packet) < 0) enet_packet_destroy(packet);
+  if (enet_peer_send(peer_, kChannelReliable, packet) < 0) enet_packet_destroy(packet);
 }
 
-void NetTransport::sendPacket(const void* data, size_t len) {
+void NetTransport::SendPacket(const void* data, size_t len) {
   if (!peer_) return;
   ENetPacket* packet = enet_packet_create(data, len, ENET_PACKET_FLAG_RELIABLE);
   if (!packet) return;
-  if (enet_peer_send(peer_, CHANNEL_RELIABLE, packet) < 0) enet_packet_destroy(packet);
+  if (enet_peer_send(peer_, kChannelReliable, packet) < 0) enet_packet_destroy(packet);
 }

--- a/src/game/net/transport.hpp
+++ b/src/game/net/transport.hpp
@@ -25,31 +25,31 @@ struct NetTransport {
 
   // Packet types
   enum PacketType : uint8_t {
-    PacketInput = 1,
-    PacketHandshake = 2,
-    PacketChecksum = 3,
-    PacketPlayerInfo = 4,
-    PacketMatchSettings = 5,
-    PacketMapData = 6,
-    PacketPause = 7,
-    PacketResume = 8,
-    PacketRematchReady = 9,
-    PacketRematchLevel = 10,
-    PacketEndMatch = 11,
-    PacketTcInfo = 12,
-    PacketTcResponse = 13,
-    PacketTcData = 14,
+    kPacketInput = 1,
+    kPacketHandshake = 2,
+    kPacketChecksum = 3,
+    kPacketPlayerInfo = 4,
+    kPacketMatchSettings = 5,
+    kPacketMapData = 6,
+    kPacketPause = 7,
+    kPacketResume = 8,
+    kPacketRematchReady = 9,
+    kPacketRematchLevel = 10,
+    kPacketEndMatch = 11,
+    kPacketTcInfo = 12,
+    kPacketTcResponse = 13,
+    kPacketTcData = 14,
     // K-wide redundant input window with the sender's current sim
     // frame, delivered unreliable-sequenced.
     //   [type:1][gen:1][baseFrame:u32 LE][count:u8][localDelta:u8][input[count]:u8]
     // The receiver reconstructs `remoteLocalFrame = baseFrame + localDelta`
     // for frame-advantage tracking; `gen` lets the receiver drop
     // pre-transition packets after a WS→game reset.
-    PacketInputBatch = 15,
+    kPacketInputBatch = 15,
     // Sender is leaving the match (pause menu "Disconnect"). Receiver
     // should drop back to the menu without showing stats or a
     // "peer disconnected" InfoBox.
-    PacketPeerLeft = 16,
+    kPacketPeerLeft = 16,
   };
 
   struct PlayerInfo {
@@ -61,29 +61,29 @@ struct NetTransport {
 
   struct MatchSettingsData {
     int32_t lives;
-    int32_t loadingTime;
-    uint32_t gameMode;
+    int32_t loading_time;
+    uint32_t game_mode;
     int32_t blood;
-    int32_t maxBonuses;
-    int32_t timeToLose;
-    int32_t flagsToWin;
-    uint8_t loadChange;
-    uint32_t weapTable[40];
-    uint8_t regenerateLevel;
+    int32_t max_bonuses;
+    int32_t time_to_lose;
+    int32_t flags_to_win;
+    uint8_t load_change;
+    uint32_t weap_table[40];
+    uint8_t regenerate_level;
     uint8_t shadow;
-    uint8_t namesOnBonuses;
-    int32_t bloodParticleMax;
-    int32_t zoneTimeout;
-    int32_t inputDelay;
+    uint8_t names_on_bonuses;
+    int32_t blood_particle_max;
+    int32_t zone_timeout;
+    int32_t input_delay;
   };
 
   // Connection state
   enum State {
-    Disconnected,
-    Listening,   // Host waiting for peer
-    Connecting,  // Client connecting to host
-    Connected,
-    Failed,
+    kDisconnected,
+    kListening,   // Host waiting for peer
+    kConnecting,  // Client connecting to host
+    kConnected,
+    kFailed,
   };
 
   NetTransport();
@@ -95,99 +95,99 @@ struct NetTransport {
   NetTransport(const NetTransport&) = delete;
   NetTransport& operator=(const NetTransport&) = delete;
 
-  void disconnect();
+  void Disconnect();
 
   // Host a game on the given port.
-  bool host(uint16_t port);
+  bool Host(uint16_t port);
 
   // Connect to a host directly.
-  bool connect(const std::string& address, uint16_t port);
+  bool Connect(const std::string& address, uint16_t port);
 
   // Connect to a peer using the existing host.
   // The host must already be created.
-  bool connectExisting(const std::string& address, uint16_t port);
+  bool ConnectExisting(const std::string& address, uint16_t port);
 
   // Create ENet host using a pre-existing socket (from IceBridge).
   // The socket should be non-blocking with adequate buffer sizes.
-  bool createHostOnBridgeSocket(BridgeSocket bridgeSocket);
+  bool CreateHostOnBridgeSocket(BridgeSocket bridge_socket);
 
   // Attach ICE bridge and agent — transport takes ownership and polls them.
   // Must be called after createHostOnBridgeSocket.
-  void attachIce(std::unique_ptr<IceBridge> bridge, std::unique_ptr<IceAgent> agent);
+  void AttachIce(std::unique_ptr<IceBridge> bridge, std::unique_ptr<IceAgent> agent);
 
   // --- General ---
   // Poll for events. Call once per frame.
-  bool poll();
+  bool Poll();
 
-  void sendInput(uint32_t frame, uint8_t input);
+  void SendInput(uint32_t frame, uint8_t input);
   // Rollback batched input send. `inputs` covers frames
   // [baseFrame, baseFrame + count - 1]. `localDelta` is the sender's
   // `simFrame - baseFrame` at send time (range [0, count - 1]).
   // `generation` is the sender's phase generation; receivers drop
   // older generations. Unreliable-sequenced; receiver dedups against
   // confirmed frames.
-  void sendInputBatch(uint8_t generation, uint32_t baseFrame, uint8_t count, uint8_t localDelta,
+  void SendInputBatch(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t local_delta,
                       uint8_t const* inputs);
-  void sendChecksum(uint8_t generation, uint32_t frame, uint32_t checksum);
-  void sendHandshake(uint32_t seed, uint32_t settingsHash);
-  void sendPlayerInfo(const PlayerInfo& info);
-  void sendMatchSettings(const MatchSettingsData& data);
-  void sendMapData(const void* data, size_t len);
-  void sendPause();
-  void sendResume();
-  void sendRematchReady(bool ready);
-  void sendRematchLevel(bool randomLevel, const std::string& levelFile);
-  void sendEndMatch();
-  void sendPeerLeft();
-  void sendTcInfo(uint32_t hash, const std::string& name);
-  void sendTcResponse(bool needData);
-  void sendTcData(const void* data, size_t len);
+  void SendChecksum(uint8_t generation, uint32_t frame, uint32_t checksum);
+  void SendHandshake(uint32_t seed, uint32_t settings_hash);
+  void SendPlayerInfo(const PlayerInfo& info);
+  void SendMatchSettings(const MatchSettingsData& data);
+  void SendMapData(const void* data, size_t len);
+  void SendPause();
+  void SendResume();
+  void SendRematchReady(bool ready);
+  void SendRematchLevel(bool random_level, const std::string& level_file);
+  void SendEndMatch();
+  void SendPeerLeft();
+  void SendTcInfo(uint32_t hash, const std::string& name);
+  void SendTcResponse(bool need_data);
+  void SendTcData(const void* data, size_t len);
 
-  State state() const { return state_; }
-  uint16_t listeningPort() const;
+  State State() const { return state_; }
+  uint16_t ListeningPort() const;
 
   // Access the ENet host (for STUN-via-host integration)
-  _ENetHost* enetHost() const { return enetHost_; }
+  _ENetHost* EnetHost() const { return enetHost_; }
 
   // Callbacks
-  std::function<void(uint32_t frame, uint8_t input)> onRemoteInput;
+  std::function<void(uint32_t frame, uint8_t input)> on_remote_input;
   // Rollback batched input arrival. `remoteLocalFrame` = sender's
   // simFrame at send time (= baseFrame + localDelta) — used for
   // frame-advantage tracking. `inputs` is valid only for the duration
   // of the callback; copy if you need to keep it.
-  std::function<void(uint8_t generation, uint32_t baseFrame, uint8_t count, uint8_t const* inputs,
-                     uint32_t remoteLocalFrame)>
-      onRemoteInputBatch;
-  std::function<void(uint32_t seed, uint32_t settingsHash)> onHandshake;
-  std::function<void(uint8_t generation, uint32_t frame, uint32_t checksum)> onChecksum;
-  std::function<void(const PlayerInfo& info)> onPlayerInfo;
-  std::function<void(const MatchSettingsData& data)> onMatchSettings;
-  std::function<void(const void* data, size_t len)> onMapData;
-  std::function<void()> onPause;
-  std::function<void()> onResume;
-  std::function<void(bool ready)> onRematchReady;
-  std::function<void(bool randomLevel, std::string levelFile)> onRematchLevel;
-  std::function<void()> onEndMatch;
-  std::function<void()> onPeerLeft;
-  std::function<void(uint32_t hash, std::string name)> onTcInfo;
-  std::function<void(bool needData)> onTcResponse;
-  std::function<void(const void* data, size_t len)> onTcData;
-  std::function<void()> onConnected;
-  std::function<void()> onDisconnected;
+  std::function<void(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t const* inputs,
+                     uint32_t remote_local_frame)>
+      on_remote_input_batch;
+  std::function<void(uint32_t seed, uint32_t settings_hash)> on_handshake;
+  std::function<void(uint8_t generation, uint32_t frame, uint32_t checksum)> on_checksum;
+  std::function<void(const PlayerInfo& info)> on_player_info;
+  std::function<void(const MatchSettingsData& data)> on_match_settings;
+  std::function<void(const void* data, size_t len)> on_map_data;
+  std::function<void()> on_pause;
+  std::function<void()> on_resume;
+  std::function<void(bool ready)> on_rematch_ready;
+  std::function<void(bool random_level, std::string level_file)> on_rematch_level;
+  std::function<void()> on_end_match;
+  std::function<void()> on_peer_left;
+  std::function<void(uint32_t hash, std::string name)> on_tc_info;
+  std::function<void(bool need_data)> on_tc_response;
+  std::function<void(const void* data, size_t len)> on_tc_data;
+  std::function<void()> on_connected;
+  std::function<void()> on_disconnected;
   // Called for each non-ENet packet intercepted (STUN, etc.)
   // Return true if consumed.
-  std::function<bool(const uint8_t* data, size_t len)> onInterceptedPacket;
+  std::function<bool(const uint8_t* data, size_t len)> on_intercepted_packet;
 
  private:
-  void sendPacket(const void* data, size_t len);
-  bool createHost(uint16_t port);
-  void setupIntercept();
+  void SendPacket(const void* data, size_t len);
+  bool CreateHost(uint16_t port);
+  void SetupIntercept();
 
-  static int interceptCallback(_ENetHost* host, void* event);
+  static int InterceptCallback(_ENetHost* host, void* event);
 
   _ENetHost* enetHost_;
   _ENetPeer* peer_;
-  State state_;
+  enum State state_;
   std::unique_ptr<IceBridge> iceBridge_;
   std::unique_ptr<IceAgent> iceAgent_;
 };

--- a/src/game/net/transport.hpp
+++ b/src/game/net/transport.hpp
@@ -143,7 +143,7 @@ struct NetTransport {
   void SendTcResponse(bool need_data);
   void SendTcData(const void* data, size_t len);
 
-  State State() const { return state_; }
+  State CurrentState() const { return state_; }
   uint16_t ListeningPort() const;
 
   // Access the ENet host (for STUN-via-host integration)

--- a/src/game/netConnectState.cpp
+++ b/src/game/netConnectState.cpp
@@ -153,17 +153,17 @@ void NetConnectState::Draw() {
   int cy = 60;
 
   int w1 = font.GetDims(line1);
-  font.DrawText(gfx->play_renderer.bmp, line1, cx - w1 / 2, cy, 50);
+  font.DrawString(gfx->play_renderer.bmp, line1, cx - w1 / 2, cy, 50);
 
   int w2 = font.GetDims(line2);
-  font.DrawText(gfx->play_renderer.bmp, line2, cx - w2 / 2, cy + 12, 7);
+  font.DrawString(gfx->play_renderer.bmp, line2, cx - w2 / 2, cy + 12, 7);
 
   // Show local addresses when hosting
   if (role_ == NetSession::kHost && !localAddresses_.empty()) {
     int addr_y = cy + 30;
     std::string hdr = "CONNECT USING:";
     int wh = font.GetDims(hdr);
-    font.DrawText(gfx->play_renderer.bmp, hdr, cx - wh / 2, addr_y, 6);
+    font.DrawString(gfx->play_renderer.bmp, hdr, cx - wh / 2, addr_y, 6);
     addr_y += 10;
 
     for (auto& addr : localAddresses_) {
@@ -173,7 +173,7 @@ void NetConnectState::Draw() {
       else
         display = addr.ip + ":" + std::to_string(port_);
       int wd = font.GetDims(display);
-      font.DrawText(gfx->play_renderer.bmp, display, cx - wd / 2, addr_y, 7);
+      font.DrawString(gfx->play_renderer.bmp, display, cx - wd / 2, addr_y, 7);
       addr_y += 10;
     }
 
@@ -181,21 +181,21 @@ void NetConnectState::Draw() {
       uint16_t ext_port = externalIPs_.ipv4_port ? externalIPs_.ipv4_port : port_;
       std::string d = externalIPs_.ipv4 + ":" + std::to_string(ext_port) + " (EXTERNAL)";
       int wd = font.GetDims(d);
-      font.DrawText(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
+      font.DrawString(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
       addr_y += 10;
     }
     if (!externalIPs_.ipv6.empty()) {
       uint16_t ext_port = externalIPs_.ipv6_port ? externalIPs_.ipv6_port : port_;
       std::string d = "[" + externalIPs_.ipv6 + "]:" + std::to_string(ext_port) + " (EXTERNAL)";
       int wd = font.GetDims(d);
-      font.DrawText(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
+      font.DrawString(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
       addr_y += 10;
     }
 
     int w3 = font.GetDims(line3);
-    font.DrawText(gfx->play_renderer.bmp, line3, cx - w3 / 2, addr_y + 6, 6);
+    font.DrawString(gfx->play_renderer.bmp, line3, cx - w3 / 2, addr_y + 6, 6);
   } else {
     int w3 = font.GetDims(line3);
-    font.DrawText(gfx->play_renderer.bmp, line3, cx - w3 / 2, cy + 30, 6);
+    font.DrawString(gfx->play_renderer.bmp, line3, cx - w3 / 2, cy + 30, 6);
   }
 }

--- a/src/game/netConnectState.cpp
+++ b/src/game/netConnectState.cpp
@@ -17,99 +17,99 @@ NetConnectState::NetConnectState(NetSession::Role role, std::string address, uin
     : role_(role), address_(std::move(address)), port_(port) {}
 
 NetConnectState::NetConnectState(NetSession::Role role, NetTransport&& transport,
-                                 std::string peerAddr, uint16_t peerPort)
+                                 std::string peer_addr, uint16_t peer_port)
     : role_(role),
-      address_(std::move(peerAddr)),
-      port_(peerPort),
+      address_(std::move(peer_addr)),
+      port_(peer_port),
       hasTransport_(true),
       existingTransport_(std::move(transport)) {}
 
-void NetConnectState::enter() {
-  FsNode tcRoot = gfx->getConfigNode() / "TC" / gfx->settings->tc;
-  auto session = std::make_unique<NetSession>(gfx->common, gfx->settings, tcRoot);
+void NetConnectState::Enter() {
+  FsNode tc_root = gfx->GetConfigNode() / "TC" / gfx->settings->tc;
+  auto session = std::make_unique<NetSession>(gfx->common, gfx->settings, tc_root);
 
   // When client receives a new TC, update global gfx.common
-  session->onTcReloaded = [](std::shared_ptr<Common> newCommon) {
-    ::gfx.common = newCommon;
-    ::gfx.playRenderer.loadPalette(*newCommon);
-    if (auto* dp = dynamic_cast<DefaultSoundPlayer*>(::gfx.soundPlayer.get()))
-      dp->setCommon(*newCommon);
+  session->on_tc_reloaded = [](std::shared_ptr<Common> new_common) {
+    ::gfx.common = new_common;
+    ::gfx.play_renderer.LoadPalette(*new_common);
+    if (auto* dp = dynamic_cast<DefaultSoundPlayer*>(::gfx.sound_player.get()))
+      dp->SetCommon(*new_common);
   };
 
   bool ok = false;
   if (hasTransport_) {
     // Use the existing transport (from ICE bridge)
-    if (role_ == NetSession::Host)
-      ok = session->hostWithTransport(std::move(existingTransport_));
+    if (role_ == NetSession::kHost)
+      ok = session->HostWithTransport(std::move(existingTransport_));
     else
-      ok = session->connectWithTransport(std::move(existingTransport_), address_, port_);
-  } else if (role_ == NetSession::Host) {
-    ok = session->hostGame(port_);
+      ok = session->ConnectWithTransport(std::move(existingTransport_), address_, port_);
+  } else if (role_ == NetSession::kHost) {
+    ok = session->HostGame(port_);
     if (ok) {
-      localAddresses_ = getLocalAddresses();
+      localAddresses_ = GetLocalAddresses();
       stunQuery_ = std::make_unique<StunQuery>();
-      stunQuery_->start(port_);
+      stunQuery_->Start(port_);
     }
   } else
-    ok = session->joinGame(address_, port_);
+    ok = session->JoinGame(address_, port_);
 
   if (!ok) {
-    gfx->pendingErrorMessage = "FAILED TO START NETWORK";
+    gfx->pending_error_message = "FAILED TO START NETWORK";
     cancel_ = true;
-    gfx->netSession.reset();
+    gfx->net_session.reset();
     return;
   }
 
-  gfx->netSession = std::move(session);
+  gfx->net_session = std::move(session);
 }
 
-void NetConnectState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void NetConnectState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool NetConnectState::update() {
+bool NetConnectState::Update() {
   if (cancel_) {
-    if (!gfx->pendingErrorMessage.empty()) {
-      std::string msg = std::move(gfx->pendingErrorMessage);
-      gfx->pendingErrorMessage.clear();
-      gfx->stateStack.scheduleReplaceTop(
+    if (!gfx->pending_error_message.empty()) {
+      std::string msg = std::move(gfx->pending_error_message);
+      gfx->pending_error_message.clear();
+      gfx->state_stack.ScheduleReplaceTop(
           std::make_unique<InfoBoxState>(std::move(msg), 160, 100, true));
     }
     return false;
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE)) {
-    gfx->netSession.reset();
-    gfx->clearKeys();
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE)) {
+    gfx->net_session.reset();
+    gfx->ClearKeys();
     return false;
   }
 
-  if (!gfx->netSession) return false;
+  if (!gfx->net_session) return false;
 
-  gfx->netSession->update();
+  gfx->net_session->Update();
 
   // Check for STUN result
-  if (externalIPs_.ipv4.empty() && externalIPs_.ipv6.empty() && stunQuery_ && stunQuery_->done())
-    externalIPs_ = stunQuery_->result();
+  if (externalIPs_.ipv4.empty() && externalIPs_.ipv6.empty() && stunQuery_ && stunQuery_->Done())
+    externalIPs_ = stunQuery_->Result();
 
-  auto state = gfx->netSession->sessionState();
+  auto state = gfx->net_session->State();
 
-  if (state == NetSession::Playing) {
+  if (state == NetSession::kPlaying) {
     // Connection established — transfer controller and start game
-    auto ctrl = gfx->netSession->releaseController();
+    auto ctrl = gfx->net_session->ReleaseController();
     gfx->controller = std::unique_ptr<Controller>(ctrl.release());
-    gfx->stateStack.scheduleReplaceTop(std::make_unique<GamePlayState>());
+    gfx->state_stack.ScheduleReplaceTop(std::make_unique<GamePlayState>());
     return true;
   }
 
-  if (state == NetSession::Failed) {
-    gfx->netSession.reset();
-    gfx->stateStack.scheduleReplaceTop(
+  if (state == NetSession::kFailed) {
+    gfx->net_session.reset();
+    gfx->state_stack.ScheduleReplaceTop(
         std::make_unique<InfoBoxState>("CONNECTION FAILED", 160, 100, true));
     return true;
   }
 
-  if (state == NetSession::Disconnected) {
-    gfx->netSession.reset();
-    gfx->stateStack.scheduleReplaceTop(
+  if (state == NetSession::kDisconnected) {
+    gfx->net_session.reset();
+    gfx->state_stack.ScheduleReplaceTop(
         std::make_unique<InfoBoxState>("PEER DISCONNECTED", 160, 100, true));
     return true;
   }
@@ -117,26 +117,26 @@ bool NetConnectState::update() {
   return true;
 }
 
-void NetConnectState::draw() {
+void NetConnectState::Draw() {
   Common& common = *gfx->common;
   Font& font = common.font;
 
-  gfx->playRenderer.pal = common.exepal;
-  fill(gfx->playRenderer.bmp, 0);
+  gfx->play_renderer.pal = common.exepal;
+  Fill(gfx->play_renderer.bmp, 0);
 
   std::string line1;
-  if (role_ == NetSession::Host)
+  if (role_ == NetSession::kHost)
     line1 = "HOSTING ON PORT " + std::to_string(port_);
   else
     line1 = "CONNECTING TO " + address_;
 
   std::string line2;
-  if (gfx->netSession) {
-    switch (gfx->netSession->sessionState()) {
-      case NetSession::WaitingForPeer:
+  if (gfx->net_session) {
+    switch (gfx->net_session->State()) {
+      case NetSession::kWaitingForPeer:
         line2 = "WAITING FOR PEER...";
         break;
-      case NetSession::Handshaking:
+      case NetSession::kHandshaking:
         line2 = "HANDSHAKING...";
         break;
       default:
@@ -152,50 +152,50 @@ void NetConnectState::draw() {
   int cx = 160;
   int cy = 60;
 
-  int w1 = font.getDims(line1);
-  font.drawText(gfx->playRenderer.bmp, line1, cx - w1 / 2, cy, 50);
+  int w1 = font.GetDims(line1);
+  font.DrawText(gfx->play_renderer.bmp, line1, cx - w1 / 2, cy, 50);
 
-  int w2 = font.getDims(line2);
-  font.drawText(gfx->playRenderer.bmp, line2, cx - w2 / 2, cy + 12, 7);
+  int w2 = font.GetDims(line2);
+  font.DrawText(gfx->play_renderer.bmp, line2, cx - w2 / 2, cy + 12, 7);
 
   // Show local addresses when hosting
-  if (role_ == NetSession::Host && !localAddresses_.empty()) {
-    int addrY = cy + 30;
+  if (role_ == NetSession::kHost && !localAddresses_.empty()) {
+    int addr_y = cy + 30;
     std::string hdr = "CONNECT USING:";
-    int wh = font.getDims(hdr);
-    font.drawText(gfx->playRenderer.bmp, hdr, cx - wh / 2, addrY, 6);
-    addrY += 10;
+    int wh = font.GetDims(hdr);
+    font.DrawText(gfx->play_renderer.bmp, hdr, cx - wh / 2, addr_y, 6);
+    addr_y += 10;
 
     for (auto& addr : localAddresses_) {
       std::string display;
-      if (addr.isIPv6)
+      if (addr.is_i_pv6)
         display = "[" + addr.ip + "]:" + std::to_string(port_);
       else
         display = addr.ip + ":" + std::to_string(port_);
-      int wd = font.getDims(display);
-      font.drawText(gfx->playRenderer.bmp, display, cx - wd / 2, addrY, 7);
-      addrY += 10;
+      int wd = font.GetDims(display);
+      font.DrawText(gfx->play_renderer.bmp, display, cx - wd / 2, addr_y, 7);
+      addr_y += 10;
     }
 
     if (!externalIPs_.ipv4.empty()) {
-      uint16_t extPort = externalIPs_.ipv4Port ? externalIPs_.ipv4Port : port_;
-      std::string d = externalIPs_.ipv4 + ":" + std::to_string(extPort) + " (EXTERNAL)";
-      int wd = font.getDims(d);
-      font.drawText(gfx->playRenderer.bmp, d, cx - wd / 2, addrY, 45);
-      addrY += 10;
+      uint16_t ext_port = externalIPs_.ipv4_port ? externalIPs_.ipv4_port : port_;
+      std::string d = externalIPs_.ipv4 + ":" + std::to_string(ext_port) + " (EXTERNAL)";
+      int wd = font.GetDims(d);
+      font.DrawText(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
+      addr_y += 10;
     }
     if (!externalIPs_.ipv6.empty()) {
-      uint16_t extPort = externalIPs_.ipv6Port ? externalIPs_.ipv6Port : port_;
-      std::string d = "[" + externalIPs_.ipv6 + "]:" + std::to_string(extPort) + " (EXTERNAL)";
-      int wd = font.getDims(d);
-      font.drawText(gfx->playRenderer.bmp, d, cx - wd / 2, addrY, 45);
-      addrY += 10;
+      uint16_t ext_port = externalIPs_.ipv6_port ? externalIPs_.ipv6_port : port_;
+      std::string d = "[" + externalIPs_.ipv6 + "]:" + std::to_string(ext_port) + " (EXTERNAL)";
+      int wd = font.GetDims(d);
+      font.DrawText(gfx->play_renderer.bmp, d, cx - wd / 2, addr_y, 45);
+      addr_y += 10;
     }
 
-    int w3 = font.getDims(line3);
-    font.drawText(gfx->playRenderer.bmp, line3, cx - w3 / 2, addrY + 6, 6);
+    int w3 = font.GetDims(line3);
+    font.DrawText(gfx->play_renderer.bmp, line3, cx - w3 / 2, addr_y + 6, 6);
   } else {
-    int w3 = font.getDims(line3);
-    font.drawText(gfx->playRenderer.bmp, line3, cx - w3 / 2, cy + 30, 6);
+    int w3 = font.GetDims(line3);
+    font.DrawText(gfx->play_renderer.bmp, line3, cx - w3 / 2, cy + 30, 6);
   }
 }

--- a/src/game/netConnectState.hpp
+++ b/src/game/netConnectState.hpp
@@ -16,13 +16,13 @@
 struct NetConnectState : AppState {
   NetConnectState(NetSession::Role role, std::string address, uint16_t port);
   // Direct connection with existing transport (after ICE)
-  NetConnectState(NetSession::Role role, NetTransport&& transport, std::string peerAddr = "",
-                  uint16_t peerPort = 0);
+  NetConnectState(NetSession::Role role, NetTransport&& transport, std::string peer_addr = "",
+                  uint16_t peer_port = 0);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
  private:
   NetSession::Role role_;

--- a/src/game/ninjarope.cpp
+++ b/src/game/ninjarope.cpp
@@ -4,19 +4,19 @@
 #include "math.hpp"
 #include "worm.hpp"
 
-void Ninjarope::process(Worm& owner, Game& game) {
+void Ninjarope::Process(Worm& owner, Game& game) {
   Common& common = *game.common;
 
   if (out) {
     pos += vel;
 
-    auto ipos = ftoi(pos);
+    auto ipos = Ftoi(pos);
 
     anchor = 0;
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm& w = *game.worms[i];
 
-      if (&w != &owner && checkForSpecWormHit(game, ipos.x, ipos.y, 1, w)) {
+      if (&w != &owner && CheckForSpecWormHit(game, ipos.x, ipos.y, 1, w)) {
         anchor = &w;
         break;
       }
@@ -27,27 +27,27 @@ void Ninjarope::process(Worm& owner, Game& game) {
     fixedvec force((diff.x << LC(NRForceShlX)) / LC(NRForceDivX),
                    (diff.y << LC(NRForceShlY)) / LC(NRForceDivY));
 
-    curLen = (vectorLength(ftoi(diff.x), ftoi(diff.y)) + 1) << LC(NRForceLenShl);
+    cur_len = (VectorLength(Ftoi(diff.x), Ftoi(diff.y)) + 1) << LC(NRForceLenShl);
 
     if (ipos.x <= 0 || ipos.x >= game.level.width - 1 || ipos.y <= 0 ||
-        ipos.y >= game.level.height - 1 || game.level.mat(ipos).dirtRock()) {
+        ipos.y >= game.level.height - 1 || game.level.Mat(ipos).DirtRock()) {
       if (!attached) {
         length = LC(NRAttachLength);
         attached = true;
 
-        if (game.level.inside(ipos)) {
-          if (game.level.mat(ipos).anyDirt()) {
-            PalIdx pix = game.level.pixel(ipos);
+        if (game.level.Inside(ipos)) {
+          if (game.level.Mat(ipos).AnyDirt()) {
+            PalIdx pix = game.level.Pixel(ipos);
             for (int i = 0; i < 11; ++i)  // TODO: Check 11 and read from exe
             {
-              common.nobjectTypes[2].create2(game, game.rand(128), fixedvec(), pos, pix,
+              common.nobject_types[2].Create2(game, game.rand(128), fixedvec(), pos, pix,
                                              owner.index, 0);
             }
           }
         }
       }
 
-      vel.zero();
+      vel.Zero();
     } else if (anchor) {
       if (!attached) {
         length =
@@ -55,8 +55,8 @@ void Ninjarope::process(Worm& owner, Game& game) {
         attached = true;
       }
 
-      if (curLen > length) {
-        anchor->vel -= force / curLen;
+      if (cur_len > length) {
+        anchor->vel -= force / cur_len;
       }
 
       vel = anchor->vel;
@@ -68,14 +68,14 @@ void Ninjarope::process(Worm& owner, Game& game) {
     if (attached) {
       // curLen can't be 0
 
-      if (curLen > length) {
-        owner.vel += force / curLen;
+      if (cur_len > length) {
+        owner.vel += force / cur_len;
       }
     } else {
       vel.y += LC(NinjaropeGravity);
 
-      if (curLen > length) {
-        vel -= force / curLen;
+      if (cur_len > length) {
+        vel -= force / cur_len;
       }
     }
   }

--- a/src/game/ninjarope.cpp
+++ b/src/game/ninjarope.cpp
@@ -41,7 +41,7 @@ void Ninjarope::Process(Worm& owner, Game& game) {
             for (int i = 0; i < 11; ++i)  // TODO: Check 11 and read from exe
             {
               common.nobject_types[2].Create2(game, game.rand(128), fixedvec(), pos, pix,
-                                             owner.index, 0);
+                                              owner.index, 0);
             }
           }
         }

--- a/src/game/nobject.cpp
+++ b/src/game/nobject.cpp
@@ -4,53 +4,53 @@
 #include "gfx/renderer.hpp"
 #include "mixer/player.hpp"
 
-NObject& NObjectType::create(Game& game, fixedvec vel, fixedvec pos, int color, int ownerIdx,
-                             WormWeapon* firedBy) {
-  NObject& obj = *game.nobjects.newObjectReuse();
+NObject& NObjectType::Create(Game& game, fixedvec vel, fixedvec pos, int color, int owner_idx,
+                             WormWeapon* fired_by) {
+  NObject& obj = *game.nobjects.NewObjectReuse();
 
   obj.type = this;
-  obj.ownerIdx = ownerIdx;
+  obj.owner_idx = owner_idx;
   obj.pos = pos;
 
   obj.vel = vel;
 
   // STATS
-  obj.firedBy = firedBy;
-  obj.hasHit = false;
+  obj.fired_by = fired_by;
+  obj.has_hit = false;
 
-  Worm* owner = game.wormByIdx(ownerIdx);
-  game.statsRecorder->damagePotential(owner, firedBy, hitDamage);
+  Worm* owner = game.WormByIdx(owner_idx);
+  game.stats_recorder->DamagePotential(owner, fired_by, hit_damage);
 
-  if (startFrame > 0) {
-    obj.curFrame = game.rand(numFrames + 1);
+  if (start_frame > 0) {
+    obj.cur_frame = game.rand(num_frames + 1);
   } else if (color != 0) {
-    obj.curFrame = color;
+    obj.cur_frame = color;
   } else {
-    obj.curFrame = colorBullets;
+    obj.cur_frame = color_bullets;
   }
 
-  obj.timeLeft = timeToExplo;
+  obj.time_left = time_to_explo;
 
-  if (timeToExploV) obj.timeLeft -= game.rand(timeToExploV);
+  if (time_to_explo_v) obj.time_left -= game.rand(time_to_explo_v);
 
   return obj;
 }
 
-NObject& NObjectType::create1(Game& game, fixedvec vel, fixedvec pos, int color, int ownerIdx,
-                              WormWeapon* firedBy) {
+NObject& NObjectType::Create1(Game& game, fixedvec vel, fixedvec pos, int color, int owner_idx,
+                              WormWeapon* fired_by) {
   if (distribution) {
     vel.x += distribution - game.rand(distribution * 2);
     vel.y += distribution - game.rand(distribution * 2);
   }
 
-  return create(game, vel, pos, color, ownerIdx, firedBy);
+  return Create(game, vel, pos, color, owner_idx, fired_by);
 }
 
-void NObjectType::create2(Game& game, int angle, fixedvec vel, fixedvec pos, int color,
-                          int ownerIdx, WormWeapon* firedBy) {
-  int realSpeed = speed - game.rand(speedV);
+void NObjectType::Create2(Game& game, int angle, fixedvec vel, fixedvec pos, int color,
+                          int owner_idx, WormWeapon* fired_by) {
+  int real_speed = speed - game.rand(speed_v);
 
-  vel += cossinTable[angle] * realSpeed / 100;
+  vel += cossin_table[angle] * real_speed / 100;
 
   // TODO: !REPLAYS Make the distributions use the same code
   if (distribution) {
@@ -58,152 +58,152 @@ void NObjectType::create2(Game& game, int angle, fixedvec vel, fixedvec pos, int
     vel.y += game.rand(distribution * 2) - distribution;
   }
 
-  auto& obj = create(game, vel, pos, color, ownerIdx, firedBy);
+  auto& obj = Create(game, vel, pos, color, owner_idx, fired_by);
 
   obj.pos += obj.vel;
 }
 
-void NObject::process(Game& game) {
+void NObject::Process(Game& game) {
   Common& common = *game.common;
 
   bool bounced = false;
-  bool doExplode = false;
+  bool do_explode = false;
 
   pos += vel;
 
-  auto inewPos = ftoi(pos + vel);
-  auto ipos = ftoi(pos);
+  auto inew_pos = Ftoi(pos + vel);
+  auto ipos = Ftoi(pos);
 
   NObjectType const& t = *type;
 
   if (t.bounce > 0) {
-    if (!game.level.inside(inewPos.x, ipos.y) || game.pixelMat(inewPos.x, ipos.y).dirtRock()) {
+    if (!game.level.Inside(inew_pos.x, ipos.y) || game.PixelMat(inew_pos.x, ipos.y).DirtRock()) {
       vel.x = -vel.x * t.bounce / 100;
       vel.y = (vel.y * 4) / 5;  // TODO: Read from EXE
       bounced = true;
     }
 
-    if (!game.level.inside(ipos.x, inewPos.y) || game.pixelMat(ipos.x, inewPos.y).dirtRock()) {
+    if (!game.level.Inside(ipos.x, inew_pos.y) || game.PixelMat(ipos.x, inew_pos.y).DirtRock()) {
       vel.y = -vel.y * t.bounce / 100;
       vel.x = (vel.x * 4) / 5;  // TODO: Read from EXE
       bounced = true;
     }
   }
 
-  if (t.bloodTrail && t.bloodTrailDelay > 0 && (game.cycles % t.bloodTrailDelay) == 0) {
-    game.createBObject(pos, vel / 4);  // TODO: Read from EXE
+  if (t.blood_trail && t.blood_trail_delay > 0 && (game.cycles % t.blood_trail_delay) == 0) {
+    game.CreateBObject(pos, vel / 4);  // TODO: Read from EXE
   }
 
   // Yes, we do this again.
-  inewPos = ftoi(pos + vel);
+  inew_pos = Ftoi(pos + vel);
 
-  if (inewPos.x < 0) pos.x = 0;
-  if (inewPos.y < 0) pos.y = 0;
-  if (inewPos.x >= game.level.width) pos.x = itof(game.level.width);
-  if (inewPos.y >= game.level.height) pos.y = itof(game.level.height);
+  if (inew_pos.x < 0) pos.x = 0;
+  if (inew_pos.y < 0) pos.y = 0;
+  if (inew_pos.x >= game.level.width) pos.x = Itof(game.level.width);
+  if (inew_pos.y >= game.level.height) pos.y = Itof(game.level.height);
 
-  if (!game.level.inside(inewPos) || game.pixelMat(inewPos.x, inewPos.y).dirtRock()) {
-    vel.zero();
+  if (!game.level.Inside(inew_pos) || game.PixelMat(inew_pos.x, inew_pos.y).DirtRock()) {
+    vel.Zero();
 
-    if (t.explGround) {
-      if (t.startFrame > 0 && t.drawOnMap) {
-        blitImageOnMap(common, game.level, common.smallSprites.spritePtr(t.startFrame + curFrame),
+    if (t.expl_ground) {
+      if (t.start_frame > 0 && t.draw_on_map) {
+        BlitImageOnMap(common, game.level, common.small_sprites.SpritePtr(t.start_frame + cur_frame),
                        ipos.x - 3, ipos.y - 3, 7, 7);
         if (game.settings->shadow)
-          correctShadow(common, game.level,
+          CorrectShadow(common, game.level,
                         Rect(ipos.x - 8, ipos.y - 8, ipos.x + 9,
                              ipos.y + 9));  // This seems like an overly large rectangle
       }
 
-      doExplode = true;
+      do_explode = true;
     }
   } else {
-    if (!bounced && t.leaveObjDelay != 0 &&
-        t.leaveObj >= 0  // NOTE: AFAIK, this doesn't exist in Liero, but some TCs seem to forget to
+    if (!bounced && t.leave_obj_delay != 0 &&
+        t.leave_obj >= 0  // NOTE: AFAIK, this doesn't exist in Liero, but some TCs seem to forget to
                          // set leaveObjDelay to 0 when not using this trail
-        && (game.cycles % t.leaveObjDelay) == 0) {
-      common.sobjectTypes[t.leaveObj].create(game, ftoi(pos.x), ftoi(pos.y), ownerIdx, firedBy);
+        && (game.cycles % t.leave_obj_delay) == 0) {
+      common.sobject_types[t.leave_obj].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
     }
 
     vel.y += t.gravity;
   }
 
-  if (t.numFrames > 0) {
+  if (t.num_frames > 0) {
     if ((game.cycles & 7) == 0)  // TODO: Read from EXE
     {
       if (vel.x > 0) {
-        ++curFrame;
-        if (curFrame > t.numFrames) curFrame = 0;
+        ++cur_frame;
+        if (cur_frame > t.num_frames) cur_frame = 0;
       } else if (vel.x < 0) {
-        --curFrame;
-        if (curFrame < 0) curFrame = t.numFrames;
+        --cur_frame;
+        if (cur_frame < 0) cur_frame = t.num_frames;
       }
     }
   }
 
-  if (t.timeToExplo > 0) {
-    if (--timeLeft <= 0) doExplode = true;
+  if (t.time_to_explo > 0) {
+    if (--time_left <= 0) do_explode = true;
   }
 
-  if (!doExplode) {
-    if (t.hitDamage > 0) {
+  if (!do_explode) {
+    if (t.hit_damage > 0) {
       for (std::size_t i = 0; i < game.worms.size(); ++i) {
         Worm& w = *game.worms[i];
 
-        if (checkForSpecWormHit(game, ftoi(pos.x), ftoi(pos.y), t.detectDistance, w)) {
-          w.vel += vel * t.blowAway / 100;
+        if (CheckForSpecWormHit(game, Ftoi(pos.x), Ftoi(pos.y), t.detect_distance, w)) {
+          w.vel += vel * t.blow_away / 100;
 
-          game.doDamage(w, t.hitDamage, ownerIdx);
+          game.DoDamage(w, t.hit_damage, owner_idx);
 
-          Worm* owner = game.wormByIdx(ownerIdx);
-          game.statsRecorder->damageDealt(owner, firedBy, &w, t.hitDamage, hasHit);
-          hasHit = true;
+          Worm* owner = game.WormByIdx(owner_idx);
+          game.stats_recorder->DamageDealt(owner, fired_by, &w, t.hit_damage, has_hit);
+          has_hit = true;
 
-          if (t.hitDamage > 0 && w.health > 0 && game.rand(3) == 0) {
+          if (t.hit_damage > 0 && w.health > 0 && game.rand(3) == 0) {
             int snd = 18 + game.rand(3);  // NOTE: MUST be outside the unpredictable branch below
-            if (!game.soundPlayer->isPlaying(&w)) {
-              game.soundPlayer->play(snd, &w);
+            if (!game.sound_player->IsPlaying(&w)) {
+              game.sound_player->Play(snd, &w);
             }
           }
 
-          int blood = t.bloodOnHit * game.settings->blood / 100;
+          int blood = t.blood_on_hit * game.settings->blood / 100;
 
           for (int i = 0; i < blood; ++i) {
             int angle = game.rand(128);
-            common.nobjectTypes[6].create2(game, angle, vel / 3, pos, 0, ownerIdx, 0);
+            common.nobject_types[6].Create2(game, angle, vel / 3, pos, 0, owner_idx, 0);
           }
 
-          if (t.wormExplode)
-            doExplode = true;
-          else if (t.wormDestroy && used)
-            game.nobjects.free(this);
+          if (t.worm_explode)
+            do_explode = true;
+          else if (t.worm_destroy && used)
+            game.nobjects.Free(this);
         }
       }
     }
   }
 
-  if (doExplode) {
-    if (t.createOnExp >= 0) {
-      common.sobjectTypes[t.createOnExp].create(game, ftoi(pos.x), ftoi(pos.y), ownerIdx, firedBy);
+  if (do_explode) {
+    if (t.create_on_exp >= 0) {
+      common.sobject_types[t.create_on_exp].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
     }
 
-    if (t.dirtEffect >= 0) {
-      drawDirtEffect(common, game.rand, game.level, t.dirtEffect, ftoi(pos.x) - 7, ftoi(pos.y) - 7);
+    if (t.dirt_effect >= 0) {
+      DrawDirtEffect(common, game.rand, game.level, t.dirt_effect, Ftoi(pos.x) - 7, Ftoi(pos.y) - 7);
 
       if (game.settings->shadow)
-        correctShadow(common, game.level,
-                      Rect(ftoi(pos.x) - 10, ftoi(pos.y) - 10, ftoi(pos.x) + 11, ftoi(pos.y) + 11));
+        CorrectShadow(common, game.level,
+                      Rect(Ftoi(pos.x) - 10, Ftoi(pos.y) - 10, Ftoi(pos.x) + 11, Ftoi(pos.y) + 11));
     }
 
-    if (t.splinterAmount > 0) {
-      for (int i = 0; i < t.splinterAmount; ++i) {
+    if (t.splinter_amount > 0) {
+      for (int i = 0; i < t.splinter_amount; ++i) {
         int angle = game.rand(128);
-        int colorSub = game.rand(2);
-        common.nobjectTypes[t.splinterType].create2(game, angle, fixedvec(), pos,
-                                                    t.splinterColour - colorSub, ownerIdx, 0);
+        int color_sub = game.rand(2);
+        common.nobject_types[t.splinter_type].Create2(game, angle, fixedvec(), pos,
+                                                    t.splinter_colour - color_sub, owner_idx, 0);
       }
     }
 
-    if (used) game.nobjects.free(this);
+    if (used) game.nobjects.Free(this);
   }
 }

--- a/src/game/nobject.cpp
+++ b/src/game/nobject.cpp
@@ -107,8 +107,9 @@ void NObject::Process(Game& game) {
 
     if (t.expl_ground) {
       if (t.start_frame > 0 && t.draw_on_map) {
-        BlitImageOnMap(common, game.level, common.small_sprites.SpritePtr(t.start_frame + cur_frame),
-                       ipos.x - 3, ipos.y - 3, 7, 7);
+        BlitImageOnMap(common, game.level,
+                       common.small_sprites.SpritePtr(t.start_frame + cur_frame), ipos.x - 3,
+                       ipos.y - 3, 7, 7);
         if (game.settings->shadow)
           CorrectShadow(common, game.level,
                         Rect(ipos.x - 8, ipos.y - 8, ipos.x + 9,
@@ -119,8 +120,8 @@ void NObject::Process(Game& game) {
     }
   } else {
     if (!bounced && t.leave_obj_delay != 0 &&
-        t.leave_obj >= 0  // NOTE: AFAIK, this doesn't exist in Liero, but some TCs seem to forget to
-                         // set leaveObjDelay to 0 when not using this trail
+        t.leave_obj >= 0  // NOTE: AFAIK, this doesn't exist in Liero, but some TCs seem to forget
+                          // to set leaveObjDelay to 0 when not using this trail
         && (game.cycles % t.leave_obj_delay) == 0) {
       common.sobject_types[t.leave_obj].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
     }
@@ -184,11 +185,13 @@ void NObject::Process(Game& game) {
 
   if (do_explode) {
     if (t.create_on_exp >= 0) {
-      common.sobject_types[t.create_on_exp].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
+      common.sobject_types[t.create_on_exp].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx,
+                                                   fired_by);
     }
 
     if (t.dirt_effect >= 0) {
-      DrawDirtEffect(common, game.rand, game.level, t.dirt_effect, Ftoi(pos.x) - 7, Ftoi(pos.y) - 7);
+      DrawDirtEffect(common, game.rand, game.level, t.dirt_effect, Ftoi(pos.x) - 7,
+                     Ftoi(pos.y) - 7);
 
       if (game.settings->shadow)
         CorrectShadow(common, game.level,
@@ -200,7 +203,7 @@ void NObject::Process(Game& game) {
         int angle = game.rand(128);
         int color_sub = game.rand(2);
         common.nobject_types[t.splinter_type].Create2(game, angle, fixedvec(), pos,
-                                                    t.splinter_colour - color_sub, owner_idx, 0);
+                                                      t.splinter_colour - color_sub, owner_idx, 0);
       }
     }
 

--- a/src/game/nobject.hpp
+++ b/src/game/nobject.hpp
@@ -16,12 +16,12 @@ Chiquita bananas dropped by Chiquita Bomb. Like other types of objects, they are
 order in the array (counting started from 0).
 */
 struct NObjectType {
-  NObject& create(Game& game, fixedvec vel, fixedvec pos, int color, int ownerIdx,
-                  WormWeapon* firedBy);
-  NObject& create1(Game& game, fixedvec vel, fixedvec pos, int color, int ownerIdx,
-                   WormWeapon* firedBy);
-  void create2(Game& game, int angle, fixedvec vel, fixedvec pos, int color, int ownerIdx,
-               WormWeapon* firedBy);
+  NObject& Create(Game& game, fixedvec vel, fixedvec pos, int color, int owner_idx,
+                  WormWeapon* fired_by);
+  NObject& Create1(Game& game, fixedvec vel, fixedvec pos, int color, int owner_idx,
+                   WormWeapon* fired_by);
+  void Create2(Game& game, int angle, fixedvec vel, fixedvec pos, int color, int owner_idx,
+               WormWeapon* fired_by);
 
   /*
   Additional worm detect distance for the bullet. This setting affects the distance at which an
@@ -30,7 +30,7 @@ struct NObjectType {
   Note: if detectDistance < 0, then the worm will not receive damage from the object and also
   blowAway parameter will not work.
   */
-  int detectDistance;
+  int detect_distance;
   /*
   Gravity of the particle. Can also be negative.
   */
@@ -47,7 +47,7 @@ struct NObjectType {
   /*
   (Negative) variation in initial speed of the particle.
   */
-  int speedV;
+  int speed_v;
   /*
   Spread of the particle. This works by adding a random direction vector of random length to current
   speed vector of the projectile. Note: if you set its value to > 1 or < -1, then more than 1
@@ -60,7 +60,7 @@ struct NObjectType {
   will simply not disappear and push the worm continuously. Note: works only if the particle is
   moving and detectDistance ⩾ 0 and hitDamage > 0.
   */
-  int blowAway;
+  int blow_away;
   /*
   Speed multiply on hitting rock/dirt obstacle or the edge of the map. After every bounce, the
   projectile will get this percentage of its original speed. Note: unlike in wObject, setting
@@ -72,30 +72,30 @@ struct NObjectType {
   Note: If the object has "wormDestroy" property set to "false", this will be applied each frame the
   collision still occurs, leading to potentially huge damage values.
   */
-  int hitDamage;
+  int hit_damage;
   /*
   Whether the object should explode (produce a sObject) on worm collision. Works independently of
   "wormDestroy" parameter, which means that the object will explode also even if "wormDestroy" is
   set to "false". Note: this property doesn't work if nObject "hitDamage" parameter equals 0.
   */
-  bool wormExplode;
+  bool worm_explode;
   /*
   Whether the object should explode on ground collision.
   Note: works only when the object is no longer in motion.
   */
-  bool explGround;
+  bool expl_ground;
   /*
   Whether the object should collide with the worm and get removed.
   Note: this property doesn't work if nObject "hitDamage" parameter equals 0.
   */
-  bool wormDestroy;
+  bool worm_destroy;
   /*
   How many blood particles (nObject6) should be created on worm hit, divided by 2.
   So, if you set it to "10", then 5 blood particles will be created on worm hit (per each frame -
   which means that the amount of blood particles is affected by "wormDestroy" parameter). Note: this
   property doesn't work if nObject "hitDamage" parameter equals 0.
   */
-  int bloodOnHit;
+  int blood_on_hit;
   /*
   First sprite of animation used for nObject.
   If -1 or 0, it will be a single pixel using a colour indicated in:
@@ -103,7 +103,7 @@ struct NObjectType {
   nObject) - if this "splinterColour" property is set to 2 or more; b) "colorBullets" property - if
   "splinterColour" parameter mentioned above is set to 0 or 1.
   */
-  int startFrame;
+  int start_frame;
   /*
   Amount of sprites to use to animate the object, starting with "startFrame".
   Note: Animation begins on random frame, so is suitable really only for objects which have
@@ -112,103 +112,103 @@ struct NObjectType {
   numFrames > 0, then the animation cycle works only if the particle is moving; when the particle
   stops moving, the animation cycle also stops.
   */
-  int numFrames;
+  int num_frames;
   /*
   When set to true, this makes the object to be drawn onto the map and object itself gets removed
   from the game. This is how mountains of shells and body parts are created in liero and also the
   reason why they clutter up the bunnyhoops. Note: works only on collsision with rock / dirt / edge
   of the map if explGround is set "true" and the object is no longer in motion!
   */
-  bool drawOnMap;
+  bool draw_on_map;
   /*
   Color of the object. Works only if u use a pixel (startframe: -1 or 0) for a nObject and only if
   "splinterColour" parameter (used in in the other wObject or nObject which produced your nObject)
   is set to 0 or 1 (otherwise, your nObject will have color indicated in "splinterColour" parameter
   used in this other object).
   */
-  int colorBullets;
+  int color_bullets;
   /*
   Which special object (sObject) to use on explosion. Set -1 for none.
   */
-  int createOnExp;
+  int create_on_exp;
   /*
   Whether the object is affected by explosions' push force (on collision with sObject).
   Note: works only if the colliding sObject has got detectRange > 0 and damage > 0 and blowAway ≠ 0!
   */
-  bool affectByExplosions;
+  bool affect_by_explosions;
   /*
   Which dirt mask to use on object explosion. Set -1 for none.
   */
-  int dirtEffect;
+  int dirt_effect;
   /*
   Amount of nObjects to create on explosion.
   Note: the object must actually explode, for example if "wormExplode" is set to false and
   "wormDestroy" is set to true, no nObjects will be created. Note: NEVER set splinterAmount > 0 and
   splinterType to "null" for the same object, otherwise the game will freeze!
   */
-  int splinterAmount;
+  int splinter_amount;
   /*
   Color used on nObjects (produced as splinters) when they are a single pixel (startFrame -1 or 0).
   If splinterColour is set to 0 or 1, then splinters will have a colour indicated in nObject
   "colorBullets" property. Note: if splinterColour is set 2 or more, nObject splinter will actually
   use two colours: the one indicated in this parameter, and also the previous one.
   */
-  int splinterColour;
+  int splinter_colour;
   /*
   Type of nObject to create when the object explodes.
   */
-  int splinterType;
+  int splinter_type;
   /*
   A nObject-specific property; when set to true, the nObject will trail blood particles.
   Note: when nObject stops moving in the air, it keeps creating blood particles on its trail.
   However, if nObject is spawned or "trapped" inside rock or dirt on the map, then it stops creating
   blood particles on its trail.
   */
-  bool bloodTrail;
+  bool blood_trail;
   /*
   Delay between blood particles.
   */
-  int bloodTrailDelay;
+  int blood_trail_delay;
   /*
   sObject (special Object) used as a trail. Set -1 for none.
   Note: when nObject stops moving, it keeps creating sObjects on its trail. However, if nObject is
   spawned or "trapped" inside rock or dirt on the map, then it stops creating sObjects on its trail.
   */
-  int leaveObj;
+  int leave_obj;
   /*
   Delay time (in frames) between creating trailing sObjects.
   Note: the delay is not referred to object's lifetime but game ticks, which means that it is
   measured in relation to the time elapsed since the game started, not since the object was created.
   Note: notice that nObjects cannot trail other nObjects.
   */
-  int leaveObjDelay;
+  int leave_obj_delay;
   /*
   Time to explode in frames. When set to 0 there will be no explosion at all.
   Any positive value will cause creation of a designated sObject indicated in createOnExp parameter
   (if not -1). Note: it is not recommended to set negative value for this property. Note: it is not
   recommended to set timeToExplo > 32767.
   */
-  int timeToExplo;
+  int time_to_explo;
   /*
   Maximum (negative) variation of time to explode in frames.
   */
-  int timeToExploV;
+  int time_to_explo_v;
 
   int id;
-  std::string idStr;
+  std::string id_str;
 };
 
 struct NObject : ExactObjectListBase {
-  void process(Game& game);
+  void Process(Game& game);
 
   fixedvec pos, vel;
-  int timeLeft;
+  int time_left;
   // int id;
   NObjectType const* type;
-  int ownerIdx;
-  int curFrame;
+  int owner_idx;
+  int cur_frame;
 
   // STATS
-  WormWeapon* firedBy;
-  bool hasHit;
+  WormWeapon* fired_by;
+  bool has_hit;
 };

--- a/src/game/onlineConnectState.cpp
+++ b/src/game/onlineConnectState.cpp
@@ -258,19 +258,19 @@ void OnlineConnectState::Draw() {
   int cy = 60;
 
   int w1 = font.GetDims(statusLine1_);
-  font.DrawText(gfx->play_renderer.bmp, statusLine1_, cx - w1 / 2, cy, 50);
+  font.DrawString(gfx->play_renderer.bmp, statusLine1_, cx - w1 / 2, cy, 50);
 
   int w2 = font.GetDims(statusLine2_);
-  font.DrawText(gfx->play_renderer.bmp, statusLine2_, cx - w2 / 2, cy + 14, 7);
+  font.DrawString(gfx->play_renderer.bmp, statusLine2_, cx - w2 / 2, cy + 14, 7);
 
   if (role_ == NetSession::kHost && !roomCode_.empty() &&
       signaling_.State() == SignalingClient::kHosting) {
     std::string code_str = "CODE: " + roomCode_;
     int wc = font.GetDims(code_str);
-    font.DrawText(gfx->play_renderer.bmp, code_str, cx - wc / 2, cy + 30, 45);
+    font.DrawString(gfx->play_renderer.bmp, code_str, cx - wc / 2, cy + 30, 45);
   }
 
   std::string esc = "PRESS ESC TO CANCEL";
   int we = font.GetDims(esc);
-  font.DrawText(gfx->play_renderer.bmp, esc, cx - we / 2, 170, 7);
+  font.DrawString(gfx->play_renderer.bmp, esc, cx - we / 2, 170, 7);
 }

--- a/src/game/onlineConnectState.cpp
+++ b/src/game/onlineConnectState.cpp
@@ -11,52 +11,52 @@
 #include <memory>
 #include <string>
 
-using netutil::nowMs;
+using netutil::NowMs;
 
-OnlineConnectState::OnlineConnectState(NetSession::Role role, std::string roomCode)
-    : role_(role), roomCode_(std::move(roomCode)) {}
+OnlineConnectState::OnlineConnectState(NetSession::Role role, std::string room_code)
+    : role_(role), roomCode_(std::move(room_code)) {}
 
-void OnlineConnectState::enter() {
+void OnlineConnectState::Enter() {
   fprintf(stderr, "[online] enter: role=%s roomCode='%s'\n",
-          role_ == NetSession::Host ? "Host" : "Client", roomCode_.c_str());
+          role_ == NetSession::kHost ? "Host" : "Client", roomCode_.c_str());
 
   statusLine1_ =
-      (role_ == NetSession::Host) ? "CREATING ONLINE ROOM..." : "JOINING ROOM " + roomCode_ + "...";
+      (role_ == NetSession::kHost) ? "CREATING ONLINE ROOM..." : "JOINING ROOM " + roomCode_ + "...";
   statusLine2_ = "SETTING UP ICE...";
 
   iceAgent_ = std::make_unique<IceAgent>();
   iceBridge_ = std::make_unique<IceBridge>();
 
   // Wire IceAgent callbacks
-  iceAgent_->onLocalCandidate = [this](const std::string& candidate) {
+  iceAgent_->on_local_candidate = [this](const std::string& candidate) {
     if (signalingReady_) {
-      signaling_.sendIceCandidate(candidate);
+      signaling_.SendIceCandidate(candidate);
     } else {
       bufferedCandidates_.push_back(candidate);
     }
   };
 
-  iceAgent_->onGatheringDone = [this]() {
+  iceAgent_->on_gathering_done = [this]() {
     gatheringDone_ = true;
     if (signalingReady_) {
-      signaling_.sendIceGatherDone();
+      signaling_.SendIceGatherDone();
     }
   };
 
-  iceAgent_->onStateChange = [this](IceAgent::State state) {
+  iceAgent_->on_state_change = [this](IceAgent::State state) {
     fprintf(stderr, "[online] ICE state: %d\n", (int)state);
     switch (state) {
-      case IceAgent::State::Gathering:
+      case IceAgent::State::kGathering:
         statusLine2_ = "GATHERING CANDIDATES...";
         break;
-      case IceAgent::State::Connecting:
+      case IceAgent::State::kConnecting:
         statusLine2_ = "ICE CONNECTING...";
         break;
-      case IceAgent::State::Connected:
+      case IceAgent::State::kConnected:
         iceConnected_ = true;
         statusLine2_ = "CONNECTED! STARTING GAME...";
         break;
-      case IceAgent::State::Failed:
+      case IceAgent::State::kFailed:
         statusLine2_ = "CONNECTION FAILED";
         cancel_ = true;
         break;
@@ -66,19 +66,19 @@ void OnlineConnectState::enter() {
   };
 
   // Start ICE agent (begins gathering immediately)
-  IceAgent::Config iceCfg;
-  iceCfg.stunServer = "stun.l.google.com";
-  iceCfg.stunPort = 19302;
+  IceAgent::Config ice_cfg;
+  ice_cfg.stun_server = "stun.l.google.com";
+  ice_cfg.stun_port = 19302;
   // TURN credentials will be set after signaling responds
-  iceAgent_->start(iceCfg);
+  iceAgent_->Start(ice_cfg);
 
   // Start signaling immediately (don't wait for STUN — ICE handles it)
-  startSignaling();
+  StartSignaling();
 }
 
-void OnlineConnectState::startSignaling() {
+void OnlineConnectState::StartSignaling() {
   // Wire signaling callbacks
-  signaling_.onRoomCreated = [this](const std::string& code) {
+  signaling_.on_room_created = [this](const std::string& code) {
     fprintf(stderr, "[online] onRoomCreated: code=%s\n", code.c_str());
     roomCode_ = code;
     statusLine1_ = "ROOM CODE: " + code;
@@ -87,37 +87,37 @@ void OnlineConnectState::startSignaling() {
     // Room created but peer hasn't joined yet — don't send ICE yet
   };
 
-  signaling_.onPeerJoined = [this]() {
+  signaling_.on_peer_joined = [this]() {
     fprintf(stderr, "[online] onPeerJoined\n");
     statusLine2_ = "PEER JOINED! EXCHANGING ICE...";
 
     // Now send our ICE credentials and buffered candidates
     signalingReady_ = true;
-    signaling_.sendIceCredentials(iceAgent_->localUfrag(), iceAgent_->localPwd());
-    sendBufferedCandidates();
+    signaling_.SendIceCredentials(iceAgent_->LocalUfrag(), iceAgent_->LocalPwd());
+    SendBufferedCandidates();
   };
 
-  signaling_.onJoinAcked = [this]() {
+  signaling_.on_join_acked = [this]() {
     fprintf(stderr, "[online] join acknowledged\n");
     statusLine2_ = "JOINED! EXCHANGING ICE...";
 
     // Send our ICE credentials and buffered candidates
     signalingReady_ = true;
-    signaling_.sendIceCredentials(iceAgent_->localUfrag(), iceAgent_->localPwd());
-    sendBufferedCandidates();
+    signaling_.SendIceCredentials(iceAgent_->LocalUfrag(), iceAgent_->LocalPwd());
+    SendBufferedCandidates();
   };
 
   // ICE callbacks from signaling
-  signaling_.onPeerCredentials = [this](const std::string& ufrag, const std::string& pwd) {
+  signaling_.on_peer_credentials = [this](const std::string& ufrag, const std::string& pwd) {
     fprintf(stderr, "[online] onPeerCredentials: ufrag=%s\n", ufrag.c_str());
-    iceAgent_->setRemoteCredentials(ufrag, pwd);
+    iceAgent_->SetRemoteCredentials(ufrag, pwd);
   };
 
-  signaling_.onPeerCandidate = [this](const std::string& candidate) {
-    iceAgent_->addRemoteCandidate(candidate);
+  signaling_.on_peer_candidate = [this](const std::string& candidate) {
+    iceAgent_->AddRemoteCandidate(candidate);
   };
 
-  signaling_.onPeerGatherDone = [this]() {
+  signaling_.on_peer_gather_done = [this]() {
     // Not calling iceAgent_.setRemoteGatheringDone() — it's optional in ICE.
     // Omitting it avoids a race where UDP reordering delivers gather-done
     // before late candidates (which libjuice would then reject).
@@ -125,103 +125,103 @@ void OnlineConnectState::startSignaling() {
     // timeout to conclude that no more candidates are coming.
   };
 
-  signaling_.onError = [this](const std::string& msg) {
+  signaling_.on_error = [this](const std::string& msg) {
     fprintf(stderr, "[online] onError: %s\n", msg.c_str());
     statusLine2_ = "ERROR: " + msg;
     cancel_ = true;
   };
 
-  signaling_.onRoomExpired = [this]() {
+  signaling_.on_room_expired = [this]() {
     fprintf(stderr, "[online] onRoomExpired\n");
     statusLine2_ = "ROOM EXPIRED";
     cancel_ = true;
   };
 
   // Connect to signaling server
-  if (role_ == NetSession::Host) {
-    if (!signaling_.createRoom(signalingServer_, signalingPort_)) {
+  if (role_ == NetSession::kHost) {
+    if (!signaling_.CreateRoom(signaling_server_, signalingPort_)) {
       statusLine2_ = "FAILED TO REACH SIGNALING SERVER";
       cancel_ = true;
     }
   } else {
-    if (!signaling_.joinRoom(signalingServer_, signalingPort_, roomCode_)) {
+    if (!signaling_.JoinRoom(signaling_server_, signalingPort_, roomCode_)) {
       statusLine2_ = "FAILED TO REACH SIGNALING SERVER";
       cancel_ = true;
     }
   }
 }
 
-void OnlineConnectState::sendBufferedCandidates() {
-  for (auto& c : bufferedCandidates_) signaling_.sendIceCandidate(c);
+void OnlineConnectState::SendBufferedCandidates() {
+  for (auto& c : bufferedCandidates_) signaling_.SendIceCandidate(c);
   bufferedCandidates_.clear();
 
-  if (gatheringDone_) signaling_.sendIceGatherDone();
+  if (gatheringDone_) signaling_.SendIceGatherDone();
 }
 
-void OnlineConnectState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void OnlineConnectState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool OnlineConnectState::update() {
+bool OnlineConnectState::Update() {
   if (cancel_) {
-    if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) || gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN)) {
-      if (iceAgent_) iceAgent_->stop();
-      signaling_.disconnect();
+    if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) || gfx->TestSdlKeyOnce(SDL_SCANCODE_RETURN)) {
+      if (iceAgent_) iceAgent_->Stop();
+      signaling_.Disconnect();
       return false;
     }
     return true;
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE)) {
-    if (iceAgent_) iceAgent_->stop();
-    signaling_.disconnect();
-    gfx->clearKeys();
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE)) {
+    if (iceAgent_) iceAgent_->Stop();
+    signaling_.Disconnect();
+    gfx->ClearKeys();
     return false;
   }
 
   // Poll ICE agent (drains event queue, fires callbacks on main thread)
-  if (iceAgent_) iceAgent_->poll();
+  if (iceAgent_) iceAgent_->Poll();
 
   // Poll signaling
-  signaling_.poll();
+  signaling_.Poll();
 
   // Keepalive
-  if (signaling_.state() != SignalingClient::Idle &&
-      signaling_.state() != SignalingClient::Failed) {
-    uint64_t now = nowMs();
+  if (signaling_.State() != SignalingClient::kIdle &&
+      signaling_.State() != SignalingClient::kFailed) {
+    uint64_t now = NowMs();
     if (now - lastKeepaliveMs_ > 5000) {
-      signaling_.sendKeepalive();
+      signaling_.SendKeepalive();
       lastKeepaliveMs_ = now;
     }
   }
 
   // Transition to game when ICE connects
   if (iceConnected_) {
-    transitionToGame();
+    TransitionToGame();
     iceConnected_ = false;  // prevent re-entry
   }
 
   return true;
 }
 
-void OnlineConnectState::transitionToGame() {
+void OnlineConnectState::TransitionToGame() {
   fprintf(stderr, "[online] ICE connected — creating bridge and transitioning to game\n");
 
   // Disconnect signaling (no longer needed)
-  signaling_.disconnect();
+  signaling_.Disconnect();
 
   // Create the loopback bridge
-  auto bridgeFd = iceBridge_->create(*iceAgent_);
-  if (bridgeFd == BRIDGE_INVALID) {
+  auto bridge_fd = iceBridge_->Create(*iceAgent_);
+  if (bridge_fd == kBridgeInvalid) {
     fprintf(stderr, "[online] ERROR: failed to create ICE bridge\n");
     statusLine2_ = "BRIDGE CREATION FAILED";
     cancel_ = true;
     return;
   }
 
-  uint16_t bport = iceBridge_->bridgePort();
+  uint16_t bport = iceBridge_->BridgePort();
 
   // Create a NetTransport using the bridge socket
   NetTransport transport;
-  if (!transport.createHostOnBridgeSocket(bridgeFd)) {
+  if (!transport.CreateHostOnBridgeSocket(bridge_fd)) {
     fprintf(stderr, "[online] ERROR: failed to create ENet host on bridge socket\n");
     statusLine2_ = "ENET BRIDGE SETUP FAILED";
     cancel_ = true;
@@ -230,47 +230,47 @@ void OnlineConnectState::transitionToGame() {
 
   // Transfer ICE ownership to the transport (keeps them alive after this state is destroyed)
   // Clear callbacks first — they capture `this` which will be destroyed
-  iceAgent_->onStateChange = nullptr;
-  iceAgent_->onLocalCandidate = nullptr;
-  iceAgent_->onGatheringDone = nullptr;
-  transport.attachIce(std::move(iceBridge_), std::move(iceAgent_));
+  iceAgent_->on_state_change = nullptr;
+  iceAgent_->on_local_candidate = nullptr;
+  iceAgent_->on_gathering_done = nullptr;
+  transport.AttachIce(std::move(iceBridge_), std::move(iceAgent_));
 
   // Transition to NetConnectState with the bridge-backed transport.
   // For host: ENet listens on bridge socket, peer connects.
   // For client: ENet connects to bridge port (IPv6 localhost).
-  if (role_ == NetSession::Host) {
-    gfx->stateStack.scheduleReplaceTop(
-        std::make_unique<NetConnectState>(NetSession::Host, std::move(transport)));
+  if (role_ == NetSession::kHost) {
+    gfx->state_stack.ScheduleReplaceTop(
+        std::make_unique<NetConnectState>(NetSession::kHost, std::move(transport)));
   } else {
-    gfx->stateStack.scheduleReplaceTop(
-        std::make_unique<NetConnectState>(NetSession::Client, std::move(transport), "::1", bport));
+    gfx->state_stack.ScheduleReplaceTop(
+        std::make_unique<NetConnectState>(NetSession::kClient, std::move(transport), "::1", bport));
   }
 }
 
-void OnlineConnectState::draw() {
+void OnlineConnectState::Draw() {
   Common& common = *gfx->common;
   Font& font = common.font;
 
-  gfx->playRenderer.pal = common.exepal;
-  fill(gfx->playRenderer.bmp, 0);
+  gfx->play_renderer.pal = common.exepal;
+  Fill(gfx->play_renderer.bmp, 0);
 
   int cx = 160;
   int cy = 60;
 
-  int w1 = font.getDims(statusLine1_);
-  font.drawText(gfx->playRenderer.bmp, statusLine1_, cx - w1 / 2, cy, 50);
+  int w1 = font.GetDims(statusLine1_);
+  font.DrawText(gfx->play_renderer.bmp, statusLine1_, cx - w1 / 2, cy, 50);
 
-  int w2 = font.getDims(statusLine2_);
-  font.drawText(gfx->playRenderer.bmp, statusLine2_, cx - w2 / 2, cy + 14, 7);
+  int w2 = font.GetDims(statusLine2_);
+  font.DrawText(gfx->play_renderer.bmp, statusLine2_, cx - w2 / 2, cy + 14, 7);
 
-  if (role_ == NetSession::Host && !roomCode_.empty() &&
-      signaling_.state() == SignalingClient::Hosting) {
-    std::string codeStr = "CODE: " + roomCode_;
-    int wc = font.getDims(codeStr);
-    font.drawText(gfx->playRenderer.bmp, codeStr, cx - wc / 2, cy + 30, 45);
+  if (role_ == NetSession::kHost && !roomCode_.empty() &&
+      signaling_.State() == SignalingClient::kHosting) {
+    std::string code_str = "CODE: " + roomCode_;
+    int wc = font.GetDims(code_str);
+    font.DrawText(gfx->play_renderer.bmp, code_str, cx - wc / 2, cy + 30, 45);
   }
 
   std::string esc = "PRESS ESC TO CANCEL";
-  int we = font.getDims(esc);
-  font.drawText(gfx->playRenderer.bmp, esc, cx - we / 2, 170, 7);
+  int we = font.GetDims(esc);
+  font.DrawText(gfx->play_renderer.bmp, esc, cx - we / 2, 170, 7);
 }

--- a/src/game/onlineConnectState.cpp
+++ b/src/game/onlineConnectState.cpp
@@ -20,8 +20,8 @@ void OnlineConnectState::Enter() {
   fprintf(stderr, "[online] enter: role=%s roomCode='%s'\n",
           role_ == NetSession::kHost ? "Host" : "Client", roomCode_.c_str());
 
-  statusLine1_ =
-      (role_ == NetSession::kHost) ? "CREATING ONLINE ROOM..." : "JOINING ROOM " + roomCode_ + "...";
+  statusLine1_ = (role_ == NetSession::kHost) ? "CREATING ONLINE ROOM..."
+                                              : "JOINING ROOM " + roomCode_ + "...";
   statusLine2_ = "SETTING UP ICE...";
 
   iceAgent_ = std::make_unique<IceAgent>();

--- a/src/game/onlineConnectState.hpp
+++ b/src/game/onlineConnectState.hpp
@@ -20,24 +20,24 @@
 // 4. libjuice performs ICE connectivity checks (all candidate pairs)
 // 5. On success → create IceBridge, hand socket to NetConnectState
 struct OnlineConnectState : AppState {
-  OnlineConnectState(NetSession::Role role, std::string roomCode = "");
+  OnlineConnectState(NetSession::Role role, std::string room_code = "");
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
  private:
-  void startSignaling();
-  void sendBufferedCandidates();
-  void transitionToGame();
+  void StartSignaling();
+  void SendBufferedCandidates();
+  void TransitionToGame();
 
   NetSession::Role role_;
   std::string roomCode_;
 
-  std::string signalingServer_ = "liero-server.orbmit.org";
+  std::string signaling_server_ = "liero-server.orbmit.org";
   uint16_t signalingPort_ = 19533;
-  std::string turnServer_ = "liero-server.orbmit.org";
+  std::string turn_server_ = "liero-server.orbmit.org";
   uint16_t turnPort_ = 3478;
 
   std::unique_ptr<IceAgent> iceAgent_;

--- a/src/game/rand.hpp
+++ b/src/game/rand.hpp
@@ -17,7 +17,7 @@ struct Rand {
   Rand() = default;
   explicit Rand(uint32_t s) : engine(s) {}
 
-  void seed(uint32_t s) {
+  void Seed(uint32_t s) {
     engine.seed(s);
     last = 0;
   }
@@ -37,9 +37,9 @@ struct Rand {
   }
 
   // Number in [0.0, 1.0).
-  double get_double() { return (*this)() / 4294967296.0; }
+  double GetDouble() { return (*this)() / 4294967296.0; }
 
-  double get_double(double max) { return get_double() * max; }
+  double GetDouble(double max) { return GetDouble() * max; }
 
   std::string serialize() const {
     std::ostringstream oss;
@@ -47,7 +47,7 @@ struct Rand {
     return oss.str();
   }
 
-  void deserialize(std::string const& s) {
+  void Deserialize(std::string const& s) {
     std::istringstream iss(s);
     iss >> engine;
   }
@@ -58,9 +58,9 @@ struct Rand {
   bool operator!=(Rand const& other) const { return !(*this == other); }
 };
 
-template <typename Archive>
-void archive(Archive ar, Rand& r) {
-  if constexpr (Archive::in) {
+template <typename Ar>
+void ArchiveRand(Ar ar, Rand& r) {
+  if constexpr (Ar::in) {
     uint32_t len = 0;
     ar.ui32(len);
     std::string s(len, '\0');
@@ -69,7 +69,7 @@ void archive(Archive ar, Rand& r) {
       ar.ui8(b);
       s[i] = static_cast<char>(b);
     }
-    r.deserialize(s);
+    r.Deserialize(s);
     ar.ui32(r.last);
   } else {
     std::string s = r.serialize();

--- a/src/game/reader.hpp
+++ b/src/game/reader.hpp
@@ -25,33 +25,33 @@ struct ReaderFile {
   explicit ReaderFile(io::Reader& r) {
     uint8_t buf[4096];
     for (;;) {
-      std::size_t got = r.try_get(buf, sizeof(buf));
+      std::size_t got = r.TryGet(buf, sizeof(buf));
       if (got == 0) break;
       data_.insert(data_.end(), buf, buf + got);
     }
   }
 
-  uint8_t* data() { return data_.data(); }
-  uint8_t const* data() const { return data_.data(); }
-  std::size_t len() const { return data_.size(); }
+  uint8_t* Data() { return data_.data(); }
+  uint8_t const* Data() const { return data_.data(); }
+  std::size_t Len() const { return data_.size(); }
 
   std::size_t pos = 0;
 
-  void seekg(std::size_t newPos) {
-    if (newPos > data_.size()) throw io::EndOfStream("EOF in seekg()");
-    pos = newPos;
+  void Seekg(std::size_t new_pos) {
+    if (new_pos > data_.size()) throw io::EndOfStream("EOF in seekg()");
+    pos = new_pos;
   }
 
-  std::size_t tellg() const { return pos; }
+  std::size_t Tellg() const { return pos; }
 
-  void skip(std::size_t step) { seekg(pos + step); }
+  void Skip(std::size_t step) { Seekg(pos + step); }
 
-  uint8_t get() {
+  uint8_t Get() {
     if (pos >= data_.size()) throw io::EndOfStream("EOF in get()");
     return data_[pos++];
   }
 
-  void get(uint8_t* p, std::size_t l) {
+  void Get(uint8_t* p, std::size_t l) {
     if (pos + l > data_.size()) throw io::EndOfStream("EOF in get()");
     std::memcpy(p, data_.data() + pos, l);
     pos += l;

--- a/src/game/rematchState.cpp
+++ b/src/game/rematchState.cpp
@@ -173,7 +173,7 @@ void RematchState::Draw() {
   // Title
   std::string title = "REMATCH";
   int tw = font.GetDims(title);
-  font.DrawText(gfx->play_renderer.bmp, title, cx - tw / 2, y, 50);
+  font.DrawString(gfx->play_renderer.bmp, title, cx - tw / 2, y, 50);
   y += 14;
 
   // Score summary from last game
@@ -184,7 +184,7 @@ void RematchState::Draw() {
       std::string score = w0->settings->name + "  " + std::to_string(w0->kills) + " - " +
                           std::to_string(w1->kills) + "  " + w1->settings->name;
       int sw = font.GetDims(score);
-      font.DrawText(gfx->play_renderer.bmp, score, cx - sw / 2, y, 7);
+      font.DrawString(gfx->play_renderer.bmp, score, cx - sw / 2, y, 7);
     }
     y += 14;
   }
@@ -201,24 +201,24 @@ void RematchState::Draw() {
     // Draw local player status
     std::string local_line = you + ":";
     int llw = font.GetDims(local_line);
-    font.DrawText(gfx->play_renderer.bmp, local_line, cx - llw / 2 - 10, y, 7);
+    font.DrawString(gfx->play_renderer.bmp, local_line, cx - llw / 2 - 10, y, 7);
     // Draw indicator after text
     int local_ind_x = cx - llw / 2 - 10 + llw + 4;
     if (local_ready)
-      font.DrawText(gfx->play_renderer.bmp, "READY", local_ind_x, y, 63);
+      font.DrawString(gfx->play_renderer.bmp, "READY", local_ind_x, y, 63);
     else
-      font.DrawText(gfx->play_renderer.bmp, "X", local_ind_x, y, 18);
+      font.DrawString(gfx->play_renderer.bmp, "X", local_ind_x, y, 18);
     y += 10;
 
     // Draw remote player status
     std::string remote_line = peer + ":";
     int rlw = font.GetDims(remote_line);
-    font.DrawText(gfx->play_renderer.bmp, remote_line, cx - rlw / 2 - 10, y, 7);
+    font.DrawString(gfx->play_renderer.bmp, remote_line, cx - rlw / 2 - 10, y, 7);
     int remote_ind_x = cx - rlw / 2 - 10 + rlw + 4;
     if (remote_ready)
-      font.DrawText(gfx->play_renderer.bmp, "READY", remote_ind_x, y, 63);
+      font.DrawString(gfx->play_renderer.bmp, "READY", remote_ind_x, y, 63);
     else
-      font.DrawText(gfx->play_renderer.bmp, "X", remote_ind_x, y, 18);
+      font.DrawString(gfx->play_renderer.bmp, "X", remote_ind_x, y, 18);
     y += 14;
   }
 

--- a/src/game/rematchState.cpp
+++ b/src/game/rematchState.cpp
@@ -11,73 +11,73 @@
 #include "mixer/player.hpp"
 #include "net/session.hpp"
 
-RematchState::RematchState(Game& lastGame)
-    : lastGame_(lastGame),
+RematchState::RematchState(Game& last_game)
+    : lastGame_(last_game),
       menu_(true)  // centered
 {}
 
-void RematchState::enter() {
-  fill(gfx->playRenderer.bmp, 0);
-  gfx->playRenderer.origpal = gfx->common->exepal;
-  gfx->clearKeys();
+void RematchState::Enter() {
+  Fill(gfx->play_renderer.bmp, 0);
+  gfx->play_renderer.origpal = gfx->common->exepal;
+  gfx->ClearKeys();
 
-  prevRandomLevel_ = gfx->settings->randomLevel;
-  prevLevelFile_ = gfx->settings->levelFile;
+  prevRandomLevel_ = gfx->settings->random_level;
+  prevLevelFile_ = gfx->settings->level_file;
 
   // Build menu items
-  bool isHost = gfx->netSession && gfx->netSession->isHost();
+  bool is_host = gfx->net_session && gfx->net_session->IsHost();
 
-  menu_.addItem(MenuItem(48, 7, "LEVEL", RmLevel));
-  menu_.addItem(MenuItem(48, 7, "READY", RmReady));
-  menu_.addItem(MenuItem(48, 7, "DISCONNECT", RmDisconnect));
+  menu_.AddItem(MenuItem(48, 7, "LEVEL", kRmLevel));
+  menu_.AddItem(MenuItem(48, 7, "READY", kRmReady));
+  menu_.AddItem(MenuItem(48, 7, "DISCONNECT", kRmDisconnect));
 
   // Only host can select the level item
-  if (!isHost) menu_.items[0].selectable = false;
+  if (!is_host) menu_.items[0].selectable = false;
 
-  menu_.valueOffsetX = 80;
-  menu_.place(120, 90);
-  menu_.moveToId(RmReady);
+  menu_.value_offset_x = 80;
+  menu_.Place(120, 90);
+  menu_.MoveToId(kRmReady);
 }
 
-void RematchState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void RematchState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-void RematchState::updateMenuItems() {
-  if (!gfx->netSession) return;
+void RematchState::UpdateMenuItems() {
+  if (!gfx->net_session) return;
 
   // Update level display
-  auto* levelItem = menu_.itemFromId(RmLevel);
-  if (levelItem) {
-    levelItem->hasValue = true;
-    levelItem->value = '"' + levelDisplayName() + '"';
+  auto* level_item = menu_.ItemFromId(kRmLevel);
+  if (level_item) {
+    level_item->has_value = true;
+    level_item->value = '"' + LevelDisplayName() + '"';
   }
 
   // Update ready item text
-  auto* readyItem = menu_.itemFromId(RmReady);
-  if (readyItem) {
-    bool localReady = gfx->netSession->localReady();
-    readyItem->string = localReady ? "CANCEL" : "READY UP";
-    readyItem->color = localReady ? 18 : 63;
+  auto* ready_item = menu_.ItemFromId(kRmReady);
+  if (ready_item) {
+    bool local_ready = gfx->net_session->LocalReady();
+    ready_item->string = local_ready ? "CANCEL" : "READY UP";
+    ready_item->color = local_ready ? 18 : 63;
   }
 }
 
-bool RematchState::update() {
-  if (!gfx->netSession) return false;
+bool RematchState::Update() {
+  if (!gfx->net_session) return false;
 
-  gfx->netSession->update();
+  gfx->net_session->Update();
 
-  auto state = gfx->netSession->sessionState();
+  auto state = gfx->net_session->State();
 
   // Rematch game is starting — transfer controller and enter gameplay
-  if (state == NetSession::Playing) {
-    auto ctrl = gfx->netSession->releaseController();
+  if (state == NetSession::kPlaying) {
+    auto ctrl = gfx->net_session->ReleaseController();
     gfx->controller = std::unique_ptr<Controller>(ctrl.release());
-    gfx->stateStack.scheduleReplaceTop(std::make_unique<GamePlayState>());
+    gfx->state_stack.ScheduleReplaceTop(std::make_unique<GamePlayState>());
     return true;
   }
 
-  if (state == NetSession::Disconnected || state == NetSession::Failed) {
-    gfx->netSession.reset();
-    gfx->stateStack.scheduleReplaceTop(
+  if (state == NetSession::kDisconnected || state == NetSession::kFailed) {
+    gfx->net_session.reset();
+    gfx->state_stack.ScheduleReplaceTop(
         std::make_unique<InfoBoxState>("PEER DISCONNECTED", 160, 100, true));
     return true;
   }
@@ -86,142 +86,142 @@ bool RematchState::update() {
   if (levelSelectorOpen_) {
     levelSelectorOpen_ = false;
 
-    bool changed = (gfx->settings->randomLevel != prevRandomLevel_) ||
-                   (gfx->settings->levelFile != prevLevelFile_);
+    bool changed = (gfx->settings->random_level != prevRandomLevel_) ||
+                   (gfx->settings->level_file != prevLevelFile_);
 
-    if (changed && gfx->netSession->isHost()) {
-      gfx->netSession->setRematchLevel(gfx->settings->randomLevel, gfx->settings->levelFile);
+    if (changed && gfx->net_session->IsHost()) {
+      gfx->net_session->SetRematchLevel(gfx->settings->random_level, gfx->settings->level_file);
     }
 
-    prevRandomLevel_ = gfx->settings->randomLevel;
-    prevLevelFile_ = gfx->settings->levelFile;
+    prevRandomLevel_ = gfx->settings->random_level;
+    prevLevelFile_ = gfx->settings->level_file;
   }
 
   Common& common = *gfx->common;
 
   // Menu navigation
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_UP) || gfx->testControlOnce(WormSettingsExtensions::Up) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-    menu_.movement(-1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_UP) || gfx->TestControlOnce(WormSettingsExtensions::kUp) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+    menu_.Movement(-1);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN) ||
-      gfx->testControlOnce(WormSettingsExtensions::Down) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-    menu_.movement(1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kDown) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+    menu_.Movement(1);
   }
 
   // Escape = disconnect
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
-      gfx->testControlOnce(WormSettingsExtensions::Jump) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
-    gfx->netSession->disconnect();
-    gfx->netSession.reset();
-    fill(gfx->playRenderer.bmp, 0);
-    fill(gfx->singleScreenRenderer.bmp, 0);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kJump) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
+    gfx->net_session->Disconnect();
+    gfx->net_session.reset();
+    Fill(gfx->play_renderer.bmp, 0);
+    Fill(gfx->single_screen_renderer.bmp, 0);
     return false;
   }
 
   // Enter/Fire = activate selected item
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN) || gfx->testSDLKeyOnce(SDL_SCANCODE_KP_ENTER) ||
-      gfx->testControlOnce(WormSettingsExtensions::Fire) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
-    int sel = menu_.selectedId();
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RETURN) || gfx->TestSdlKeyOnce(SDL_SCANCODE_KP_ENTER) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kFire) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
+    int sel = menu_.SelectedId();
     switch (sel) {
-      case RmLevel:
+      case kRmLevel:
         // Host opens level selector
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
         levelSelectorOpen_ = true;
-        gfx->stateStack.push(std::make_unique<LevelSelectorState>(), gfx);
+        gfx->state_stack.Push(std::make_unique<LevelSelectorState>(), gfx);
         break;
 
-      case RmReady:
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-        gfx->netSession->toggleReady();
+      case kRmReady:
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+        gfx->net_session->ToggleReady();
         break;
 
-      case RmDisconnect:
-        g_soundPlayer->play(common.soundHook[SoundMenuSelect]);
-        gfx->netSession->disconnect();
-        gfx->netSession.reset();
-        fill(gfx->playRenderer.bmp, 0);
-        fill(gfx->singleScreenRenderer.bmp, 0);
+      case kRmDisconnect:
+        g_sound_player->Play(common.sound_hook[SoundMenuSelect]);
+        gfx->net_session->Disconnect();
+        gfx->net_session.reset();
+        Fill(gfx->play_renderer.bmp, 0);
+        Fill(gfx->single_screen_renderer.bmp, 0);
         return false;
     }
   }
 
-  updateMenuItems();
+  UpdateMenuItems();
   return true;
 }
 
-std::string RematchState::levelDisplayName() const {
-  if (gfx->settings->randomLevel || gfx->settings->levelFile.empty()) return "RANDOM";
-  return getBasename(getLeaf(gfx->settings->levelFile));
+std::string RematchState::LevelDisplayName() const {
+  if (gfx->settings->random_level || gfx->settings->level_file.empty()) return "RANDOM";
+  return GetBasename(GetLeaf(gfx->settings->level_file));
 }
 
-void RematchState::draw() {
+void RematchState::Draw() {
   Common& common = *gfx->common;
   Font& font = common.font;
 
-  fill(gfx->playRenderer.bmp, 0);
+  Fill(gfx->play_renderer.bmp, 0);
 
   int cx = 160;
   int y = 40;
 
   // Title
   std::string title = "REMATCH";
-  int tw = font.getDims(title);
-  font.drawText(gfx->playRenderer.bmp, title, cx - tw / 2, y, 50);
+  int tw = font.GetDims(title);
+  font.DrawText(gfx->play_renderer.bmp, title, cx - tw / 2, y, 50);
   y += 14;
 
   // Score summary from last game
   {
-    Worm* w0 = lastGame_.wormByIdx(0);
-    Worm* w1 = lastGame_.wormByIdx(1);
+    Worm* w0 = lastGame_.WormByIdx(0);
+    Worm* w1 = lastGame_.WormByIdx(1);
     if (w0 && w1) {
       std::string score = w0->settings->name + "  " + std::to_string(w0->kills) + " - " +
                           std::to_string(w1->kills) + "  " + w1->settings->name;
-      int sw = font.getDims(score);
-      font.drawText(gfx->playRenderer.bmp, score, cx - sw / 2, y, 7);
+      int sw = font.GetDims(score);
+      font.DrawText(gfx->play_renderer.bmp, score, cx - sw / 2, y, 7);
     }
     y += 14;
   }
 
   // Peer ready status
-  if (gfx->netSession) {
-    bool isHost = gfx->netSession->isHost();
-    bool localReady = gfx->netSession->localReady();
-    bool remoteReady = gfx->netSession->remoteReady();
+  if (gfx->net_session) {
+    bool is_host = gfx->net_session->IsHost();
+    bool local_ready = gfx->net_session->LocalReady();
+    bool remote_ready = gfx->net_session->RemoteReady();
 
-    std::string peer = isHost ? "CLIENT" : "HOST";
-    std::string you = isHost ? "HOST" : "CLIENT";
+    std::string peer = is_host ? "CLIENT" : "HOST";
+    std::string you = is_host ? "HOST" : "CLIENT";
 
     // Draw local player status
-    std::string localLine = you + ":";
-    int llw = font.getDims(localLine);
-    font.drawText(gfx->playRenderer.bmp, localLine, cx - llw / 2 - 10, y, 7);
+    std::string local_line = you + ":";
+    int llw = font.GetDims(local_line);
+    font.DrawText(gfx->play_renderer.bmp, local_line, cx - llw / 2 - 10, y, 7);
     // Draw indicator after text
-    int localIndX = cx - llw / 2 - 10 + llw + 4;
-    if (localReady)
-      font.drawText(gfx->playRenderer.bmp, "READY", localIndX, y, 63);
+    int local_ind_x = cx - llw / 2 - 10 + llw + 4;
+    if (local_ready)
+      font.DrawText(gfx->play_renderer.bmp, "READY", local_ind_x, y, 63);
     else
-      font.drawText(gfx->playRenderer.bmp, "X", localIndX, y, 18);
+      font.DrawText(gfx->play_renderer.bmp, "X", local_ind_x, y, 18);
     y += 10;
 
     // Draw remote player status
-    std::string remoteLine = peer + ":";
-    int rlw = font.getDims(remoteLine);
-    font.drawText(gfx->playRenderer.bmp, remoteLine, cx - rlw / 2 - 10, y, 7);
-    int remoteIndX = cx - rlw / 2 - 10 + rlw + 4;
-    if (remoteReady)
-      font.drawText(gfx->playRenderer.bmp, "READY", remoteIndX, y, 63);
+    std::string remote_line = peer + ":";
+    int rlw = font.GetDims(remote_line);
+    font.DrawText(gfx->play_renderer.bmp, remote_line, cx - rlw / 2 - 10, y, 7);
+    int remote_ind_x = cx - rlw / 2 - 10 + rlw + 4;
+    if (remote_ready)
+      font.DrawText(gfx->play_renderer.bmp, "READY", remote_ind_x, y, 63);
     else
-      font.drawText(gfx->playRenderer.bmp, "X", remoteIndX, y, 18);
+      font.DrawText(gfx->play_renderer.bmp, "X", remote_ind_x, y, 18);
     y += 14;
   }
 
   // Draw menu
-  menu_.draw(common, gfx->playRenderer, false);
+  menu_.Draw(common, gfx->play_renderer, false);
 }

--- a/src/game/rematchState.hpp
+++ b/src/game/rematchState.hpp
@@ -12,22 +12,22 @@ struct Game;
 // When both are ready, starts a new game.
 struct RematchState : AppState {
   enum Items {
-    RmLevel,
-    RmReady,
-    RmDisconnect,
+    kRmLevel,
+    kRmReady,
+    kRmDisconnect,
   };
 
-  RematchState(Game& lastGame);
+  RematchState(Game& last_game);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
-  bool wantsMenuFlip() const override { return true; }
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
+  bool WantsMenuFlip() const override { return true; }
 
  private:
-  std::string levelDisplayName() const;
-  void updateMenuItems();
+  std::string LevelDisplayName() const;
+  void UpdateMenuItems();
 
   Game& lastGame_;
   Menu menu_;

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -72,9 +72,11 @@ uint32_t const kReplayMagic = ('L' << 24) | ('R' << 16) | ('P' << 8) | 'F';
 std::unique_ptr<Game> ReplayReader::BeginPlayback(std::shared_ptr<Common> common,
                                                   std::shared_ptr<SoundPlayer> sound_player) {
   uint32_t read_magic = io::ReadUint32(reader);
-  if (read_magic != kReplayMagic) throw io::ArchiveCheckError("File does not appear to be a replay");
+  if (read_magic != kReplayMagic)
+    throw io::ArchiveCheckError("File does not appear to be a replay");
   replay_version = reader.Get();
-  if (replay_version > kMyReplayVersion) throw io::ArchiveCheckError("Replay version is too recent");
+  if (replay_version > kMyReplayVersion)
+    throw io::ArchiveCheckError("Replay version is too recent");
 
   std::shared_ptr<Settings> settings(new Settings);
   std::unique_ptr<Game> game(new Game(common, settings, sound_player));

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -26,24 +26,24 @@ constexpr uint8_t kReplayTagEnd = 0x83;           // end of stream
 // Helper: serialize an object to a binary blob via cereal and write
 // [uint32 length][blob] into the replay stream.
 template <typename T>
-static void cerealWrite(io::Writer& writer, T& obj) {
+static void CerealWrite(io::Writer& writer, T& obj) {
   std::ostringstream ss(std::ios::binary);
   {
     cereal::PortableBinaryOutputArchive ar(ss);
     ar(obj);
   }
   std::string buf = ss.str();
-  io::write_uint32(writer, static_cast<uint32_t>(buf.size()));
-  writer.put(reinterpret_cast<uint8_t const*>(buf.data()), buf.size());
+  io::WriteUint32(writer, static_cast<uint32_t>(buf.size()));
+  writer.Put(reinterpret_cast<uint8_t const*>(buf.data()), buf.size());
 }
 
 // Helper: read [uint32 length][blob] from the replay stream and
 // deserialize into obj via cereal.
 template <typename T>
-static void cerealRead(io::MemReader& reader, T& obj) {
-  uint32_t len = io::read_uint32(reader);
+static void CerealRead(io::MemReader& reader, T& obj) {
+  uint32_t len = io::ReadUint32(reader);
   std::string buf(len, '\0');
-  for (uint32_t i = 0; i < len; ++i) buf[i] = static_cast<char>(reader.get());
+  for (uint32_t i = 0; i < len; ++i) buf[i] = static_cast<char>(reader.Get());
   std::istringstream ss(buf, std::ios::binary);
   {
     cereal::PortableBinaryInputArchive ar(ss);
@@ -52,183 +52,183 @@ static void cerealRead(io::MemReader& reader, T& obj) {
 }
 
 ReplayWriter::ReplayWriter(std::unique_ptr<io::Writer> sink)
-    : writer(std::move(sink)), settingsExpired(true) {}
+    : writer(std::move(sink)), settings_expired(true) {}
 
-ReplayWriter::~ReplayWriter() { endRecord(); }
+ReplayWriter::~ReplayWriter() { EndRecord(); }
 
 ReplayReader::ReplayReader(std::unique_ptr<io::Reader> source) {
   io::InflateReader inflater(std::move(source));
   uint8_t buf[4096];
   for (;;) {
-    std::size_t got = inflater.try_get(buf, sizeof(buf));
+    std::size_t got = inflater.TryGet(buf, sizeof(buf));
     if (got == 0) break;
     data.insert(data.end(), buf, buf + got);
   }
-  reader.reset(data.data(), data.size());
+  reader.Reset(data.data(), data.size());
 }
 
-uint32_t const replayMagic = ('L' << 24) | ('R' << 16) | ('P' << 8) | 'F';
+uint32_t const kReplayMagic = ('L' << 24) | ('R' << 16) | ('P' << 8) | 'F';
 
-std::unique_ptr<Game> ReplayReader::beginPlayback(std::shared_ptr<Common> common,
-                                                  std::shared_ptr<SoundPlayer> soundPlayer) {
-  uint32_t readMagic = io::read_uint32(reader);
-  if (readMagic != replayMagic) throw io::ArchiveCheckError("File does not appear to be a replay");
-  replayVersion = reader.get();
-  if (replayVersion > myReplayVersion) throw io::ArchiveCheckError("Replay version is too recent");
+std::unique_ptr<Game> ReplayReader::BeginPlayback(std::shared_ptr<Common> common,
+                                                  std::shared_ptr<SoundPlayer> sound_player) {
+  uint32_t read_magic = io::ReadUint32(reader);
+  if (read_magic != kReplayMagic) throw io::ArchiveCheckError("File does not appear to be a replay");
+  replay_version = reader.Get();
+  if (replay_version > kMyReplayVersion) throw io::ArchiveCheckError("Replay version is too recent");
 
   std::shared_ptr<Settings> settings(new Settings);
-  std::unique_ptr<Game> game(new Game(common, settings, soundPlayer));
+  std::unique_ptr<Game> game(new Game(common, settings, sound_player));
 
-  cerealRead(reader, *game);
+  CerealRead(reader, *game);
 
   return game;
 }
 
-void ReplayWriter::beginRecord(Game& game) {
-  io::write_uint32(writer, replayMagic);
-  writer.put(myReplayVersion);
+void ReplayWriter::BeginRecord(Game& game) {
+  io::WriteUint32(writer, kReplayMagic);
+  writer.Put(kMyReplayVersion);
 
-  cerealWrite(writer, game);
-  settingsExpired = false;
+  CerealWrite(writer, game);
+  settings_expired = false;
 
   // Track worm settings for change detection
   for (auto const& worm_sp : game.worms) {
-    WormData& data = wormData[worm_sp.get()];
-    data.settingsExpired = false;
-    data.lastSettingsHash = worm_sp->settings->updateHash();
+    WormData& data = worm_data[worm_sp.get()];
+    data.settings_expired = false;
+    data.last_settings_hash = worm_sp->settings->UpdateHash();
   }
-  lastSettingsHash = game.settings->updateHash();
+  last_settings_hash = game.settings->UpdateHash();
   this->game = &game;
 }
 
-void ReplayWriter::endRecord() { writer.put(kReplayTagEnd); }
+void ReplayWriter::EndRecord() { writer.Put(kReplayTagEnd); }
 
 namespace {
-inline void mix32(uint32_t& h, uint32_t v) { h ^= v + 0x9e3779b9u + (h << 6) + (h >> 2); }
-inline void mixBytes(uint32_t& h, void const* p, std::size_t n) {
+inline void Mix32(uint32_t& h, uint32_t v) { h ^= v + 0x9e3779b9u + (h << 6) + (h >> 2); }
+inline void MixBytes(uint32_t& h, void const* p, std::size_t n) {
   auto* b = static_cast<uint8_t const*>(p);
-  for (std::size_t i = 0; i < n; ++i) mix32(h, b[i]);
+  for (std::size_t i = 0; i < n; ++i) Mix32(h, b[i]);
 }
 }  // namespace
 
-uint32_t wideRollbackChecksum(Game& game) {
+uint32_t WideRollbackChecksum(Game& game) {
   // Folds in projectile pools, level damage, and per-worm sim state the
   // fast checksum drops. Order matters for reproducibility — both peers
   // walk the same fields in the same sequence.
   uint32_t h = game.rand.last;
-  mix32(h, static_cast<uint32_t>(game.cycles));
+  Mix32(h, static_cast<uint32_t>(game.cycles));
 
   for (auto const& w_sp : game.worms) {
     Worm const& w = *w_sp;
-    mix32(h, static_cast<uint32_t>(w.pos.x));
-    mix32(h, static_cast<uint32_t>(w.pos.y));
-    mix32(h, static_cast<uint32_t>(w.vel.x));
-    mix32(h, static_cast<uint32_t>(w.vel.y));
-    mix32(h, static_cast<uint32_t>(w.aimingAngle));
-    mix32(h, static_cast<uint32_t>(w.aimingSpeed));
-    mix32(h, static_cast<uint32_t>(w.health));
-    mix32(h, static_cast<uint32_t>(w.lives));
-    mix32(h, static_cast<uint32_t>(w.kills));
-    mix32(h, static_cast<uint32_t>(w.timer));
-    mix32(h, static_cast<uint32_t>(w.killedTimer));
-    mix32(h, static_cast<uint32_t>(w.currentFrame));
-    mix32(h, static_cast<uint32_t>(w.currentWeapon));
-    mix32(h, static_cast<uint32_t>(w.direction));
-    mix32(h, static_cast<uint32_t>(w.flags));
-    mix32(h, w.visible ? 1u : 0u);
-    mix32(h, w.ready ? 1u : 0u);
-    mix32(h, w.ableToJump ? 1u : 0u);
-    mix32(h, w.ableToDig ? 1u : 0u);
-    mix32(h, static_cast<uint32_t>(w.controlStates.istate));
-    mix32(h, static_cast<uint32_t>(w.prevControlStates.istate));
+    Mix32(h, static_cast<uint32_t>(w.pos.x));
+    Mix32(h, static_cast<uint32_t>(w.pos.y));
+    Mix32(h, static_cast<uint32_t>(w.vel.x));
+    Mix32(h, static_cast<uint32_t>(w.vel.y));
+    Mix32(h, static_cast<uint32_t>(w.aiming_angle));
+    Mix32(h, static_cast<uint32_t>(w.aiming_speed));
+    Mix32(h, static_cast<uint32_t>(w.health));
+    Mix32(h, static_cast<uint32_t>(w.lives));
+    Mix32(h, static_cast<uint32_t>(w.kills));
+    Mix32(h, static_cast<uint32_t>(w.timer));
+    Mix32(h, static_cast<uint32_t>(w.killed_timer));
+    Mix32(h, static_cast<uint32_t>(w.current_frame));
+    Mix32(h, static_cast<uint32_t>(w.current_weapon));
+    Mix32(h, static_cast<uint32_t>(w.direction));
+    Mix32(h, static_cast<uint32_t>(w.flags));
+    Mix32(h, w.visible ? 1u : 0u);
+    Mix32(h, w.ready ? 1u : 0u);
+    Mix32(h, w.able_to_jump ? 1u : 0u);
+    Mix32(h, w.able_to_dig ? 1u : 0u);
+    Mix32(h, static_cast<uint32_t>(w.control_states.istate));
+    Mix32(h, static_cast<uint32_t>(w.prev_control_states.istate));
     for (int i = 0; i < NUM_WEAPONS; ++i) {
       WormWeapon const& ww = w.weapons[i];
-      mix32(h, static_cast<uint32_t>(ww.ammo));
-      mix32(h, static_cast<uint32_t>(ww.delayLeft));
-      mix32(h, static_cast<uint32_t>(ww.loadingLeft));
+      Mix32(h, static_cast<uint32_t>(ww.ammo));
+      Mix32(h, static_cast<uint32_t>(ww.delay_left));
+      Mix32(h, static_cast<uint32_t>(ww.loading_left));
     }
   }
 
-  mix32(h, static_cast<uint32_t>(game.wobjects.count));
+  Mix32(h, static_cast<uint32_t>(game.wobjects.count));
   for (std::size_t i = 0; i < game.wobjects.count; ++i) {
     WObject const& o = game.wobjects.arr[i];
-    mix32(h, static_cast<uint32_t>(o.pos.x));
-    mix32(h, static_cast<uint32_t>(o.pos.y));
-    mix32(h, static_cast<uint32_t>(o.vel.x));
-    mix32(h, static_cast<uint32_t>(o.vel.y));
-    mix32(h, static_cast<uint32_t>(o.curFrame));
-    mix32(h, static_cast<uint32_t>(o.timeLeft));
-    mix32(h, static_cast<uint32_t>(o.ownerIdx));
+    Mix32(h, static_cast<uint32_t>(o.pos.x));
+    Mix32(h, static_cast<uint32_t>(o.pos.y));
+    Mix32(h, static_cast<uint32_t>(o.vel.x));
+    Mix32(h, static_cast<uint32_t>(o.vel.y));
+    Mix32(h, static_cast<uint32_t>(o.cur_frame));
+    Mix32(h, static_cast<uint32_t>(o.time_left));
+    Mix32(h, static_cast<uint32_t>(o.owner_idx));
   }
-  mix32(h, static_cast<uint32_t>(game.sobjects.count));
+  Mix32(h, static_cast<uint32_t>(game.sobjects.count));
   for (std::size_t i = 0; i < game.sobjects.count; ++i) {
     SObject const& o = game.sobjects.arr[i];
-    mix32(h, static_cast<uint32_t>(o.x));
-    mix32(h, static_cast<uint32_t>(o.y));
-    mix32(h, static_cast<uint32_t>(o.curFrame));
-    mix32(h, static_cast<uint32_t>(o.id));
+    Mix32(h, static_cast<uint32_t>(o.x));
+    Mix32(h, static_cast<uint32_t>(o.y));
+    Mix32(h, static_cast<uint32_t>(o.cur_frame));
+    Mix32(h, static_cast<uint32_t>(o.id));
   }
-  mix32(h, static_cast<uint32_t>(game.nobjects.count));
+  Mix32(h, static_cast<uint32_t>(game.nobjects.count));
   for (std::size_t i = 0; i < game.nobjects.count; ++i) {
     NObject const& o = game.nobjects.arr[i];
-    mix32(h, static_cast<uint32_t>(o.pos.x));
-    mix32(h, static_cast<uint32_t>(o.pos.y));
-    mix32(h, static_cast<uint32_t>(o.vel.x));
-    mix32(h, static_cast<uint32_t>(o.vel.y));
-    mix32(h, static_cast<uint32_t>(o.curFrame));
+    Mix32(h, static_cast<uint32_t>(o.pos.x));
+    Mix32(h, static_cast<uint32_t>(o.pos.y));
+    Mix32(h, static_cast<uint32_t>(o.vel.x));
+    Mix32(h, static_cast<uint32_t>(o.vel.y));
+    Mix32(h, static_cast<uint32_t>(o.cur_frame));
   }
-  mix32(h, static_cast<uint32_t>(game.bonuses.count));
+  Mix32(h, static_cast<uint32_t>(game.bonuses.count));
   for (std::size_t i = 0; i < game.bonuses.count; ++i) {
     Bonus const& b = game.bonuses.arr[i];
-    mix32(h, static_cast<uint32_t>(b.x));
-    mix32(h, static_cast<uint32_t>(b.y));
-    mix32(h, static_cast<uint32_t>(b.frame));
-    mix32(h, static_cast<uint32_t>(b.timer));
+    Mix32(h, static_cast<uint32_t>(b.x));
+    Mix32(h, static_cast<uint32_t>(b.y));
+    Mix32(h, static_cast<uint32_t>(b.frame));
+    Mix32(h, static_cast<uint32_t>(b.timer));
   }
 
-  std::size_t const cells =
+  std::size_t const kCells =
       static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
-  if (cells > 0) {
-    mixBytes(h, game.level.data.data(), cells);
+  if (kCells > 0) {
+    MixBytes(h, game.level.data.data(), kCells);
   }
 
   return h;
 }
 
-bool ReplayReader::playbackFrame(Renderer& renderer) {
+bool ReplayReader::PlaybackFrame(Renderer& renderer) {
   Game& game = *this->game;
 
-  bool settingsChanged = false;
+  bool settings_changed = false;
 
   while (true) {
-    uint8_t first = reader.get();
+    uint8_t first = reader.Get();
 
     if (first == kReplayTagEmptyFrame)
       break;
     else if (first == kReplayTagSettings) {
-      cerealRead(reader, *game.settings);
-      settingsChanged = true;
+      CerealRead(reader, *game.settings);
+      settings_changed = true;
     } else if (first == kReplayTagWormSettings) {
-      uint32_t wormId = io::read_uint32(reader);
-      Worm* w = game.wormByIdx(wormId);
+      uint32_t worm_id = io::ReadUint32(reader);
+      Worm* w = game.WormByIdx(worm_id);
       if (w) {
-        cerealRead(reader, *w->settings);
-        settingsChanged = true;
+        CerealRead(reader, *w->settings);
+        settings_changed = true;
       }
     } else if (first == kReplayTagEnd) {
       // End of replay
       return false;
     } else if (first < kReplayTagEmptyFrame) {
       uint8_t state = first;
-      bool hasState = true;
+      bool has_state = true;
 
       for (auto const& worm : game.worms) {
-        if (!hasState)
-          state = reader.get();
+        if (!has_state)
+          state = reader.Get();
         else
-          hasState = false;
+          has_state = false;
 
-        worm->controlStates.unpack(state ^ worm->prevControlStates.pack());
+        worm->control_states.Unpack(state ^ worm->prev_control_states.Pack());
       }
 
       break;  // Read frame
@@ -236,75 +236,75 @@ bool ReplayReader::playbackFrame(Renderer& renderer) {
       throw io::ArchiveCheckError("Unexpected header byte");
   }
 
-  if (settingsChanged) {
-    game.updateSettings(renderer);
+  if (settings_changed) {
+    game.UpdateSettings(renderer);
   }
 
   if ((game.cycles % (70 * 15)) == 0) {
-    uint32_t expected = io::read_uint32(reader);
-    uint32_t actual = wideRollbackChecksum(game);
+    uint32_t expected = io::ReadUint32(reader);
+    uint32_t actual = WideRollbackChecksum(game);
     if (actual != expected) throw io::ArchiveCheckError("Replay has desynced");
   }
 
   return true;
 }
 
-void ReplayWriter::recordFrame() {
+void ReplayWriter::RecordFrame() {
   Game& game = *this->game;
 
-  if (settingsExpired) {
-    writer.put(kReplayTagSettings);
-    cerealWrite(writer, *game.settings);
-    settingsExpired = false;
+  if (settings_expired) {
+    writer.Put(kReplayTagSettings);
+    CerealWrite(writer, *game.settings);
+    settings_expired = false;
   }
 
-  bool writeStates = false;
+  bool write_states = false;
 
   if (game.worms.size() <= 3)  // TODO: What limit do we want here? None?
-    writeStates = true;
+    write_states = true;
   else {
     for (auto const& worm : game.worms) {
-      WormData& data = wormData[worm.get()];
-      if (worm->controlStates != worm->prevControlStates) {
-        writeStates = true;
+      WormData& data = worm_data[worm.get()];
+      if (worm->control_states != worm->prev_control_states) {
+        write_states = true;
       }
 
-      if (data.settingsExpired) {
-        writer.put(kReplayTagWormSettings);
-        io::write_uint32(writer, worm->index);
-        cerealWrite(writer, *worm->settings);
-        data.settingsExpired = false;
+      if (data.settings_expired) {
+        writer.Put(kReplayTagWormSettings);
+        io::WriteUint32(writer, worm->index);
+        CerealWrite(writer, *worm->settings);
+        data.settings_expired = false;
       }
     }
   }
 
-  if (writeStates) {
+  if (write_states) {
     for (auto const& worm : game.worms) {
-      uint8_t state = worm->controlStates.pack() ^ worm->prevControlStates.pack();
+      uint8_t state = worm->control_states.Pack() ^ worm->prev_control_states.Pack();
 
       assert(state < kReplayTagEmptyFrame);
 
-      writer.put(state);
+      writer.Put(state);
     }
   } else {
-    writer.put(kReplayTagEmptyFrame);
+    writer.Put(kReplayTagEmptyFrame);
   }
 
   if ((game.cycles % (70 * 15)) == 0) {
-    uint32_t checksum = wideRollbackChecksum(game);
-    io::write_uint32(writer, checksum);
+    uint32_t checksum = WideRollbackChecksum(game);
+    io::WriteUint32(writer, checksum);
   }
 }
 
-void ReplayWriter::unfocus() {
-  for (auto& [worm, data] : wormData) data.lastSettingsHash = worm->settings->updateHash();
-  lastSettingsHash = game->settings->updateHash();
+void ReplayWriter::Unfocus() {
+  for (auto& [worm, data] : worm_data) data.last_settings_hash = worm->settings->UpdateHash();
+  last_settings_hash = game->settings->UpdateHash();
 }
 
-void ReplayWriter::focus() {
-  for (auto& [worm, data] : wormData) {
-    if (data.lastSettingsHash != worm->settings->updateHash()) data.settingsExpired = true;
+void ReplayWriter::Focus() {
+  for (auto& [worm, data] : worm_data) {
+    if (data.last_settings_hash != worm->settings->UpdateHash()) data.settings_expired = true;
   }
 
-  if (lastSettingsHash != game->settings->updateHash()) settingsExpired = true;
+  if (last_settings_hash != game->settings->UpdateHash()) settings_expired = true;
 }

--- a/src/game/replay.hpp
+++ b/src/game/replay.hpp
@@ -15,32 +15,32 @@ struct Game;
 
 struct Replay {
   Game* game = nullptr;
-  int replayVersion = myReplayVersion;
+  int replay_version = kMyReplayVersion;
 };
 
 struct ReplayWriter : Replay {
   ReplayWriter(std::unique_ptr<io::Writer> sink);
   ~ReplayWriter();
 
-  void unfocus();
-  void focus();
+  void Unfocus();
+  void Focus();
 
   io::DeflateWriter writer;
-  uint64_t lastSettingsHash;
-  bool settingsExpired;
+  uint64_t last_settings_hash;
+  bool settings_expired;
 
   struct WormData {
-    WormData() : settingsExpired(true) {}
-    uint64_t lastSettingsHash;
-    bool settingsExpired;
+    WormData() : settings_expired(true) {}
+    uint64_t last_settings_hash;
+    bool settings_expired;
   };
-  std::map<Worm*, WormData> wormData;
+  std::map<Worm*, WormData> worm_data;
 
-  void beginRecord(Game& game);
-  void recordFrame();
+  void BeginRecord(Game& game);
+  void RecordFrame();
 
  private:
-  void endRecord();
+  void EndRecord();
 };
 
 struct Renderer;
@@ -48,12 +48,12 @@ struct Renderer;
 struct ReplayReader : Replay {
   ReplayReader(std::unique_ptr<io::Reader> source);
 
-  void unfocus() {}
-  void focus() {}
+  void Unfocus() {}
+  void Focus() {}
 
-  std::unique_ptr<Game> beginPlayback(std::shared_ptr<Common> common,
-                                      std::shared_ptr<SoundPlayer> soundPlayer);
-  bool playbackFrame(Renderer& renderer);
+  std::unique_ptr<Game> BeginPlayback(std::shared_ptr<Common> common,
+                                      std::shared_ptr<SoundPlayer> sound_player);
+  bool PlaybackFrame(Renderer& renderer);
 
   // The full inflated replay is held in memory so we can rewind to
   // the recorded initial position when the user presses R.

--- a/src/game/rollback/buffer.hpp
+++ b/src/game/rollback/buffer.hpp
@@ -27,8 +27,8 @@ namespace rollback {
 constexpr int kMaxRollback = 7;
 
 enum class RemoteState : uint8_t {
-  Predicted,
-  Confirmed,
+  kPredicted,
+  kConfirmed,
 };
 
 struct Slot {
@@ -39,10 +39,10 @@ struct Slot {
   // of the two is meaningful per frame (a slot is either pre-game-start
   // weapon-select state or in-game sim state). `wsSnap.valid` indicates
   // which.
-  WeaponSelectSnap wsSnap;
-  uint8_t localInput = 0;
-  uint8_t remoteInput = 0;
-  RemoteState remoteState = RemoteState::Predicted;
+  WeaponSelectSnap ws_snap;
+  uint8_t local_input = 0;
+  uint8_t remote_input = 0;
+  RemoteState remote_state = RemoteState::kPredicted;
   // Post-frame checksum cached when the snapshot was written. The
   // controller sends it to the desync detector only once the frame is
   // confirmed (forward with real input, on promote of a matching
@@ -57,19 +57,19 @@ class RollbackBuffer {
 
   // Pre-size every slot's snapshot vectors. Call once after the level is
   // generated; no allocations happen on subsequent save/load.
-  void prepare(Game const& game) {
-    for (auto& slot : slots_) slot.snapshot.prepare(game);
+  void Prepare(Game const& game) {
+    for (auto& slot : slots_) slot.snapshot.Prepare(game);
   }
 
   // Reset all slots to empty. Snapshot capacity (sized by prepare) is kept.
-  void clear() {
+  void Clear() {
     for (auto& slot : slots_) {
       slot.frame = -1;
-      slot.localInput = 0;
-      slot.remoteInput = 0;
-      slot.remoteState = RemoteState::Predicted;
+      slot.local_input = 0;
+      slot.remote_input = 0;
+      slot.remote_state = RemoteState::kPredicted;
       slot.checksum = 0;
-      slot.wsSnap.valid = false;
+      slot.ws_snap.valid = false;
     }
     newest_ = -1;
   }
@@ -83,66 +83,66 @@ class RollbackBuffer {
   // overwrite it via Game::saveSnapshotFast when appropriate. This keeps
   // pure input-only updates (e.g. arriving remote input for a future frame)
   // cheap.
-  Slot& write(int frame) {
+  Slot& Write(int frame) {
     // indexOf masks via unsigned, so a negative frame would land on a
     // valid slot and corrupt the ring (frame stored as -1, newest_ not
     // updated). Callers must pass a non-negative sim frame.
     assert(frame >= 0);
-    Slot& slot = slots_[indexOf(frame)];
+    Slot& slot = slots_[IndexOf(frame)];
     if (slot.frame != frame) {
       slot.frame = frame;
-      slot.localInput = 0;
-      slot.remoteInput = 0;
-      slot.remoteState = RemoteState::Predicted;
+      slot.local_input = 0;
+      slot.remote_input = 0;
+      slot.remote_state = RemoteState::kPredicted;
       slot.checksum = 0;
-      slot.wsSnap.valid = false;
+      slot.ws_snap.valid = false;
     }
     if (frame > newest_) newest_ = frame;
     return slot;
   }
 
-  Slot* find(int frame) {
-    if (!resident(frame)) return nullptr;
-    Slot& slot = slots_[indexOf(frame)];
+  Slot* Find(int frame) {
+    if (!Resident(frame)) return nullptr;
+    Slot& slot = slots_[IndexOf(frame)];
     return slot.frame == frame ? &slot : nullptr;
   }
 
-  Slot const* find(int frame) const {
-    if (!resident(frame)) return nullptr;
-    Slot const& slot = slots_[indexOf(frame)];
+  Slot const* Find(int frame) const {
+    if (!Resident(frame)) return nullptr;
+    Slot const& slot = slots_[IndexOf(frame)];
     return slot.frame == frame ? &slot : nullptr;
   }
 
   // Newest frame written so far, or -1 if empty.
-  int newestFrame() const { return newest_; }
+  int NewestFrame() const { return newest_; }
 
   // Oldest frame still resident, or -1 if empty. This is what the rollback
   // controller compares against when deciding whether a confirmed input is
   // too old to apply (which would mean the local peer already advanced past
   // the rollback horizon — a stall condition).
-  int oldestFrame() const {
+  int OldestFrame() const {
     if (newest_ < 0) return -1;
     int floor = newest_ - static_cast<int>(kCapacity) + 1;
     return floor < 0 ? 0 : floor;
   }
 
-  bool empty() const { return newest_ < 0; }
+  bool Empty() const { return newest_ < 0; }
 
-  std::size_t size() const {
+  std::size_t Size() const {
     if (newest_ < 0) return 0;
     int span = newest_ + 1;
     return span < static_cast<int>(kCapacity) ? static_cast<std::size_t>(span) : kCapacity;
   }
 
  private:
-  static std::size_t indexOf(int frame) {
+  static std::size_t IndexOf(int frame) {
     // frame is non-negative in practice (sim frames start at 0), but stay
     // defensive in case a caller passes -1.
     return static_cast<std::size_t>(static_cast<unsigned>(frame) % kCapacity);
   }
 
-  bool resident(int frame) const {
-    return frame >= 0 && frame >= oldestFrame() && frame <= newest_;
+  bool Resident(int frame) const {
+    return frame >= 0 && frame >= OldestFrame() && frame <= newest_;
   }
 
   std::array<Slot, kCapacity> slots_{};

--- a/src/game/serialization/cereal_types.hpp
+++ b/src/game/serialization/cereal_types.hpp
@@ -141,9 +141,9 @@ void SerializeSettingsScalars(Archive& ar, Settings& s) {
      cereal::make_nvp("loadChange", s.load_change),
      cereal::make_nvp("namesOnBonuses", s.names_on_bonuses),
      cereal::make_nvp("regenerateLevel", s.regenerate_level), cereal::make_nvp("lives", s.lives),
-     cereal::make_nvp("loadingTime", s.loading_time), cereal::make_nvp("randomLevel", s.random_level),
-     cereal::make_nvp("levelFile", s.level_file), cereal::make_nvp("map", s.map),
-     cereal::make_nvp("screenSync", s.screen_sync));
+     cereal::make_nvp("loadingTime", s.loading_time),
+     cereal::make_nvp("randomLevel", s.random_level), cereal::make_nvp("levelFile", s.level_file),
+     cereal::make_nvp("map", s.map), cereal::make_nvp("screenSync", s.screen_sync));
   ar(cereal::make_nvp("bonusTimeout", s.bonus_timeout));
   // v3 fields. Missing on older configs → defaults remain.
   ar(cereal::make_nvp("inputDelay", s.input_delay));
@@ -183,9 +183,9 @@ void SerializeGameplay(Archive& ar, Settings& s) {
      cereal::make_nvp("loadChange", s.load_change),
      cereal::make_nvp("namesOnBonuses", s.names_on_bonuses),
      cereal::make_nvp("regenerateLevel", s.regenerate_level), cereal::make_nvp("lives", s.lives),
-     cereal::make_nvp("loadingTime", s.loading_time), cereal::make_nvp("randomLevel", s.random_level),
-     cereal::make_nvp("levelFile", s.level_file), cereal::make_nvp("map", s.map),
-     cereal::make_nvp("screenSync", s.screen_sync));
+     cereal::make_nvp("loadingTime", s.loading_time),
+     cereal::make_nvp("randomLevel", s.random_level), cereal::make_nvp("levelFile", s.level_file),
+     cereal::make_nvp("map", s.map), cereal::make_nvp("screenSync", s.screen_sync));
   SerializeArray(ar, "weapTable", s.weap_table);
   ar(cereal::make_nvp("bonusTimeout", s.bonus_timeout));
   ar(cereal::make_nvp("inputDelay", s.input_delay));
@@ -266,8 +266,8 @@ void serialize(Archive& ar, Worm& w) {
   ar(cereal::make_nvp("pos", w.pos), cereal::make_nvp("vel", w.vel),
      cereal::make_nvp("logicRespawn", w.logic_respawn), cereal::make_nvp("hotspotX", w.hotspot_x),
      cereal::make_nvp("hotspotY", w.hotspot_y), cereal::make_nvp("aimingAngle", w.aiming_angle),
-     cereal::make_nvp("aimingSpeed", w.aiming_speed), cereal::make_nvp("ableToJump", w.able_to_jump),
-     cereal::make_nvp("ableToDig", w.able_to_dig),
+     cereal::make_nvp("aimingSpeed", w.aiming_speed),
+     cereal::make_nvp("ableToJump", w.able_to_jump), cereal::make_nvp("ableToDig", w.able_to_dig),
      cereal::make_nvp("keyChangePressed", w.key_change_pressed),
      cereal::make_nvp("movable", w.movable), cereal::make_nvp("animate", w.animate),
      cereal::make_nvp("visible", w.visible), cereal::make_nvp("ready", w.ready),
@@ -276,11 +276,13 @@ void serialize(Archive& ar, Worm& w) {
      cereal::make_nvp("kills", w.kills), cereal::make_nvp("timer", w.timer),
      cereal::make_nvp("killedTimer", w.killed_timer),
      cereal::make_nvp("currentFrame", w.current_frame), cereal::make_nvp("flags", w.flags),
-     cereal::make_nvp("ninjarope", w.ninjarope), cereal::make_nvp("currentWeapon", w.current_weapon),
+     cereal::make_nvp("ninjarope", w.ninjarope),
+     cereal::make_nvp("currentWeapon", w.current_weapon),
      cereal::make_nvp("lastKilledByIdx", w.last_killed_by_idx),
      cereal::make_nvp("fireCone", w.fire_cone),
      cereal::make_nvp("leaveShellTimer", w.leave_shell_timer), cereal::make_nvp("index", w.index),
-     cereal::make_nvp("direction", w.direction), cereal::make_nvp("controlStates", w.control_states),
+     cereal::make_nvp("direction", w.direction),
+     cereal::make_nvp("controlStates", w.control_states),
      cereal::make_nvp("prevControlStates", w.prev_control_states));
   for (int i = 0; i < 4; ++i) ar(cereal::make_nvp("react" + std::to_string(i), w.reacts[i]));
   for (int i = 0; i < NUM_WEAPONS; ++i)
@@ -334,8 +336,8 @@ void save(Archive& ar, Game const& game) {
     // Context: weapon type indices (-1 if null)
     for (int i = 0; i < NUM_WEAPONS; ++i) {
       int32_t weap_idx = w.weapons[i].type
-                            ? static_cast<int32_t>(w.weapons[i].type - &game.common->weapons[0])
-                            : -1;
+                             ? static_cast<int32_t>(w.weapons[i].type - &game.common->weapons[0])
+                             : -1;
       ar(cereal::make_nvp("weapIdx" + std::to_string(i), weap_idx));
     }
 

--- a/src/game/serialization/cereal_types.hpp
+++ b/src/game/serialization/cereal_types.hpp
@@ -39,7 +39,7 @@ void serialize(Archive& ar, BasicRect<T>& r) {
 
 // Serialize a C array as a cereal array (produces inline TOML arrays).
 template <class Archive, typename T, std::size_t N>
-void serializeArray(Archive& ar, const char* name, T (&arr)[N]) {
+void SerializeArray(Archive& ar, const char* name, T (&arr)[N]) {
   ar.setNextName(name);
   ar.startNode();
   cereal::size_type size = N;
@@ -64,7 +64,7 @@ template <class Archive>
 void serialize(Archive& ar, Ninjarope& n) {
   ar(cereal::make_nvp("out", n.out), cereal::make_nvp("attached", n.attached),
      cereal::make_nvp("pos", n.pos), cereal::make_nvp("vel", n.vel),
-     cereal::make_nvp("length", n.length), cereal::make_nvp("curLen", n.curLen));
+     cereal::make_nvp("length", n.length), cereal::make_nvp("curLen", n.cur_len));
 }
 
 // ---- Rand ----
@@ -80,7 +80,7 @@ template <class Archive>
 void load(Archive& ar, Rand& r) {
   std::string state;
   ar(cereal::make_nvp("state", state), cereal::make_nvp("last", r.last));
-  r.deserialize(state);
+  r.Deserialize(state);
 }
 
 // ---- Color ----
@@ -119,76 +119,76 @@ void serialize(Archive& ar, Level& lvl) {
 // handled separately because the TOML path writes it as an array while
 // the binary path uses indexed fields.
 template <class Archive>
-void serializeSettingsScalars(Archive& ar, Settings& s) {
+void SerializeSettingsScalars(Archive& ar, Settings& s) {
   // GameplayExtensions
-  ar(cereal::make_nvp("recordReplays", s.recordReplays),
-     cereal::make_nvp("loadPowerlevelPalette", s.loadPowerlevelPalette),
-     cereal::make_nvp("aiFrames", s.aiFrames), cereal::make_nvp("aiMutations", s.aiMutations),
-     cereal::make_nvp("aiTraces", s.aiTraces), cereal::make_nvp("aiParallels", s.aiParallels),
-     cereal::make_nvp("zoneTimeout", s.zoneTimeout),
-     cereal::make_nvp("selectBotWeapons", s.selectBotWeapons),
-     cereal::make_nvp("allowViewingSpawnPoint", s.allowViewingSpawnPoint),
+  ar(cereal::make_nvp("recordReplays", s.record_replays),
+     cereal::make_nvp("loadPowerlevelPalette", s.load_powerlevel_palette),
+     cereal::make_nvp("aiFrames", s.ai_frames), cereal::make_nvp("aiMutations", s.ai_mutations),
+     cereal::make_nvp("aiTraces", s.ai_traces), cereal::make_nvp("aiParallels", s.ai_parallels),
+     cereal::make_nvp("zoneTimeout", s.zone_timeout),
+     cereal::make_nvp("selectBotWeapons", s.select_bot_weapons),
+     cereal::make_nvp("allowViewingSpawnPoint", s.allow_viewing_spawn_point),
      cereal::make_nvp("tc", s.tc));
   // AppSettings
   ar(cereal::make_nvp("fullscreen", s.fullscreen),
-     cereal::make_nvp("singleScreenReplay", s.singleScreenReplay),
-     cereal::make_nvp("spectatorWindow", s.spectatorWindow),
-     cereal::make_nvp("bloodParticleMax", s.bloodParticleMax));
+     cereal::make_nvp("singleScreenReplay", s.single_screen_replay),
+     cereal::make_nvp("spectatorWindow", s.spectator_window),
+     cereal::make_nvp("bloodParticleMax", s.blood_particle_max));
   // Settings proper
-  ar(cereal::make_nvp("maxBonuses", s.maxBonuses), cereal::make_nvp("blood", s.blood),
-     cereal::make_nvp("timeToLose", s.timeToLose), cereal::make_nvp("flagsToWin", s.flagsToWin),
-     cereal::make_nvp("gameMode", s.gameMode), cereal::make_nvp("shadow", s.shadow),
-     cereal::make_nvp("loadChange", s.loadChange),
-     cereal::make_nvp("namesOnBonuses", s.namesOnBonuses),
-     cereal::make_nvp("regenerateLevel", s.regenerateLevel), cereal::make_nvp("lives", s.lives),
-     cereal::make_nvp("loadingTime", s.loadingTime), cereal::make_nvp("randomLevel", s.randomLevel),
-     cereal::make_nvp("levelFile", s.levelFile), cereal::make_nvp("map", s.map),
-     cereal::make_nvp("screenSync", s.screenSync));
-  ar(cereal::make_nvp("bonusTimeout", s.bonusTimeout));
+  ar(cereal::make_nvp("maxBonuses", s.max_bonuses), cereal::make_nvp("blood", s.blood),
+     cereal::make_nvp("timeToLose", s.time_to_lose), cereal::make_nvp("flagsToWin", s.flags_to_win),
+     cereal::make_nvp("gameMode", s.game_mode), cereal::make_nvp("shadow", s.shadow),
+     cereal::make_nvp("loadChange", s.load_change),
+     cereal::make_nvp("namesOnBonuses", s.names_on_bonuses),
+     cereal::make_nvp("regenerateLevel", s.regenerate_level), cereal::make_nvp("lives", s.lives),
+     cereal::make_nvp("loadingTime", s.loading_time), cereal::make_nvp("randomLevel", s.random_level),
+     cereal::make_nvp("levelFile", s.level_file), cereal::make_nvp("map", s.map),
+     cereal::make_nvp("screenSync", s.screen_sync));
+  ar(cereal::make_nvp("bonusTimeout", s.bonus_timeout));
   // v3 fields. Missing on older configs → defaults remain.
-  ar(cereal::make_nvp("inputDelay", s.inputDelay));
+  ar(cereal::make_nvp("inputDelay", s.input_delay));
 }
 
 // Full Settings fields for binary archives (indexed weapon keys).
 template <class Archive>
-void serializeSettingsFields(Archive& ar, Settings& s) {
-  serializeSettingsScalars(ar, s);
-  for (int i = 0; i < 40; ++i) ar(cereal::make_nvp("weap" + std::to_string(i), s.weapTable[i]));
+void SerializeSettingsFields(Archive& ar, Settings& s) {
+  SerializeSettingsScalars(ar, s);
+  for (int i = 0; i < 40; ++i) ar(cereal::make_nvp("weap" + std::to_string(i), s.weap_table[i]));
 }
 
 template <class Archive>
-void serialize(Archive& ar, Settings& s, std::uint32_t const version) {
-  serializeSettingsFields(ar, s);
-  for (int i = 0; i < Settings::NumWormSettings; ++i)
-    ar(cereal::make_nvp("worm" + std::to_string(i), s.wormSettings[i]));
-  (void)version;  // all fields always written now (breaking change)
+void serialize(Archive& ar, Settings& s, std::uint32_t const kVersion) {
+  SerializeSettingsFields(ar, s);
+  for (int i = 0; i < Settings::kNumWormSettings; ++i)
+    ar(cereal::make_nvp("worm" + std::to_string(i), s.worm_settings[i]));
+  (void)kVersion;  // all fields always written now (breaking change)
 }
 CEREAL_CLASS_VERSION(Settings, 3);
 
 // Gameplay-only subset for hash computation. AppSettings fields are
 // deliberately excluded so UI-only changes don't affect the hash.
 template <class Archive>
-void serializeGameplay(Archive& ar, Settings& s) {
-  ar(cereal::make_nvp("recordReplays", s.recordReplays),
-     cereal::make_nvp("loadPowerlevelPalette", s.loadPowerlevelPalette),
-     cereal::make_nvp("aiFrames", s.aiFrames), cereal::make_nvp("aiMutations", s.aiMutations),
-     cereal::make_nvp("aiTraces", s.aiTraces), cereal::make_nvp("aiParallels", s.aiParallels),
-     cereal::make_nvp("zoneTimeout", s.zoneTimeout),
-     cereal::make_nvp("selectBotWeapons", s.selectBotWeapons),
-     cereal::make_nvp("allowViewingSpawnPoint", s.allowViewingSpawnPoint),
+void SerializeGameplay(Archive& ar, Settings& s) {
+  ar(cereal::make_nvp("recordReplays", s.record_replays),
+     cereal::make_nvp("loadPowerlevelPalette", s.load_powerlevel_palette),
+     cereal::make_nvp("aiFrames", s.ai_frames), cereal::make_nvp("aiMutations", s.ai_mutations),
+     cereal::make_nvp("aiTraces", s.ai_traces), cereal::make_nvp("aiParallels", s.ai_parallels),
+     cereal::make_nvp("zoneTimeout", s.zone_timeout),
+     cereal::make_nvp("selectBotWeapons", s.select_bot_weapons),
+     cereal::make_nvp("allowViewingSpawnPoint", s.allow_viewing_spawn_point),
      cereal::make_nvp("tc", s.tc));
-  ar(cereal::make_nvp("maxBonuses", s.maxBonuses), cereal::make_nvp("blood", s.blood),
-     cereal::make_nvp("timeToLose", s.timeToLose), cereal::make_nvp("flagsToWin", s.flagsToWin),
-     cereal::make_nvp("gameMode", s.gameMode), cereal::make_nvp("shadow", s.shadow),
-     cereal::make_nvp("loadChange", s.loadChange),
-     cereal::make_nvp("namesOnBonuses", s.namesOnBonuses),
-     cereal::make_nvp("regenerateLevel", s.regenerateLevel), cereal::make_nvp("lives", s.lives),
-     cereal::make_nvp("loadingTime", s.loadingTime), cereal::make_nvp("randomLevel", s.randomLevel),
-     cereal::make_nvp("levelFile", s.levelFile), cereal::make_nvp("map", s.map),
-     cereal::make_nvp("screenSync", s.screenSync));
-  serializeArray(ar, "weapTable", s.weapTable);
-  ar(cereal::make_nvp("bonusTimeout", s.bonusTimeout));
-  ar(cereal::make_nvp("inputDelay", s.inputDelay));
+  ar(cereal::make_nvp("maxBonuses", s.max_bonuses), cereal::make_nvp("blood", s.blood),
+     cereal::make_nvp("timeToLose", s.time_to_lose), cereal::make_nvp("flagsToWin", s.flags_to_win),
+     cereal::make_nvp("gameMode", s.game_mode), cereal::make_nvp("shadow", s.shadow),
+     cereal::make_nvp("loadChange", s.load_change),
+     cereal::make_nvp("namesOnBonuses", s.names_on_bonuses),
+     cereal::make_nvp("regenerateLevel", s.regenerate_level), cereal::make_nvp("lives", s.lives),
+     cereal::make_nvp("loadingTime", s.loading_time), cereal::make_nvp("randomLevel", s.random_level),
+     cereal::make_nvp("levelFile", s.level_file), cereal::make_nvp("map", s.map),
+     cereal::make_nvp("screenSync", s.screen_sync));
+  SerializeArray(ar, "weapTable", s.weap_table);
+  ar(cereal::make_nvp("bonusTimeout", s.bonus_timeout));
+  ar(cereal::make_nvp("inputDelay", s.input_delay));
 }
 
 // ---- Viewport ----
@@ -198,9 +198,9 @@ void serializeGameplay(Archive& ar, Settings& s) {
 template <class Archive>
 void serialize(Archive& ar, Viewport& v) {
   ar(cereal::make_nvp("x", v.x), cereal::make_nvp("y", v.y), cereal::make_nvp("shake", v.shake),
-     cereal::make_nvp("maxX", v.maxX), cereal::make_nvp("maxY", v.maxY),
-     cereal::make_nvp("centerX", v.centerX), cereal::make_nvp("centerY", v.centerY),
-     cereal::make_nvp("wormIdx", v.wormIdx), cereal::make_nvp("bannerY", v.bannerY),
+     cereal::make_nvp("maxX", v.max_x), cereal::make_nvp("maxY", v.max_y),
+     cereal::make_nvp("centerX", v.center_x), cereal::make_nvp("centerY", v.center_y),
+     cereal::make_nvp("wormIdx", v.worm_idx), cereal::make_nvp("bannerY", v.banner_y),
      cereal::make_nvp("rect", v.rect));
 }
 
@@ -210,35 +210,35 @@ void serialize(Archive& ar, Viewport& v) {
 template <class Archive>
 void serialize(Archive& ar, WormSettings& ws) {
   ar(cereal::make_nvp("health", ws.health), cereal::make_nvp("controller", ws.controller),
-     cereal::make_nvp("name", ws.name), cereal::make_nvp("randomName", ws.randomName),
+     cereal::make_nvp("name", ws.name), cereal::make_nvp("randomName", ws.random_name),
      cereal::make_nvp("color", ws.color), cereal::make_nvp("rgb0", ws.rgb[0]),
      cereal::make_nvp("rgb1", ws.rgb[1]), cereal::make_nvp("rgb2", ws.rgb[2]),
-     cereal::make_nvp("inputDevice", ws.inputDevice),
-     cereal::make_nvp("gamepadName", ws.gamepadName),
-     cereal::make_nvp("gamepadSerial", ws.gamepadSerial));
+     cereal::make_nvp("inputDevice", ws.input_device),
+     cereal::make_nvp("gamepadName", ws.gamepad_name),
+     cereal::make_nvp("gamepadSerial", ws.gamepad_serial));
   for (int i = 0; i < NUM_WEAPONS; ++i)
     ar(cereal::make_nvp("weapon" + std::to_string(i), ws.weapons[i]));
-  for (int i = 0; i < WormSettingsExtensions::MaxControl; ++i)
+  for (int i = 0; i < WormSettingsExtensions::kMaxControl; ++i)
     ar(cereal::make_nvp("control" + std::to_string(i), ws.controls[i]));
-  for (int i = 0; i < WormSettingsExtensions::MaxControlEx; ++i)
-    ar(cereal::make_nvp("controlEx" + std::to_string(i), ws.controlsEx[i]));
-  for (int i = 0; i < WormSettingsExtensions::MaxControlEx; ++i)
-    ar(cereal::make_nvp("gpControl" + std::to_string(i), ws.gamepadControls[i]));
+  for (int i = 0; i < WormSettingsExtensions::kMaxControlEx; ++i)
+    ar(cereal::make_nvp("controlEx" + std::to_string(i), ws.controls_ex[i]));
+  for (int i = 0; i < WormSettingsExtensions::kMaxControlEx; ++i)
+    ar(cereal::make_nvp("gpControl" + std::to_string(i), ws.gamepad_controls[i]));
 }
 
 // TOML-specific WormSettings serialization: uses arrays instead of indexed keys.
 template <class Archive>
-void serializeWormSettingsToml(Archive& ar, WormSettings& ws) {
+void SerializeWormSettingsToml(Archive& ar, WormSettings& ws) {
   ar(cereal::make_nvp("name", ws.name), cereal::make_nvp("health", ws.health),
-     cereal::make_nvp("controller", ws.controller), cereal::make_nvp("randomName", ws.randomName),
-     cereal::make_nvp("color", ws.color), cereal::make_nvp("inputDevice", ws.inputDevice),
-     cereal::make_nvp("gamepadName", ws.gamepadName),
-     cereal::make_nvp("gamepadSerial", ws.gamepadSerial));
-  serializeArray(ar, "rgb", ws.rgb);
-  serializeArray(ar, "weapons", ws.weapons);
-  serializeArray(ar, "controls", ws.controls);
-  serializeArray(ar, "controlsEx", ws.controlsEx);
-  serializeArray(ar, "gamepadControls", ws.gamepadControls);
+     cereal::make_nvp("controller", ws.controller), cereal::make_nvp("randomName", ws.random_name),
+     cereal::make_nvp("color", ws.color), cereal::make_nvp("inputDevice", ws.input_device),
+     cereal::make_nvp("gamepadName", ws.gamepad_name),
+     cereal::make_nvp("gamepadSerial", ws.gamepad_serial));
+  SerializeArray(ar, "rgb", ws.rgb);
+  SerializeArray(ar, "weapons", ws.weapons);
+  SerializeArray(ar, "controls", ws.controls);
+  SerializeArray(ar, "controlsEx", ws.controls_ex);
+  SerializeArray(ar, "gamepadControls", ws.gamepad_controls);
 }
 
 // ---- WormWeapon ----
@@ -247,8 +247,8 @@ void serializeWormSettingsToml(Archive& ar, WormSettings& ws) {
 // the existing replay archive). Plain numeric fields only.
 template <class Archive>
 void serialize(Archive& ar, WormWeapon& w) {
-  ar(cereal::make_nvp("ammo", w.ammo), cereal::make_nvp("delayLeft", w.delayLeft),
-     cereal::make_nvp("loadingLeft", w.loadingLeft));
+  ar(cereal::make_nvp("ammo", w.ammo), cereal::make_nvp("delayLeft", w.delay_left),
+     cereal::make_nvp("loadingLeft", w.loading_left));
 }
 
 // ---- Worm ----
@@ -264,24 +264,24 @@ void serialize(Archive& ar, WormWeapon& w) {
 template <class Archive>
 void serialize(Archive& ar, Worm& w) {
   ar(cereal::make_nvp("pos", w.pos), cereal::make_nvp("vel", w.vel),
-     cereal::make_nvp("logicRespawn", w.logicRespawn), cereal::make_nvp("hotspotX", w.hotspotX),
-     cereal::make_nvp("hotspotY", w.hotspotY), cereal::make_nvp("aimingAngle", w.aimingAngle),
-     cereal::make_nvp("aimingSpeed", w.aimingSpeed), cereal::make_nvp("ableToJump", w.ableToJump),
-     cereal::make_nvp("ableToDig", w.ableToDig),
-     cereal::make_nvp("keyChangePressed", w.keyChangePressed),
+     cereal::make_nvp("logicRespawn", w.logic_respawn), cereal::make_nvp("hotspotX", w.hotspot_x),
+     cereal::make_nvp("hotspotY", w.hotspot_y), cereal::make_nvp("aimingAngle", w.aiming_angle),
+     cereal::make_nvp("aimingSpeed", w.aiming_speed), cereal::make_nvp("ableToJump", w.able_to_jump),
+     cereal::make_nvp("ableToDig", w.able_to_dig),
+     cereal::make_nvp("keyChangePressed", w.key_change_pressed),
      cereal::make_nvp("movable", w.movable), cereal::make_nvp("animate", w.animate),
      cereal::make_nvp("visible", w.visible), cereal::make_nvp("ready", w.ready),
-     cereal::make_nvp("flag", w.flag), cereal::make_nvp("makeSightGreen", w.makeSightGreen),
+     cereal::make_nvp("flag", w.flag), cereal::make_nvp("makeSightGreen", w.make_sight_green),
      cereal::make_nvp("health", w.health), cereal::make_nvp("lives", w.lives),
      cereal::make_nvp("kills", w.kills), cereal::make_nvp("timer", w.timer),
-     cereal::make_nvp("killedTimer", w.killedTimer),
-     cereal::make_nvp("currentFrame", w.currentFrame), cereal::make_nvp("flags", w.flags),
-     cereal::make_nvp("ninjarope", w.ninjarope), cereal::make_nvp("currentWeapon", w.currentWeapon),
-     cereal::make_nvp("lastKilledByIdx", w.lastKilledByIdx),
-     cereal::make_nvp("fireCone", w.fireCone),
-     cereal::make_nvp("leaveShellTimer", w.leaveShellTimer), cereal::make_nvp("index", w.index),
-     cereal::make_nvp("direction", w.direction), cereal::make_nvp("controlStates", w.controlStates),
-     cereal::make_nvp("prevControlStates", w.prevControlStates));
+     cereal::make_nvp("killedTimer", w.killed_timer),
+     cereal::make_nvp("currentFrame", w.current_frame), cereal::make_nvp("flags", w.flags),
+     cereal::make_nvp("ninjarope", w.ninjarope), cereal::make_nvp("currentWeapon", w.current_weapon),
+     cereal::make_nvp("lastKilledByIdx", w.last_killed_by_idx),
+     cereal::make_nvp("fireCone", w.fire_cone),
+     cereal::make_nvp("leaveShellTimer", w.leave_shell_timer), cereal::make_nvp("index", w.index),
+     cereal::make_nvp("direction", w.direction), cereal::make_nvp("controlStates", w.control_states),
+     cereal::make_nvp("prevControlStates", w.prev_control_states));
   for (int i = 0; i < 4; ++i) ar(cereal::make_nvp("react" + std::to_string(i), w.reacts[i]));
   for (int i = 0; i < NUM_WEAPONS; ++i)
     ar(cereal::make_nvp("weapon" + std::to_string(i), w.weapons[i]));
@@ -304,39 +304,39 @@ void save(Archive& ar, Game const& game) {
   ar(cereal::make_nvp("settings", game.settings));
 
   // Scalars
-  ar(cereal::make_nvp("cycles", game.cycles), cereal::make_nvp("gotChanged", game.gotChanged),
-     cereal::make_nvp("lastKilledIdx", game.lastKilledIdx),
-     cereal::make_nvp("screenFlash", game.screenFlash));
+  ar(cereal::make_nvp("cycles", game.cycles), cereal::make_nvp("gotChanged", game.got_changed),
+     cereal::make_nvp("lastKilledIdx", game.last_killed_idx),
+     cereal::make_nvp("screenFlash", game.screen_flash));
 
   // Rand
   ar(cereal::make_nvp("rand", const_cast<Rand&>(game.rand)));
 
   // Worms
-  cereal::size_type wormCount = game.worms.size();
-  ar(cereal::make_size_tag(wormCount));
+  cereal::size_type worm_count = game.worms.size();
+  ar(cereal::make_size_tag(worm_count));
   for (auto const& worm_sp : game.worms) {
     Worm const& w = *worm_sp;
     // Flat worm data
     ar(cereal::make_nvp("worm", const_cast<Worm&>(w)));
 
     // Context: anchor worm index (-1 if null)
-    int32_t anchorIdx = -1;
+    int32_t anchor_idx = -1;
     if (w.ninjarope.anchor) {
       for (std::size_t i = 0; i < game.worms.size(); ++i) {
         if (game.worms[i].get() == w.ninjarope.anchor) {
-          anchorIdx = static_cast<int32_t>(i);
+          anchor_idx = static_cast<int32_t>(i);
           break;
         }
       }
     }
-    ar(cereal::make_nvp("anchorIdx", anchorIdx));
+    ar(cereal::make_nvp("anchorIdx", anchor_idx));
 
     // Context: weapon type indices (-1 if null)
     for (int i = 0; i < NUM_WEAPONS; ++i) {
-      int32_t weapIdx = w.weapons[i].type
+      int32_t weap_idx = w.weapons[i].type
                             ? static_cast<int32_t>(w.weapons[i].type - &game.common->weapons[0])
                             : -1;
-      ar(cereal::make_nvp("weapIdx" + std::to_string(i), weapIdx));
+      ar(cereal::make_nvp("weapIdx" + std::to_string(i), weap_idx));
     }
 
     // Per-worm settings (shared_ptr — cereal tracks sharing)
@@ -344,8 +344,8 @@ void save(Archive& ar, Game const& game) {
   }
 
   // Viewports
-  cereal::size_type vpCount = game.viewports.size();
-  ar(cereal::make_size_tag(vpCount));
+  cereal::size_type vp_count = game.viewports.size();
+  ar(cereal::make_size_tag(vp_count));
   for (auto* vp : game.viewports) {
     ar(cereal::make_nvp("viewport", *vp));
   }
@@ -360,20 +360,20 @@ void load(Archive& ar, Game& game) {
   ar(cereal::make_nvp("settings", game.settings));
 
   // Scalars
-  ar(cereal::make_nvp("cycles", game.cycles), cereal::make_nvp("gotChanged", game.gotChanged),
-     cereal::make_nvp("lastKilledIdx", game.lastKilledIdx),
-     cereal::make_nvp("screenFlash", game.screenFlash));
+  ar(cereal::make_nvp("cycles", game.cycles), cereal::make_nvp("gotChanged", game.got_changed),
+     cereal::make_nvp("lastKilledIdx", game.last_killed_idx),
+     cereal::make_nvp("screenFlash", game.screen_flash));
 
   // Rand
   ar(cereal::make_nvp("rand", game.rand));
 
   // Worms
-  cereal::size_type wormCount;
-  ar(cereal::make_size_tag(wormCount));
+  cereal::size_type worm_count;
+  ar(cereal::make_size_tag(worm_count));
 
-  game.clearWorms();
-  std::vector<int32_t> anchorIndices(wormCount);
-  for (cereal::size_type i = 0; i < wormCount; ++i) {
+  game.ClearWorms();
+  std::vector<int32_t> anchor_indices(worm_count);
+  for (cereal::size_type i = 0; i < worm_count; ++i) {
     auto worm_sp = std::make_shared<Worm>();
     Worm& w = *worm_sp;
 
@@ -381,37 +381,37 @@ void load(Archive& ar, Game& game) {
     ar(cereal::make_nvp("worm", w));
 
     // Context: anchor index (resolve after all worms loaded)
-    ar(cereal::make_nvp("anchorIdx", anchorIndices[i]));
+    ar(cereal::make_nvp("anchorIdx", anchor_indices[i]));
 
     // Context: weapon type indices
     for (int j = 0; j < NUM_WEAPONS; ++j) {
-      int32_t weapIdx;
-      ar(cereal::make_nvp("weapIdx" + std::to_string(j), weapIdx));
-      w.weapons[j].type = weapIdx >= 0 ? &game.common->weapons[weapIdx] : nullptr;
+      int32_t weap_idx;
+      ar(cereal::make_nvp("weapIdx" + std::to_string(j), weap_idx));
+      w.weapons[j].type = weap_idx >= 0 ? &game.common->weapons[weap_idx] : nullptr;
     }
 
     // Per-worm settings
     ar(cereal::make_nvp("wormSettings", w.settings));
 
-    game.addWorm(worm_sp);
+    game.AddWorm(worm_sp);
   }
 
   // Resolve anchor pointers now that all worms exist
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    int32_t idx = anchorIndices[i];
+    int32_t idx = anchor_indices[i];
     game.worms[i]->ninjarope.anchor = (idx >= 0 && idx < static_cast<int32_t>(game.worms.size()))
                                           ? game.worms[idx].get()
                                           : nullptr;
   }
 
   // Viewports
-  cereal::size_type vpCount;
-  ar(cereal::make_size_tag(vpCount));
-  game.clearViewports();
-  for (cereal::size_type i = 0; i < vpCount; ++i) {
+  cereal::size_type vp_count;
+  ar(cereal::make_size_tag(vp_count));
+  game.ClearViewports();
+  for (cereal::size_type i = 0; i < vp_count; ++i) {
     Viewport* vp = new Viewport();
     ar(cereal::make_nvp("viewport", *vp));
-    game.addViewport(vp);
+    game.AddViewport(vp);
   }
 
   // Level

--- a/src/game/serialization/fast_snapshot.hpp
+++ b/src/game/serialization/fast_snapshot.hpp
@@ -28,108 +28,108 @@
 
 struct WormSimState {
   fixedvec pos{}, vel{};
-  IVec2 logicRespawn{};
-  int hotspotX = 0, hotspotY = 0;
-  fixed aimingAngle = 0, aimingSpeed = 0;
-  bool ableToJump = false, ableToDig = false;
-  bool keyChangePressed = false;
+  IVec2 logic_respawn{};
+  int hotspot_x = 0, hotspot_y = 0;
+  fixed aiming_angle = 0, aiming_speed = 0;
+  bool able_to_jump = false, able_to_dig = false;
+  bool key_change_pressed = false;
   bool movable = false;
   bool animate = false, visible = false, ready = false, flag = false;
-  bool makeSightGreen = false;
+  bool make_sight_green = false;
   int health = 0, lives = 0, kills = 0;
-  int timer = 0, killedTimer = 0;
-  int currentFrame = 0;
+  int timer = 0, killed_timer = 0;
+  int current_frame = 0;
   int flags = 0;
   Ninjarope ninjarope;
-  int currentWeapon = 0;
-  int lastKilledByIdx = -1;
-  int fireCone = 0;
-  int leaveShellTimer = 0;
+  int current_weapon = 0;
+  int last_killed_by_idx = -1;
+  int fire_cone = 0;
+  int leave_shell_timer = 0;
   int reacts[4] = {0, 0, 0, 0};
   WormWeapon weapons[NUM_WEAPONS];
   int direction = 0;
-  Worm::ControlState controlStates, prevControlStates;
-  int steerableSumX = 0, steerableSumY = 0, steerableCount = 0;
+  Worm::ControlState control_states, prev_control_states;
+  int steerable_sum_x = 0, steerable_sum_y = 0, steerable_count = 0;
   int index = 0;
 };
 
-inline void saveWormSimState(WormSimState& s, Worm const& w) {
+inline void SaveWormSimState(WormSimState& s, Worm const& w) {
   s.pos = w.pos;
   s.vel = w.vel;
-  s.logicRespawn = w.logicRespawn;
-  s.hotspotX = w.hotspotX;
-  s.hotspotY = w.hotspotY;
-  s.aimingAngle = w.aimingAngle;
-  s.aimingSpeed = w.aimingSpeed;
-  s.ableToJump = w.ableToJump;
-  s.ableToDig = w.ableToDig;
-  s.keyChangePressed = w.keyChangePressed;
+  s.logic_respawn = w.logic_respawn;
+  s.hotspot_x = w.hotspot_x;
+  s.hotspot_y = w.hotspot_y;
+  s.aiming_angle = w.aiming_angle;
+  s.aiming_speed = w.aiming_speed;
+  s.able_to_jump = w.able_to_jump;
+  s.able_to_dig = w.able_to_dig;
+  s.key_change_pressed = w.key_change_pressed;
   s.movable = w.movable;
   s.animate = w.animate;
   s.visible = w.visible;
   s.ready = w.ready;
   s.flag = w.flag;
-  s.makeSightGreen = w.makeSightGreen;
+  s.make_sight_green = w.make_sight_green;
   s.health = w.health;
   s.lives = w.lives;
   s.kills = w.kills;
   s.timer = w.timer;
-  s.killedTimer = w.killedTimer;
-  s.currentFrame = w.currentFrame;
+  s.killed_timer = w.killed_timer;
+  s.current_frame = w.current_frame;
   s.flags = w.flags;
   s.ninjarope = w.ninjarope;
-  s.currentWeapon = w.currentWeapon;
-  s.lastKilledByIdx = w.lastKilledByIdx;
-  s.fireCone = w.fireCone;
-  s.leaveShellTimer = w.leaveShellTimer;
+  s.current_weapon = w.current_weapon;
+  s.last_killed_by_idx = w.last_killed_by_idx;
+  s.fire_cone = w.fire_cone;
+  s.leave_shell_timer = w.leave_shell_timer;
   std::memcpy(s.reacts, w.reacts, sizeof(s.reacts));
   for (int i = 0; i < NUM_WEAPONS; ++i) s.weapons[i] = w.weapons[i];
   s.direction = w.direction;
-  s.controlStates = w.controlStates;
-  s.prevControlStates = w.prevControlStates;
-  s.steerableSumX = w.steerableSumX;
-  s.steerableSumY = w.steerableSumY;
-  s.steerableCount = w.steerableCount;
+  s.control_states = w.control_states;
+  s.prev_control_states = w.prev_control_states;
+  s.steerable_sum_x = w.steerable_sum_x;
+  s.steerable_sum_y = w.steerable_sum_y;
+  s.steerable_count = w.steerable_count;
   s.index = w.index;
 }
 
-inline void restoreWormSimState(Worm& w, WormSimState const& s) {
+inline void RestoreWormSimState(Worm& w, WormSimState const& s) {
   w.pos = s.pos;
   w.vel = s.vel;
-  w.logicRespawn = s.logicRespawn;
-  w.hotspotX = s.hotspotX;
-  w.hotspotY = s.hotspotY;
-  w.aimingAngle = s.aimingAngle;
-  w.aimingSpeed = s.aimingSpeed;
-  w.ableToJump = s.ableToJump;
-  w.ableToDig = s.ableToDig;
-  w.keyChangePressed = s.keyChangePressed;
+  w.logic_respawn = s.logic_respawn;
+  w.hotspot_x = s.hotspot_x;
+  w.hotspot_y = s.hotspot_y;
+  w.aiming_angle = s.aiming_angle;
+  w.aiming_speed = s.aiming_speed;
+  w.able_to_jump = s.able_to_jump;
+  w.able_to_dig = s.able_to_dig;
+  w.key_change_pressed = s.key_change_pressed;
   w.movable = s.movable;
   w.animate = s.animate;
   w.visible = s.visible;
   w.ready = s.ready;
   w.flag = s.flag;
-  w.makeSightGreen = s.makeSightGreen;
+  w.make_sight_green = s.make_sight_green;
   w.health = s.health;
   w.lives = s.lives;
   w.kills = s.kills;
   w.timer = s.timer;
-  w.killedTimer = s.killedTimer;
-  w.currentFrame = s.currentFrame;
+  w.killed_timer = s.killed_timer;
+  w.current_frame = s.current_frame;
   w.flags = s.flags;
   w.ninjarope = s.ninjarope;
-  w.currentWeapon = s.currentWeapon;
-  w.lastKilledByIdx = s.lastKilledByIdx;
-  w.fireCone = s.fireCone;
-  w.leaveShellTimer = s.leaveShellTimer;
+  w.current_weapon = s.current_weapon;
+  w.last_killed_by_idx = s.last_killed_by_idx;
+  w.fire_cone = s.fire_cone;
+  w.leave_shell_timer = s.leave_shell_timer;
   std::memcpy(w.reacts, s.reacts, sizeof(w.reacts));
   for (int i = 0; i < NUM_WEAPONS; ++i) w.weapons[i] = s.weapons[i];
   w.direction = s.direction;
-  w.controlStates = s.controlStates;
-  w.prevControlStates = s.prevControlStates;
-  w.steerableSumX = s.steerableSumX;
-  w.steerableSumY = s.steerableSumY;
-  w.steerableCount = s.steerableCount;
+  w.control_states = s.control_states;
+  w.prev_control_states = s.prev_control_states;
+  w.steerable_sum_x = s.steerable_sum_x;
+  w.steerable_sum_y = s.steerable_sum_y;
+  w.steerable_count = s.steerable_count;
   w.index = s.index;
 }
 
@@ -137,9 +137,9 @@ struct GameSnapshot {
   Rand rand;
 
   int cycles = 0;
-  int screenFlash = 0;
-  int lastKilledIdx = -1;
-  bool gotChanged = false;
+  int screen_flash = 0;
+  int last_killed_idx = -1;
+  bool got_changed = false;
   Holdazone holdazone;
 
   std::array<WormSimState, 2> worms{};
@@ -149,21 +149,21 @@ struct GameSnapshot {
   Game::SObjectList sobjects;
   Game::NObjectList nobjects;
 
-  std::vector<BObject> bobjectsArr;
-  std::size_t bobjectsCount = 0;
+  std::vector<BObject> bobjects_arr;
+  std::size_t bobjects_count = 0;
 
-  std::vector<uint8_t> levelData;
-  std::vector<Material> levelMaterials;
+  std::vector<uint8_t> level_data;
+  std::vector<Material> level_materials;
 
   uint32_t checksum = 0;
 
   // Pre-size the dynamic buffers so save/load can avoid allocations.
   // Call once after the level is generated.
-  void prepare(Game const& game) {
-    bobjectsArr.resize(game.bobjects.limit);
-    std::size_t const cells =
+  void Prepare(Game const& game) {
+    bobjects_arr.resize(game.bobjects.limit);
+    std::size_t const kCells =
         static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
-    levelData.resize(cells);
-    levelMaterials.resize(cells);
+    level_data.resize(kCells);
+    level_materials.resize(kCells);
   }
 };

--- a/src/game/serialization/snapshot.hpp
+++ b/src/game/serialization/snapshot.hpp
@@ -26,18 +26,18 @@
 // ---- Holdazone ----
 template <class Archive>
 void serialize(Archive& ar, Holdazone& h) {
-  ar(cereal::make_nvp("rect", h.rect), cereal::make_nvp("holderIdx", h.holderIdx),
-     cereal::make_nvp("contenderIdx", h.contenderIdx),
-     cereal::make_nvp("contenderFrames", h.contenderFrames),
-     cereal::make_nvp("timeoutLeft", h.timeoutLeft), cereal::make_nvp("zoneWidth", h.zoneWidth),
-     cereal::make_nvp("zoneHeight", h.zoneHeight));
+  ar(cereal::make_nvp("rect", h.rect), cereal::make_nvp("holderIdx", h.holder_idx),
+     cereal::make_nvp("contenderIdx", h.contender_idx),
+     cereal::make_nvp("contenderFrames", h.contender_frames),
+     cereal::make_nvp("timeoutLeft", h.timeout_left), cereal::make_nvp("zoneWidth", h.zone_width),
+     cereal::make_nvp("zoneHeight", h.zone_height));
 }
 
 // ---- Bonus (pure POD-ish) ----
 template <class Archive>
 void serialize(Archive& ar, Bonus& b) {
   ar(cereal::make_nvp("used", b.used), cereal::make_nvp("x", b.x), cereal::make_nvp("y", b.y),
-     cereal::make_nvp("velY", b.velY), cereal::make_nvp("frame", b.frame),
+     cereal::make_nvp("velY", b.vel_y), cereal::make_nvp("frame", b.frame),
      cereal::make_nvp("timer", b.timer), cereal::make_nvp("weapon", b.weapon));
 }
 
@@ -45,8 +45,8 @@ void serialize(Archive& ar, Bonus& b) {
 template <class Archive>
 void serialize(Archive& ar, SObject& s) {
   ar(cereal::make_nvp("used", s.used), cereal::make_nvp("x", s.x), cereal::make_nvp("y", s.y),
-     cereal::make_nvp("id", s.id), cereal::make_nvp("curFrame", s.curFrame),
-     cereal::make_nvp("animDelay", s.animDelay));
+     cereal::make_nvp("id", s.id), cereal::make_nvp("curFrame", s.cur_frame),
+     cereal::make_nvp("animDelay", s.anim_delay));
 }
 
 // ---- BObject (pure POD) ----
@@ -61,28 +61,28 @@ void serialize(Archive& ar, BObject& b) {
 // numeric fields. The Game-level pool save/load below writes the indices.
 
 template <class Archive>
-void serializeNObjectScalars(Archive& ar, NObject& n) {
+void SerializeNObjectScalars(Archive& ar, NObject& n) {
   ar(cereal::make_nvp("used", n.used), cereal::make_nvp("pos", n.pos),
-     cereal::make_nvp("vel", n.vel), cereal::make_nvp("timeLeft", n.timeLeft),
-     cereal::make_nvp("ownerIdx", n.ownerIdx), cereal::make_nvp("curFrame", n.curFrame),
-     cereal::make_nvp("hasHit", n.hasHit));
+     cereal::make_nvp("vel", n.vel), cereal::make_nvp("timeLeft", n.time_left),
+     cereal::make_nvp("ownerIdx", n.owner_idx), cereal::make_nvp("curFrame", n.cur_frame),
+     cereal::make_nvp("hasHit", n.has_hit));
 }
 
 template <class Archive>
-void serializeWObjectScalars(Archive& ar, WObject& w) {
+void SerializeWObjectScalars(Archive& ar, WObject& w) {
   ar(cereal::make_nvp("used", w.used), cereal::make_nvp("pos", w.pos),
-     cereal::make_nvp("vel", w.vel), cereal::make_nvp("ownerIdx", w.ownerIdx),
-     cereal::make_nvp("curFrame", w.curFrame), cereal::make_nvp("timeLeft", w.timeLeft),
-     cereal::make_nvp("hasHit", w.hasHit));
+     cereal::make_nvp("vel", w.vel), cereal::make_nvp("ownerIdx", w.owner_idx),
+     cereal::make_nvp("curFrame", w.cur_frame), cereal::make_nvp("timeLeft", w.time_left),
+     cereal::make_nvp("hasHit", w.has_hit));
 }
 
 // ---- (wormIdx, slot) encoding for WormWeapon* firedBy ----
 struct FiredByRef {
-  int8_t wormIdx;
+  int8_t worm_idx;
   int8_t slot;
 };
 
-inline FiredByRef encodeFiredBy(Game const& game, WormWeapon const* fb) {
+inline FiredByRef EncodeFiredBy(Game const& game, WormWeapon const* fb) {
   if (!fb) return {-1, -1};
   for (std::size_t wi = 0; wi < game.worms.size(); ++wi) {
     WormWeapon const* base = game.worms[wi]->weapons;
@@ -92,15 +92,15 @@ inline FiredByRef encodeFiredBy(Game const& game, WormWeapon const* fb) {
   return {-1, -1};
 }
 
-inline WormWeapon* decodeFiredBy(Game& game, FiredByRef ref) {
-  if (ref.wormIdx < 0 || ref.slot < 0) return nullptr;
-  if (static_cast<std::size_t>(ref.wormIdx) >= game.worms.size()) return nullptr;
-  return &game.worms[ref.wormIdx]->weapons[ref.slot];
+inline WormWeapon* DecodeFiredBy(Game& game, FiredByRef ref) {
+  if (ref.worm_idx < 0 || ref.slot < 0) return nullptr;
+  if (static_cast<std::size_t>(ref.worm_idx) >= game.worms.size()) return nullptr;
+  return &game.worms[ref.worm_idx]->weapons[ref.slot];
 }
 
 template <class Archive>
 void serialize(Archive& ar, FiredByRef& r) {
-  ar(cereal::make_nvp("w", r.wormIdx), cereal::make_nvp("s", r.slot));
+  ar(cereal::make_nvp("w", r.worm_idx), cereal::make_nvp("s", r.slot));
 }
 
 // ---- ExactObjectList<T, Limit> ----
@@ -118,7 +118,7 @@ void save(Archive& ar, ExactObjectList<T, Limit> const& list) {
 
 template <class Archive, typename T, int Limit>
 void load(Archive& ar, ExactObjectList<T, Limit>& list) {
-  list.clear();
+  list.Clear();
   for (int i = 0; i < Limit; ++i) {
     bool used;
     ar(cereal::make_nvp("u", used));
@@ -126,7 +126,7 @@ void load(Archive& ar, ExactObjectList<T, Limit>& list) {
       // Bypass getFreeObject — it picks the lowest free slot, not slot i.
       ar(cereal::make_nvp("e", list.arr[i]));
       list.arr[i].used = true;
-      list.freeList[static_cast<uint32_t>(i) >> 5] &=
+      list.free_list[static_cast<uint32_t>(i) >> 5] &=
           ~(uint32_t(1) << (static_cast<uint32_t>(i) & 31));
       ++list.count;
     }
@@ -145,9 +145,9 @@ template <class Archive, typename T>
 void load(Archive& ar, FastObjectList<T>& list) {
   uint32_t count;
   ar(cereal::make_nvp("count", count));
-  list.clear();
+  list.Clear();
   for (uint32_t i = 0; i < count; ++i) {
-    T* slot = list.newObject();
+    T* slot = list.NewObject();
     if (!slot) {
       // List capacity smaller than snapshotted count — bug, but read into
       // a scratch element to keep the stream consumed.
@@ -165,7 +165,7 @@ void load(Archive& ar, FastObjectList<T>& list) {
 // state that replays don't need: object pools, holdazone, and the type/
 // firedBy index sidecars for the typed pools.
 template <class Archive>
-void saveGameSnapshot(Archive& ar, Game const& game) {
+void SaveGameSnapshot(Archive& ar, Game const& game) {
   save(ar, game);  // existing Game save (settings, worms, viewports, level, ...)
 
   ar(cereal::make_nvp("holdazone", const_cast<Holdazone&>(game.holdazone)));
@@ -181,11 +181,11 @@ void saveGameSnapshot(Archive& ar, Game const& game) {
       NObject const& n = list.arr[i];
       ar(cereal::make_nvp("u", n.used));
       if (n.used) {
-        serializeNObjectScalars(ar, const_cast<NObject&>(n));
-        int32_t typeIdx =
-            n.type ? static_cast<int32_t>(n.type - &game.common->nobjectTypes[0]) : -1;
-        FiredByRef fb = encodeFiredBy(game, n.firedBy);
-        ar(cereal::make_nvp("typeIdx", typeIdx), cereal::make_nvp("firedBy", fb));
+        SerializeNObjectScalars(ar, const_cast<NObject&>(n));
+        int32_t type_idx =
+            n.type ? static_cast<int32_t>(n.type - &game.common->nobject_types[0]) : -1;
+        FiredByRef fb = EncodeFiredBy(game, n.fired_by);
+        ar(cereal::make_nvp("typeIdx", type_idx), cereal::make_nvp("firedBy", fb));
       }
     }
   }
@@ -197,10 +197,10 @@ void saveGameSnapshot(Archive& ar, Game const& game) {
       WObject const& w = list.arr[i];
       ar(cereal::make_nvp("u", w.used));
       if (w.used) {
-        serializeWObjectScalars(ar, const_cast<WObject&>(w));
-        int32_t typeIdx = w.type ? static_cast<int32_t>(w.type - &game.common->weapons[0]) : -1;
-        FiredByRef fb = encodeFiredBy(game, w.firedBy);
-        ar(cereal::make_nvp("typeIdx", typeIdx), cereal::make_nvp("firedBy", fb));
+        SerializeWObjectScalars(ar, const_cast<WObject&>(w));
+        int32_t type_idx = w.type ? static_cast<int32_t>(w.type - &game.common->weapons[0]) : -1;
+        FiredByRef fb = EncodeFiredBy(game, w.fired_by);
+        ar(cereal::make_nvp("typeIdx", type_idx), cereal::make_nvp("firedBy", fb));
       }
     }
   }
@@ -210,7 +210,7 @@ void saveGameSnapshot(Archive& ar, Game const& game) {
 }
 
 template <class Archive>
-void loadGameSnapshot(Archive& ar, Game& game) {
+void LoadGameSnapshot(Archive& ar, Game& game) {
   load(ar, game);  // existing Game load — recreates worms, viewports, level
 
   ar(cereal::make_nvp("holdazone", game.holdazone));
@@ -221,22 +221,22 @@ void loadGameSnapshot(Archive& ar, Game& game) {
   // NObjects
   {
     auto& list = game.nobjects;
-    list.clear();
+    list.Clear();
     for (int i = 0; i < 600; ++i) {
       bool used;
       ar(cereal::make_nvp("u", used));
       if (used) {
         NObject& n = list.arr[i];
-        serializeNObjectScalars(ar, n);
+        SerializeNObjectScalars(ar, n);
         n.used = true;
-        list.freeList[static_cast<uint32_t>(i) >> 5] &=
+        list.free_list[static_cast<uint32_t>(i) >> 5] &=
             ~(uint32_t(1) << (static_cast<uint32_t>(i) & 31));
         ++list.count;
-        int32_t typeIdx;
+        int32_t type_idx;
         FiredByRef fb;
-        ar(cereal::make_nvp("typeIdx", typeIdx), cereal::make_nvp("firedBy", fb));
-        n.type = (typeIdx >= 0) ? &game.common->nobjectTypes[typeIdx] : nullptr;
-        n.firedBy = decodeFiredBy(game, fb);
+        ar(cereal::make_nvp("typeIdx", type_idx), cereal::make_nvp("firedBy", fb));
+        n.type = (type_idx >= 0) ? &game.common->nobject_types[type_idx] : nullptr;
+        n.fired_by = DecodeFiredBy(game, fb);
       }
     }
   }
@@ -244,22 +244,22 @@ void loadGameSnapshot(Archive& ar, Game& game) {
   // WObjects
   {
     auto& list = game.wobjects;
-    list.clear();
+    list.Clear();
     for (int i = 0; i < 600; ++i) {
       bool used;
       ar(cereal::make_nvp("u", used));
       if (used) {
         WObject& w = list.arr[i];
-        serializeWObjectScalars(ar, w);
+        SerializeWObjectScalars(ar, w);
         w.used = true;
-        list.freeList[static_cast<uint32_t>(i) >> 5] &=
+        list.free_list[static_cast<uint32_t>(i) >> 5] &=
             ~(uint32_t(1) << (static_cast<uint32_t>(i) & 31));
         ++list.count;
-        int32_t typeIdx;
+        int32_t type_idx;
         FiredByRef fb;
-        ar(cereal::make_nvp("typeIdx", typeIdx), cereal::make_nvp("firedBy", fb));
-        w.type = (typeIdx >= 0) ? &game.common->weapons[typeIdx] : nullptr;
-        w.firedBy = decodeFiredBy(game, fb);
+        ar(cereal::make_nvp("typeIdx", type_idx), cereal::make_nvp("firedBy", fb));
+        w.type = (type_idx >= 0) ? &game.common->weapons[type_idx] : nullptr;
+        w.fired_by = DecodeFiredBy(game, fb);
       }
     }
   }

--- a/src/game/serialization/toml_archive.hpp
+++ b/src/game/serialization/toml_archive.hpp
@@ -5,7 +5,7 @@
 // Mirrors the structure of cereal's bundled json.hpp: a single
 // `serialize()` per type works for both PortableBinaryArchive and these
 // TOML archives. Names come from CEREAL_NVP / make_nvp. Variable-sized
-// containers (std::vector, etc.) use SizeTag, which triggers an array
+// containers (std::vector, etc.) use sizeTag, which triggers an array
 // in TOML; everything else lands in a table.
 //
 // Limitations vs. JSON:
@@ -54,29 +54,29 @@ class TomlOutputArchive : public cereal::OutputArchive<TomlOutputArchive>,
     f.container = nullptr;
     f.is_array = false;
     f.materialized = false;
-    f.name_in_parent = takeName(frames_.back());
+    f.name_in_parent = TakeName(frames_.back());
     frames_.push_back(std::move(f));
   }
 
   void finishNode() {
-    if (!frames_.back().materialized) materializeAll();
+    if (!frames_.back().materialized) MaterializeAll();
     frames_.pop_back();
   }
 
-  // SizeTag prologue calls this to mark the just-started node as an array.
-  void makeArray() { frames_.back().is_array = true; }
+  // sizeTag prologue calls this to mark the just-started node as an array.
+  void MakeArray() { frames_.back().is_array = true; }
 
-  void saveValue(bool v) { putValue(v); }
-  void saveValue(std::int32_t v) { putValue(static_cast<std::int64_t>(v)); }
-  void saveValue(std::uint32_t v) { putValue(static_cast<std::int64_t>(v)); }
-  void saveValue(std::int64_t v) { putValue(v); }
+  void saveValue(bool v) { PutValue(v); }
+  void saveValue(std::int32_t v) { PutValue(static_cast<std::int64_t>(v)); }
+  void saveValue(std::uint32_t v) { PutValue(static_cast<std::int64_t>(v)); }
+  void saveValue(std::int64_t v) { PutValue(v); }
   void saveValue(std::uint64_t v) {
     // toml++ stores ints as int64_t; values above INT64_MAX would corrupt.
-    putValue(static_cast<std::int64_t>(v));
+    PutValue(static_cast<std::int64_t>(v));
   }
-  void saveValue(double v) { putValue(v); }
-  void saveValue(float v) { putValue(static_cast<double>(v)); }
-  void saveValue(std::string const& s) { putValue(s); }
+  void saveValue(double v) { PutValue(v); }
+  void saveValue(float v) { PutValue(static_cast<double>(v)); }
+  void saveValue(std::string const& s) { PutValue(s); }
 
  private:
   struct Frame {
@@ -92,7 +92,7 @@ class TomlOutputArchive : public cereal::OutputArchive<TomlOutputArchive>,
   std::vector<Frame> frames_;
   char const* next_name_ = nullptr;
 
-  std::string takeName(Frame& parent) {
+  std::string TakeName(Frame& parent) {
     if (next_name_) {
       std::string n = next_name_;
       next_name_ = nullptr;
@@ -101,14 +101,14 @@ class TomlOutputArchive : public cereal::OutputArchive<TomlOutputArchive>,
     return "value" + std::to_string(parent.name_counter++);
   }
 
-  void materializeAll() {
+  void MaterializeAll() {
     // Root (frame 0) is always materialized; walk down from there.
     for (std::size_t i = 1; i < frames_.size(); ++i) {
-      if (!frames_[i].materialized) materializeAt(i);
+      if (!frames_[i].materialized) MaterializeAt(i);
     }
   }
 
-  void materializeAt(std::size_t i) {
+  void MaterializeAt(std::size_t i) {
     Frame& f = frames_[i];
     Frame& parent = frames_[i - 1];
     if (parent.container->is_table()) {
@@ -130,11 +130,11 @@ class TomlOutputArchive : public cereal::OutputArchive<TomlOutputArchive>,
   }
 
   template <typename T>
-  void putValue(T const& v) {
-    materializeAll();
+  void PutValue(T const& v) {
+    MaterializeAll();
     Frame& f = frames_.back();
     if (f.container->is_table()) {
-      f.container->as_table()->insert_or_assign(takeName(f), v);
+      f.container->as_table()->insert_or_assign(TakeName(f), v);
     } else {
       f.container->as_array()->push_back(v);
     }
@@ -174,7 +174,7 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
     f.index = 0;
 
     Frame& parent = frames_.back();
-    toml::node* child = lookup(parent);
+    toml::node* child = Lookup(parent);
     f.node = child;  // may be null if missing
     frames_.push_back(std::move(f));
   }
@@ -193,11 +193,11 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
     next_name_ = nullptr;
   }
 
-  // SizeTag prologue marks the upcoming/current node as array context;
+  // sizeTag prologue marks the upcoming/current node as array context;
   // loadSize reports the size of that array.
-  void makeArray() { frames_.back().is_array = true; }
+  void MakeArray() { frames_.back().is_array = true; }
 
-  void loadSize(cereal::size_type& size) {
+  void LoadSize(cereal::size_type& size) {
     Frame& f = frames_.back();
     if (f.node && f.node->is_array())
       size = f.node->as_array()->size();
@@ -206,37 +206,37 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
   }
 
   void loadValue(bool& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_boolean()) v = n->as_boolean()->get();
-    advance();
+    if (auto* n = Lookup(frames_.back()); n && n->is_boolean()) v = n->as_boolean()->get();
+    Advance();
   }
 
   void loadValue(std::int32_t& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_integer())
+    if (auto* n = Lookup(frames_.back()); n && n->is_integer())
       v = static_cast<std::int32_t>(n->as_integer()->get());
-    advance();
+    Advance();
   }
   void loadValue(std::uint32_t& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_integer())
+    if (auto* n = Lookup(frames_.back()); n && n->is_integer())
       v = static_cast<std::uint32_t>(n->as_integer()->get());
-    advance();
+    Advance();
   }
   void loadValue(std::int64_t& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_integer()) v = n->as_integer()->get();
-    advance();
+    if (auto* n = Lookup(frames_.back()); n && n->is_integer()) v = n->as_integer()->get();
+    Advance();
   }
   void loadValue(std::uint64_t& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_integer())
+    if (auto* n = Lookup(frames_.back()); n && n->is_integer())
       v = static_cast<std::uint64_t>(n->as_integer()->get());
-    advance();
+    Advance();
   }
   void loadValue(double& v) {
-    if (auto* n = lookup(frames_.back())) {
+    if (auto* n = Lookup(frames_.back())) {
       if (n->is_floating_point())
         v = n->as_floating_point()->get();
       else if (n->is_integer())
         v = static_cast<double>(n->as_integer()->get());
     }
-    advance();
+    Advance();
   }
   void loadValue(float& v) {
     double d = v;
@@ -244,8 +244,8 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
     v = static_cast<float>(d);
   }
   void loadValue(std::string& v) {
-    if (auto* n = lookup(frames_.back()); n && n->is_string()) v = n->as_string()->get();
-    advance();
+    if (auto* n = Lookup(frames_.back()); n && n->is_string()) v = n->as_string()->get();
+    Advance();
   }
 
  private:
@@ -259,7 +259,7 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
   std::vector<Frame> frames_;
   char const* next_name_ = nullptr;
 
-  toml::node* lookup(Frame& f) {
+  toml::node* Lookup(Frame& f) {
     if (!f.node) {
       next_name_ = nullptr;
       return nullptr;
@@ -285,7 +285,7 @@ class TomlInputArchive : public cereal::InputArchive<TomlInputArchive>,
     return nullptr;
   }
 
-  void advance() {
+  void Advance() {
     Frame& f = frames_.back();
     if (f.node && f.node->is_array()) f.index += 1;
   }
@@ -316,14 +316,14 @@ inline void CEREAL_LOAD_FUNCTION_NAME(TomlInputArchive& ar, NameValuePair<T>& t)
   ar(t.value);
 }
 
-// ---- SizeTag ----
+// ---- sizeTag ----
 template <class T>
 inline void prologue(TomlOutputArchive& ar, SizeTag<T> const&) {
-  ar.makeArray();
+  ar.MakeArray();
 }
 template <class T>
 inline void prologue(TomlInputArchive& ar, SizeTag<T> const&) {
-  ar.makeArray();
+  ar.MakeArray();
 }
 template <class T>
 inline void epilogue(TomlOutputArchive&, SizeTag<T> const&) {}
@@ -336,7 +336,7 @@ inline void CEREAL_SAVE_FUNCTION_NAME(TomlOutputArchive&, SizeTag<T> const&) {
 }
 template <class T>
 inline void CEREAL_LOAD_FUNCTION_NAME(TomlInputArchive& ar, SizeTag<T>& st) {
-  ar.loadSize(st.size);
+  ar.LoadSize(st.size);
 }
 
 // ---- Generic object types (non-arithmetic, non-string) ----

--- a/src/game/serialization/weapsel_snapshot.hpp
+++ b/src/game/serialization/weapsel_snapshot.hpp
@@ -20,25 +20,25 @@
 
 struct WeaponSelectSnap {
   bool valid = false;
-  bool wsDone = false;  // true if WeaponSelection::processFrame returned
+  bool ws_done = false;  // true if WeaponSelection::processFrame returned
                         // true at this frame (both peers pressed Done).
 
   struct PerPlayer {
-    std::array<uint32_t, Settings::selectableWeapons> weapons{};
-    bool isReady = false;
-    int menuSelection = 0;
-    int menuTopItem = 0;
-    int menuBottomItem = 0;
-    uint16_t wormControlStates = 0;
-    int currentWeapon = 0;
+    std::array<uint32_t, Settings::kSelectableWeapons> weapons{};
+    bool is_ready = false;
+    int menu_selection = 0;
+    int menu_top_item = 0;
+    int menu_bottom_item = 0;
+    uint16_t worm_control_states = 0;
+    int current_weapon = 0;
   };
   std::array<PerPlayer, 2> players{};
 
   Rand rand;
 
   // Edge-detection / key-repeat state on the rollback controller.
-  uint8_t localPrevInput = 0;
-  uint8_t remotePrevInput = 0;
-  std::array<uint16_t, 8> localHeldFrames{};
-  std::array<uint16_t, 8> remoteHeldFrames{};
+  uint8_t local_prev_input = 0;
+  uint8_t remote_prev_input = 0;
+  std::array<uint16_t, 8> local_held_frames{};
+  std::array<uint16_t, 8> remote_held_frames{};
 };

--- a/src/game/serialization/weapsel_snapshot.hpp
+++ b/src/game/serialization/weapsel_snapshot.hpp
@@ -21,7 +21,7 @@
 struct WeaponSelectSnap {
   bool valid = false;
   bool ws_done = false;  // true if WeaponSelection::processFrame returned
-                        // true at this frame (both peers pressed Done).
+                         // true at this frame (both peers pressed Done).
 
   struct PerPlayer {
     std::array<uint32_t, Settings::kSelectableWeapons> weapons{};

--- a/src/game/settings.cpp
+++ b/src/game/settings.cpp
@@ -26,7 +26,10 @@ GameplayExtensions::GameplayExtensions()
       tc(std::string("openliero")) {}
 
 AppSettings::AppSettings()
-    : fullscreen(false), single_screen_replay(false), spectator_window(false), blood_particle_max(700) {}
+    : fullscreen(false),
+      single_screen_replay(false),
+      spectator_window(false),
+      blood_particle_max(700) {}
 
 Settings::Settings()
     : max_bonuses(4),
@@ -56,7 +59,7 @@ Settings::Settings()
   worm_settings[2]->color = 32;
 
   unsigned char def_controls[2][7] = {{0x13, 0x21, 0x20, 0x22, 0x1D, 0x2A, 0x38},
-                                     {0xA0, 0xA8, 0xA3, 0xA5, 0x75, 0x90, 0x36}};
+                                      {0xA0, 0xA8, 0xA3, 0xA5, 0x75, 0x90, 0x36}};
 
   unsigned char def_rgb[2][3] = {{26, 26, 63}, {15, 43, 15}};
 

--- a/src/game/settings.cpp
+++ b/src/game/settings.cpp
@@ -11,131 +11,131 @@
 #include <xxhash.h>
 #include <sstream>
 
-int const Settings::wormAnimTab[] = {0, 7, 0, 14};
+int const Settings::kWormAnimTab[] = {0, 7, 0, 14};
 
 GameplayExtensions::GameplayExtensions()
-    : recordReplays(true),
-      loadPowerlevelPalette(true),
-      aiFrames(70 * 2),
-      aiMutations(2),
-      aiTraces(false),
-      aiParallels(3),
-      zoneTimeout(30),
-      selectBotWeapons(true),
-      allowViewingSpawnPoint(false),
+    : record_replays(true),
+      load_powerlevel_palette(true),
+      ai_frames(70 * 2),
+      ai_mutations(2),
+      ai_traces(false),
+      ai_parallels(3),
+      zone_timeout(30),
+      select_bot_weapons(true),
+      allow_viewing_spawn_point(false),
       tc(std::string("openliero")) {}
 
 AppSettings::AppSettings()
-    : fullscreen(false), singleScreenReplay(false), spectatorWindow(false), bloodParticleMax(700) {}
+    : fullscreen(false), single_screen_replay(false), spectator_window(false), blood_particle_max(700) {}
 
 Settings::Settings()
-    : maxBonuses(4),
+    : max_bonuses(4),
       blood(100),
-      timeToLose(600),
-      flagsToWin(20),
-      gameMode(0),
+      time_to_lose(600),
+      flags_to_win(20),
+      game_mode(0),
       shadow(true),
-      loadChange(true),
-      namesOnBonuses(false),
-      regenerateLevel(false),
+      load_change(true),
+      names_on_bonuses(false),
+      regenerate_level(false),
       lives(15),
-      loadingTime(100),
-      randomLevel(true),
+      loading_time(100),
+      random_level(true),
       map(true),
-      screenSync(true),
-      bonusTimeout(0),
-      inputDelay(1) {
-  std::memset(weapTable, 0, sizeof(weapTable));
+      screen_sync(true),
+      bonus_timeout(0),
+      input_delay(1) {
+  std::memset(weap_table, 0, sizeof(weap_table));
 
-  wormSettings[0].reset(new WormSettings);
-  wormSettings[1].reset(new WormSettings);
-  wormSettings[2].reset(new WormSettings);
+  worm_settings[0].reset(new WormSettings);
+  worm_settings[1].reset(new WormSettings);
+  worm_settings[2].reset(new WormSettings);
 
-  wormSettings[0]->color = 32;
-  wormSettings[1]->color = 41;
-  wormSettings[2]->color = 32;
+  worm_settings[0]->color = 32;
+  worm_settings[1]->color = 41;
+  worm_settings[2]->color = 32;
 
-  unsigned char defControls[2][7] = {{0x13, 0x21, 0x20, 0x22, 0x1D, 0x2A, 0x38},
+  unsigned char def_controls[2][7] = {{0x13, 0x21, 0x20, 0x22, 0x1D, 0x2A, 0x38},
                                      {0xA0, 0xA8, 0xA3, 0xA5, 0x75, 0x90, 0x36}};
 
-  unsigned char defRGB[2][3] = {{26, 26, 63}, {15, 43, 15}};
+  unsigned char def_rgb[2][3] = {{26, 26, 63}, {15, 43, 15}};
 
   for (int i = 0; i < 2; ++i) {
     for (int j = 0; j < 7; ++j) {
-      wormSettings[i]->controls[j] = defControls[i][j];
-      wormSettings[i]->controlsEx[j] = defControls[i][j];
+      worm_settings[i]->controls[j] = def_controls[i][j];
+      worm_settings[i]->controls_ex[j] = def_controls[i][j];
     }
 
     for (int j = 0; j < 3; ++j) {
-      wormSettings[i]->rgb[j] = defRGB[i][j];
+      worm_settings[i]->rgb[j] = def_rgb[i][j];
     }
   }
 
   // Network player defaults to left player's controls and color
   for (int j = 0; j < 7; ++j) {
-    wormSettings[2]->controls[j] = defControls[0][j];
-    wormSettings[2]->controlsEx[j] = defControls[0][j];
+    worm_settings[2]->controls[j] = def_controls[0][j];
+    worm_settings[2]->controls_ex[j] = def_controls[0][j];
   }
   for (int j = 0; j < 3; ++j) {
-    wormSettings[2]->rgb[j] = defRGB[0][j];
+    worm_settings[2]->rgb[j] = def_rgb[0][j];
   }
 }
 
 bool Settings::load(FsNode node, Rand& rand) {
   try {
-    auto reader_ptr = node.toReader();
+    auto reader_ptr = node.ToReader();
     io::Reader& reader = *reader_ptr;
     std::string content;
     uint8_t buf[4096];
     for (;;) {
-      std::size_t got = reader.try_get(buf, sizeof(buf));
+      std::size_t got = reader.TryGet(buf, sizeof(buf));
       if (got == 0) break;
       content.append(reinterpret_cast<char*>(buf), got);
     }
-    fromToml(content);
+    FromToml(content);
   } catch (std::runtime_error&) {
     return false;
   }
 
   // Validate that wormSettings were deserialized (guards against corrupt
   // or incompatible config files that lack player sections).
-  for (int i = 0; i < NumWormSettings; ++i)
-    if (!wormSettings[i]) return false;
+  for (int i = 0; i < kNumWormSettings; ++i)
+    if (!worm_settings[i]) return false;
 
   return true;
 }
 
-uint64_t& Settings::updateHash() {
+uint64_t& Settings::UpdateHash() {
   std::ostringstream ss;
   {
     cereal::TomlOutputArchive ar(ss);
-    serializeGameplay(ar, *this);
+    SerializeGameplay(ar, *this);
   }
   std::string buf = ss.str();
   hash = XXH3_64bits(buf.data(), buf.size());
   return hash;
 }
 
-std::string Settings::toToml() const {
+std::string Settings::ToToml() const {
   std::ostringstream ss;
   {
     cereal::TomlOutputArchive ar(ss);
     // Serialize all scalar fields under [settings]
     ar.setNextName("settings");
     ar.startNode();
-    int32_t version = ConfigVersion;
+    int32_t version = kConfigVersion;
     ar(cereal::make_nvp("version", version));
-    serializeSettingsScalars(ar, const_cast<Settings&>(*this));
-    serializeArray(ar, "weapTable", const_cast<Settings&>(*this).weapTable);
+    SerializeSettingsScalars(ar, const_cast<Settings&>(*this));
+    SerializeArray(ar, "weapTable", const_cast<Settings&>(*this).weap_table);
     ar.finishNode();
 
     // Serialize worm settings as sub-tables with descriptive names
-    static const char* wormNames[] = {"player1", "player2", "network_player"};
-    for (int i = 0; i < NumWormSettings; ++i) {
-      if (wormSettings[i]) {
-        ar.setNextName(wormNames[i]);
+    static const char* worm_names[] = {"player1", "player2", "network_player"};
+    for (int i = 0; i < kNumWormSettings; ++i) {
+      if (worm_settings[i]) {
+        ar.setNextName(worm_names[i]);
         ar.startNode();
-        serializeWormSettingsToml(ar, *wormSettings[i]);
+        SerializeWormSettingsToml(ar, *worm_settings[i]);
         ar.finishNode();
       }
     }
@@ -143,7 +143,7 @@ std::string Settings::toToml() const {
   return ss.str();
 }
 
-void Settings::fromToml(std::string const& data) {
+void Settings::FromToml(std::string const& data) {
   std::istringstream ss(data);
   cereal::TomlInputArchive ar(ss);
 
@@ -151,28 +151,28 @@ void Settings::fromToml(std::string const& data) {
   ar.startNode();
   int32_t version = 0;
   ar(cereal::make_nvp("version", version));
-  serializeSettingsScalars(ar, *this);
-  serializeArray(ar, "weapTable", weapTable);
+  SerializeSettingsScalars(ar, *this);
+  SerializeArray(ar, "weapTable", weap_table);
   ar.finishNode();
 
-  static const char* wormNames[] = {"player1", "player2", "network_player"};
-  for (int i = 0; i < NumWormSettings; ++i) {
-    ar.setNextName(wormNames[i]);
+  static const char* worm_names[] = {"player1", "player2", "network_player"};
+  for (int i = 0; i < kNumWormSettings; ++i) {
+    ar.setNextName(worm_names[i]);
     ar.startNode();
-    if (!wormSettings[i]) wormSettings[i] = std::make_shared<WormSettings>();
-    serializeWormSettingsToml(ar, *wormSettings[i]);
+    if (!worm_settings[i]) worm_settings[i] = std::make_shared<WormSettings>();
+    SerializeWormSettingsToml(ar, *worm_settings[i]);
     ar.finishNode();
   }
 }
 
 void Settings::save(FsNode node, Rand& rand) {
-  auto writer_ptr = node.toWriter();
+  auto writer_ptr = node.ToWriter();
   io::Writer& writer = *writer_ptr;
-  std::string toml = toToml();
-  writer.put(reinterpret_cast<uint8_t const*>(toml.data()), toml.size());
+  std::string toml = ToToml();
+  writer.Put(reinterpret_cast<uint8_t const*>(toml.data()), toml.size());
 }
 
-void Settings::generateName(WormSettings& ws, Rand& rand) {
+void Settings::GenerateName(WormSettings& ws, Rand& rand) {
 #if 0  // TODO
 	try
 	{

--- a/src/game/settings.hpp
+++ b/src/game/settings.hpp
@@ -11,19 +11,19 @@
 struct GameplayExtensions {
   GameplayExtensions();
 
-  static bool const extensions = true;
+  static bool const kExtensions = true;
 
-  bool recordReplays;
-  bool loadPowerlevelPalette;
+  bool record_replays;
+  bool load_powerlevel_palette;
 
-  int aiFrames, aiMutations;
-  bool aiTraces;
-  int32_t aiParallels;
+  int ai_frames, ai_mutations;
+  bool ai_traces;
+  int32_t ai_parallels;
 
-  int32_t zoneTimeout;
-  uint32_t selectBotWeapons;
+  int32_t zone_timeout;
+  uint32_t select_bot_weapons;
 
-  bool allowViewingSpawnPoint;
+  bool allow_viewing_spawn_point;
   std::string tc;
 };
 
@@ -32,63 +32,63 @@ struct AppSettings {
   AppSettings();
 
   bool fullscreen;
-  bool singleScreenReplay;
-  bool spectatorWindow;
-  int32_t bloodParticleMax;
+  bool single_screen_replay;
+  bool spectator_window;
+  int32_t blood_particle_max;
 };
 
 struct Rand;
 
 struct Settings : GameplayExtensions, AppSettings {
-  enum GameModes { GMKillEmAll, GMGameOfTag, GMHoldazone, GMScalesOfJustice, MaxGameModes };
+  enum GameModes { kGmKillEmAll, kGmGameOfTag, kGmHoldazone, kGmScalesOfJustice, kMaxGameModes };
 
-  static int const selectableWeapons = 5;
-  static int const zoneCaptureTime = 70;
+  static int const kSelectableWeapons = 5;
+  static int const kZoneCaptureTime = 70;
 
-  static int const wormAnimTab[];
+  static int const kWormAnimTab[];
 
   Settings();
 
   bool load(FsNode node, Rand& rand);
   void save(FsNode node, Rand& rand);
-  std::string toToml() const;
-  void fromToml(std::string const& data);
-  uint64_t& updateHash();
+  std::string ToToml() const;
+  void FromToml(std::string const& data);
+  uint64_t& UpdateHash();
 
-  static void generateName(WormSettings& ws, Rand& rand);
+  static void GenerateName(WormSettings& ws, Rand& rand);
 
-  uint32_t weapTable[40];
-  int32_t maxBonuses;
+  uint32_t weap_table[40];
+  int32_t max_bonuses;
   int32_t blood;
-  int32_t timeToLose;
-  int32_t flagsToWin;
-  uint32_t gameMode;
+  int32_t time_to_lose;
+  int32_t flags_to_win;
+  uint32_t game_mode;
   bool shadow;
-  bool loadChange;
-  bool namesOnBonuses;
-  bool regenerateLevel;
+  bool load_change;
+  bool names_on_bonuses;
+  bool regenerate_level;
   int32_t lives;
-  int32_t loadingTime;
-  bool randomLevel;
-  std::string levelFile;
+  int32_t loading_time;
+  bool random_level;
+  std::string level_file;
   bool map;
-  bool screenSync;
-  int32_t bonusTimeout;  // max seconds a bonus stays on the map; 0 = no limit
+  bool screen_sync;
+  int32_t bonus_timeout;  // max seconds a bonus stays on the map; 0 = no limit
 
   // Frames of artificial input delay. Host-authoritative; synced to
   // the client via MatchSettingsData.
-  int32_t inputDelay;
+  int32_t input_delay;
 
-  static int const NumWormSettings = 3;  // 0=left, 1=right, 2=network
-  static int const NetworkPlayerIdx = 2;
-  static int const ConfigVersion = 3;  // bump when adding fields to the TOML config
-  std::shared_ptr<WormSettings> wormSettings[NumWormSettings];
+  static int const kNumWormSettings = 3;  // 0=left, 1=right, 2=network
+  static int const kNetworkPlayerIdx = 2;
+  static int const kConfigVersion = 3;  // bump when adding fields to the TOML config
+  std::shared_ptr<WormSettings> worm_settings[kNumWormSettings];
 
   uint64_t hash;
 };
 
 template <int L, int H, typename T>
-inline T limit(T v) {
+inline T Limit(T v) {
   if (v >= (T)H)
     return (T)H - 1;
   else if (v < (T)L)

--- a/src/game/sobject.cpp
+++ b/src/game/sobject.cpp
@@ -185,7 +185,7 @@ void SObjectType::Create(Game& game, int x, int y, int owner_idx, WormWeapon* fi
             PalIdx pix = game.level.Pixel(x, y);
             int angle = game.rand(128);
             common.nobject_types[2].Create2(game, angle, fixedvec(), Itof(IVec2(x, y)), pix,
-                                           owner_idx, fired_by);
+                                            owner_idx, fired_by);
           }
         }
     }

--- a/src/game/sobject.cpp
+++ b/src/game/sobject.cpp
@@ -11,213 +11,213 @@
 #include "viewport.hpp"
 #include "worm.hpp"
 
-void SObjectType::create(Game& game, int x, int y, int ownerIdx, WormWeapon* firedBy,
+void SObjectType::Create(Game& game, int x, int y, int owner_idx, WormWeapon* fired_by,
                          WObject* from) {
   Common& common = *game.common;
-  SObject& obj = *game.sobjects.newObjectReuse();
+  SObject& obj = *game.sobjects.NewObjectReuse();
 
-  assert(numSounds < 10);
+  assert(num_sounds < 10);
 
-  if (startSound >= 0) game.soundPlayer->play(game.rand(numSounds) + startSound);
+  if (start_sound >= 0) game.sound_player->Play(game.rand(num_sounds) + start_sound);
 
   for (std::size_t i = 0; i < game.viewports.size(); ++i) {
     Viewport& v = *game.viewports[i];
 
-    if (x > v.x && x < v.x + v.rect.width() && y > v.y && y < v.y + v.rect.height()) {
-      if (itof(shake) > v.shake) v.shake = itof(shake);
+    if (x > v.x && x < v.x + v.rect.Width() && y > v.y && y < v.y + v.rect.Height()) {
+      if (Itof(shake) > v.shake) v.shake = Itof(shake);
     }
   }
 
   obj.id = id;
   obj.x = x - 8;
   obj.y = y - 8;
-  obj.curFrame = 0;
-  obj.animDelay = animDelay;
+  obj.cur_frame = 0;
+  obj.anim_delay = anim_delay;
 
-  if (flash > game.screenFlash) {
-    game.screenFlash = flash;
+  if (flash > game.screen_flash) {
+    game.screen_flash = flash;
   }
 
-  Worm* owner = game.wormByIdx(ownerIdx);
+  Worm* owner = game.WormByIdx(owner_idx);
 
-  game.statsRecorder->damagePotential(owner, firedBy, damage);
+  game.stats_recorder->DamagePotential(owner, fired_by, damage);
 
   if (damage > 0) {
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm& w = *game.worms[i];
 
-      int wix = ftoi(w.pos.x);
-      int wiy = ftoi(w.pos.y);
+      int wix = Ftoi(w.pos.x);
+      int wiy = Ftoi(w.pos.y);
 
-      if (wix < x + detectRange && wix > x - detectRange && wiy < y + detectRange &&
-          wiy > y - detectRange) {
+      if (wix < x + detect_range && wix > x - detect_range && wiy < y + detect_range &&
+          wiy > y - detect_range) {
         int delta = wix - x;
-        int power = detectRange - std::abs(delta);
-        int powerSum = power;
+        int power = detect_range - std::abs(delta);
+        int power_sum = power;
 
-        if (std::abs(w.vel.x) < itof(2))  // TODO: Read from EXE
+        if (std::abs(w.vel.x) < Itof(2))  // TODO: Read from EXE
         {
           if (delta > 0)
-            w.vel.x += blowAway * power;
+            w.vel.x += blow_away * power;
           else
-            w.vel.x -= blowAway * power;
+            w.vel.x -= blow_away * power;
         }
 
         delta = wiy - y;
-        power = detectRange - std::abs(delta);
-        powerSum = (powerSum + power) / 2;
+        power = detect_range - std::abs(delta);
+        power_sum = (power_sum + power) / 2;
 
-        if (std::abs(w.vel.y) < itof(2))  // TODO: Read from EXE
+        if (std::abs(w.vel.y) < Itof(2))  // TODO: Read from EXE
         {
           if (delta > 0)
-            w.vel.y += blowAway * power;
+            w.vel.y += blow_away * power;
           else
-            w.vel.y -= blowAway * power;
+            w.vel.y -= blow_away * power;
         }
 
-        int z = damage * powerSum;
-        if (detectRange) z /= detectRange;
+        int z = damage * power_sum;
+        if (detect_range) z /= detect_range;
 
-        if (from && !from->hasHit) {
-          game.statsRecorder->hit(owner, firedBy, &w);
-          from->hasHit = true;
+        if (from && !from->has_hit) {
+          game.stats_recorder->Hit(owner, fired_by, &w);
+          from->has_hit = true;
         }
 
         if (w.health > 0) {
-          game.doDamage(w, z, ownerIdx);
-          game.statsRecorder->damageDealt(owner, firedBy, &w, z, false);
+          game.DoDamage(w, z, owner_idx);
+          game.stats_recorder->DamageDealt(owner, fired_by, &w, z, false);
 
-          int bloodAmount = game.settings->blood * powerSum / 100;
+          int blood_amount = game.settings->blood * power_sum / 100;
 
-          if (bloodAmount > 0) {
-            for (int i = 0; i < bloodAmount; ++i) {
+          if (blood_amount > 0) {
+            for (int i = 0; i < blood_amount; ++i) {
               int angle = game.rand(128);
-              common.nobjectTypes[6].create2(game, angle, w.vel / 3, w.pos, 0, w.index, firedBy);
+              common.nobject_types[6].Create2(game, angle, w.vel / 3, w.pos, 0, w.index, fired_by);
             }
           }
 
           if (game.rand(3) == 0) {
             int snd = 18 + game.rand(3);  // NOTE: MUST be outside the unpredictable branch below
-            if (!game.soundPlayer->isPlaying(&w)) {
-              game.soundPlayer->play(snd, &w);
+            if (!game.sound_player->IsPlaying(&w)) {
+              game.sound_player->Play(snd, &w);
             }
           }
         }
       }
     }  // for( ... worms ...
 
-    int objBlowAway = blowAway / 3;  // TODO: Read from EXE
+    int obj_blow_away = blow_away / 3;  // TODO: Read from EXE
 
-    auto wr = game.wobjects.all();
-    for (WObject* i; (i = wr.next());) {
+    auto wr = game.wobjects.All();
+    for (WObject* i; (i = wr.Next());) {
       Weapon const& weapon = *i->type;
 
-      if (weapon.affectByExplosions) {
-        auto ipos = ftoi(i->pos);
-        if (ipos.x < x + detectRange && ipos.x > x - detectRange && ipos.y < y + detectRange &&
-            ipos.y > y - detectRange) {
+      if (weapon.affect_by_explosions) {
+        auto ipos = Ftoi(i->pos);
+        if (ipos.x < x + detect_range && ipos.x > x - detect_range && ipos.y < y + detect_range &&
+            ipos.y > y - detect_range) {
           int delta = ipos.x - x;
-          int power = detectRange - std::abs(delta);
+          int power = detect_range - std::abs(delta);
 
           if (power > 0) {
             if (delta > 0)
-              i->vel.x += objBlowAway * power;
+              i->vel.x += obj_blow_away * power;
             else if (delta < 0)
-              i->vel.x -= objBlowAway * power;
+              i->vel.x -= obj_blow_away * power;
           }
 
           delta = ipos.y - y;
-          power = detectRange - std::abs(delta);
+          power = detect_range - std::abs(delta);
 
           if (power > 0) {
             if (delta > 0)
-              i->vel.y += objBlowAway * power;
+              i->vel.y += obj_blow_away * power;
             else if (delta < 0)
-              i->vel.y -= objBlowAway * power;
+              i->vel.y -= obj_blow_away * power;
           }
 
-          if (weapon.chainExplosion) i->blowUpObject(game, ownerIdx);
+          if (weapon.chain_explosion) i->BlowUpObject(game, owner_idx);
         }
       }  // if( ... affectByExplosions ...
     }  // for( ... wobjects ...
 
-    auto nr = game.nobjects.all();
-    for (NObject* i; (i = nr.next());) {
+    auto nr = game.nobjects.All();
+    for (NObject* i; (i = nr.Next());) {
       NObjectType const& t = *i->type;
 
-      if (t.affectByExplosions) {
-        auto ipos = ftoi(i->pos);
-        if (ipos.x < x + detectRange && ipos.x > x - detectRange && ipos.y < y + detectRange &&
-            ipos.y > y - detectRange) {
+      if (t.affect_by_explosions) {
+        auto ipos = Ftoi(i->pos);
+        if (ipos.x < x + detect_range && ipos.x > x - detect_range && ipos.y < y + detect_range &&
+            ipos.y > y - detect_range) {
           int delta = ipos.x - x;
-          int power = detectRange - std::abs(delta);
+          int power = detect_range - std::abs(delta);
 
           if (power > 0) {
             if (delta > 0)
-              i->vel.x += objBlowAway * power;
+              i->vel.x += obj_blow_away * power;
             else if (delta < 0)
-              i->vel.x -= objBlowAway * power;
+              i->vel.x -= obj_blow_away * power;
           }
 
           delta = ipos.y - y;
-          power = detectRange - std::abs(delta);
+          power = detect_range - std::abs(delta);
 
           if (power > 0) {
             if (delta > 0)
-              i->vel.y += objBlowAway * power;
+              i->vel.y += obj_blow_away * power;
             else if (delta < 0)
-              i->vel.y -= objBlowAway * power;
+              i->vel.y -= obj_blow_away * power;
           }
         }
       }
     }
 
     {
-      int width = detectRange / 2;
+      int width = detect_range / 2;
 
       Rect rect(x - width, y - width, x + width + 1, y + width + 1);
 
-      rect.intersect(game.level.rect());
+      rect.Intersect(game.level.Bounds());
 
       for (int y = rect.y1; y < rect.y2; ++y)
         for (int x = rect.x1; x < rect.x2; ++x) {
-          if (game.level.mat(x, y).anyDirt() && game.rand(8) == 0) {
-            PalIdx pix = game.level.pixel(x, y);
+          if (game.level.Mat(x, y).AnyDirt() && game.rand(8) == 0) {
+            PalIdx pix = game.level.Pixel(x, y);
             int angle = game.rand(128);
-            common.nobjectTypes[2].create2(game, angle, fixedvec(), itof(IVec2(x, y)), pix,
-                                           ownerIdx, firedBy);
+            common.nobject_types[2].Create2(game, angle, fixedvec(), Itof(IVec2(x, y)), pix,
+                                           owner_idx, fired_by);
           }
         }
     }
 
   }  // if(damage ...
 
-  if (dirtEffect >= 0) {
-    drawDirtEffect(common, game.rand, game.level, dirtEffect, x - 7, y - 7);
+  if (dirt_effect >= 0) {
+    DrawDirtEffect(common, game.rand, game.level, dirt_effect, x - 7, y - 7);
 
     if (game.settings->shadow)
-      correctShadow(common, game.level, Rect(x - 10, y - 10, x + 11, y + 11));
+      CorrectShadow(common, game.level, Rect(x - 10, y - 10, x + 11, y + 11));
   }
 
-  auto br = game.bonuses.all();
-  for (Bonus* i; (i = br.next());) {
-    int ix = ftoi(i->x), iy = ftoi(i->y);
+  auto br = game.bonuses.All();
+  for (Bonus* i; (i = br.Next());) {
+    int ix = Ftoi(i->x), iy = Ftoi(i->y);
 
-    if (ix > x - detectRange && ix < x + detectRange && iy > y - detectRange &&
-        iy < y + detectRange) {
-      game.bonuses.free(br);
-      common.sobjectTypes[0].create(game, ix, iy, ownerIdx, firedBy);
+    if (ix > x - detect_range && ix < x + detect_range && iy > y - detect_range &&
+        iy < y + detect_range) {
+      game.bonuses.Free(br);
+      common.sobject_types[0].Create(game, ix, iy, owner_idx, fired_by);
     }
   }  // for( ... bonuses ...
 }
 
-void SObject::process(Game& game) {
+void SObject::Process(Game& game) {
   Common& common = *game.common;
-  SObjectType& t = common.sobjectTypes[id];
+  SObjectType& t = common.sobject_types[id];
 
-  if (--animDelay <= 0) {
-    animDelay = t.animDelay;
-    ++curFrame;
-    if (curFrame > t.numFrames) game.sobjects.free(this);
+  if (--anim_delay <= 0) {
+    anim_delay = t.anim_delay;
+    ++cur_frame;
+    if (cur_frame > t.num_frames) game.sobjects.Free(this);
   }
 }

--- a/src/game/sobject.hpp
+++ b/src/game/sobject.hpp
@@ -16,39 +16,39 @@ and worms. Their usual usage is to make explosions or non-movable trails. Like o
 objects, they are indexed by their order in the array (counting started from 0).
 */
 struct SObjectType {
-  void create(Game& game, int x, int y, int ownedIdx, WormWeapon* firedBy, WObject* from = 0);
+  void Create(Game& game, int x, int y, int owned_idx, WormWeapon* fired_by, WObject* from = 0);
 
   /*
   which sound will be played when the object is created; set -1 for no sound.
   startSound is first index used...
   */
-  int startSound;
+  int start_sound;
   /*
   ...and numSounds is amount of indices used to pick the starting sound from.
   */
-  int numSounds;
+  int num_sounds;
   /*
   Delay time (in frames) before advancing to next frame during object animation.
   */
-  int animDelay;
+  int anim_delay;
   /*
   First sprite of animation used for the object.
   Note: unlike for wObjects and nObjects, sObjects always start at proper startFrame.
   So if you set it to -1, weird things are gonna happen on sObject animation and the game can even
   freeze.
   */
-  int startFrame;
+  int start_frame;
   /*
   Amount of sprites to use to animate the object, starting with "startFrame".
   */
-  int numFrames;
+  int num_frames;
   /*
   Maximum range of the sObject when it begins to affect the worm.
   Note: if detectRange ⩽ 0, then the worm will not receive damage from the object and also blowAway
   parameter will not work. Note: if you set detectRange > 0, bonuses (weapon/health boxes) will
   still explode on a collision with such sObject even if its damage equals 0.
   */
-  int detectRange;
+  int detect_range;
   /*
   Damage applied to the worm if it's in explosion range (vide detectRange parameter).
   Note: this is affected by how far the worm is from the epicenter of the explosion (the position of
@@ -63,7 +63,7 @@ struct SObjectType {
   Force applied on the worm as pushback. Can also be negative.
   Note: works only if detectRange > 0 and damage > 0.
   */
-  int blowAway;
+  int blow_away;
   /*
   Whether the sObject should create a shadow.
   */
@@ -79,17 +79,17 @@ struct SObjectType {
   /*
   Which dirt mask to use on object creation. Set -1 for none.
   */
-  int dirtEffect;
+  int dirt_effect;
 
   int id;
-  std::string idStr;
+  std::string id_str;
 };
 
 struct SObject : ExactObjectListBase {
-  void process(Game& game);
+  void Process(Game& game);
 
   int x, y;
   int id;  // type
-  int curFrame;
-  int animDelay;
+  int cur_frame;
+  int anim_delay;
 };

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -7,357 +7,357 @@
 #include "math.hpp"
 #include "text.hpp"
 
-void SpectatorViewport::process(Game& game) {
-  int realShake = ftoi(shake);
+void SpectatorViewport::Process(Game& game) {
+  int real_shake = Ftoi(shake);
 
   // FIXME this is a bit broken
-  if (game.wormByIdx(0)->killedTimer == Worm::KilledTimerInitial ||
-      game.wormByIdx(1)->killedTimer == Worm::KilledTimerInitial) {
-    bannerY = -8;
+  if (game.WormByIdx(0)->killed_timer == Worm::kKilledTimerInitial ||
+      game.WormByIdx(1)->killed_timer == Worm::kKilledTimerInitial) {
+    banner_y = -8;
   }
 
-  if (realShake > 0) {
-    x += rand(realShake * 2) - realShake;
-    y += rand(realShake * 2) - realShake;
+  if (real_shake > 0) {
+    x += rand(real_shake * 2) - real_shake;
+    y += rand(real_shake * 2) - real_shake;
   }
 
   if (x < 0) x = 0;
   if (y < 0) y = 0;
-  if (x > maxX) x = maxX;
-  if (y > maxY) y = maxY;
+  if (x > max_x) x = max_x;
+  if (y > max_y) y = max_y;
 }
 
-void SpectatorViewport::draw(Game& game, Renderer& renderer, GameState state, bool isReplay) {
+void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_replay) {
   Common& common = *game.common;
-  int multiplier = renderer.renderResX / 320;
-  int centerX = renderer.renderResX / 2;
-  IVec2 renderPos(x, y);
-  fixedvec offs = rect.ul() - renderPos;
+  int multiplier = renderer.render_res_x / 320;
+  int center_x = renderer.render_res_x / 2;
+  IVec2 render_pos(x, y);
+  fixedvec offs = rect.Ul() - render_pos;
 
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm const& worm = *game.worms[i];
-    int offsetX = offs.x / (i + 1);
+    int offset_x = offs.x / (i + 1);
     // fix misalignment. Not sure why this is needed
     if (i == 1) {
-      offsetX += 2;
+      offset_x += 2;
     }
-    int offsetWeaponListX = centerX - 15 + (i == 0 ? -90 : 60);
+    int offset_weapon_list_x = center_x - 15 + (i == 0 ? -90 : 60);
     if (worm.visible) {
-      int lifebarWidth = worm.health * 100 / worm.settings->health;
-      drawBar(renderer.bmp, offsetX + worm.statsX * multiplier, renderer.renderResY - 39,
-              lifebarWidth, lifebarWidth / 10 + 234);
+      int lifebar_width = worm.health * 100 / worm.settings->health;
+      DrawBar(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 39,
+              lifebar_width, lifebar_width / 10 + 234);
     } else {
-      int lifebarWidth = 100 - (worm.killedTimer * 25) / 37;
-      if (lifebarWidth > 0) {
-        if (lifebarWidth > 100) lifebarWidth = 100;
-        drawBar(renderer.bmp, offsetX + worm.statsX * multiplier, renderer.renderResY - 39,
-                lifebarWidth, lifebarWidth / 10 + 234);
+      int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
+      if (lifebar_width > 0) {
+        if (lifebar_width > 100) lifebar_width = 100;
+        DrawBar(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 39,
+                lifebar_width, lifebar_width / 10 + 234);
       }
     }
 
     // Draw kills status
 
-    WormWeapon const& ww = worm.weapons[worm.currentWeapon];
+    WormWeapon const& ww = worm.weapons[worm.current_weapon];
 
-    if (ww.available()) {
+    if (ww.Available()) {
       if (ww.ammo > 0) {
-        int ammoBarWidth = ww.ammo * 100 / ww.type->ammo;
+        int ammo_bar_width = ww.ammo * 100 / ww.type->ammo;
 
-        if (ammoBarWidth > 0)
-          drawBar(renderer.bmp, offsetX + worm.statsX * multiplier, renderer.renderResY - 34,
-                  ammoBarWidth, ammoBarWidth / 10 + 245);
+        if (ammo_bar_width > 0)
+          DrawBar(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 34,
+                  ammo_bar_width, ammo_bar_width / 10 + 245);
       }
     } else {
-      int ammoBarWidth = 0;
+      int ammo_bar_width = 0;
 
-      if (ww.type->loadingTime != 0) {
-        int computedLoadingTime = ww.type->computedLoadingTime(*game.settings);
-        ammoBarWidth = 100 - ww.loadingLeft * 100 / computedLoadingTime;
+      if (ww.type->loading_time != 0) {
+        int computed_loading_time = ww.type->ComputedLoadingTime(*game.settings);
+        ammo_bar_width = 100 - ww.loading_left * 100 / computed_loading_time;
       } else {
-        ammoBarWidth = 100 - ww.loadingLeft * 100;
+        ammo_bar_width = 100 - ww.loading_left * 100;
       }
 
-      if (ammoBarWidth > 0)
-        drawBar(renderer.bmp, offsetX + worm.statsX * multiplier, renderer.renderResY - 34,
-                ammoBarWidth, ammoBarWidth / 10 + 245);
+      if (ammo_bar_width > 0)
+        DrawBar(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 34,
+                ammo_bar_width, ammo_bar_width / 10 + 245);
 
       if ((game.cycles % 20) > 10 && worm.visible) {
-        common.font.drawText(renderer.bmp, LS(Reloading), offsetX + worm.statsX * multiplier, 164,
+        common.font.DrawText(renderer.bmp, LS(Reloading), offset_x + worm.stats_x * multiplier, 164,
                              50);
       }
     }
 
-    common.font.drawText(renderer.bmp, (LS(Kills) + toString(worm.kills)),
-                         offsetX + worm.statsX * multiplier, renderer.renderResY - 29, 10);
+    common.font.DrawText(renderer.bmp, (LS(Kills) + ToString(worm.kills)),
+                         offset_x + worm.stats_x * multiplier, renderer.render_res_y - 29, 10);
 
     // always display player names, color and time in spectator view
-    common.font.drawText(renderer.bmp, worm.settings->name, offsetX + worm.statsX * multiplier,
-                         renderer.renderResY - 15, 7);
-    fillRect(renderer.bmp, offsetX + worm.statsX * multiplier - 1, renderer.renderResY - 7 - 1, 8,
+    common.font.DrawText(renderer.bmp, worm.settings->name, offset_x + worm.stats_x * multiplier,
+                         renderer.render_res_y - 15, 7);
+    FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier - 1, renderer.render_res_y - 7 - 1, 8,
              8, 7);
-    fillRect(renderer.bmp, offsetX + worm.statsX * multiplier, renderer.renderResY - 7, 6, 6,
+    FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 7, 6, 6,
              worm.settings->color);
     // time
     // FIXME: only draw this once, not once per worm
-    common.font.drawText(renderer.bmp, timeToStringEx(game.cycles * 14, false, true), centerX - 15,
-                         renderer.renderResY - 15, 7);
+    common.font.DrawText(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true), center_x - 15,
+                         renderer.render_res_y - 15, 7);
 
     // draw available/selected weapons
-    if (state == StateGame) {
+    if (state == kStateGame) {
       for (int i = 0; i < 5; i++) {
         WormWeapon const& ww = worm.weapons[i];
         if (ww.ammo > 0) {
-          int ammoBarWidth = ww.ammo * 60 / ww.type->ammo;
+          int ammo_bar_width = ww.ammo * 60 / ww.type->ammo;
 
-          if (ammoBarWidth > 0) {
-            drawBar(renderer.bmp, offsetWeaponListX, renderer.renderResY - 40 + i * 8, ammoBarWidth,
-                    5, ammoBarWidth / 6 + 245);
+          if (ammo_bar_width > 0) {
+            DrawBar(renderer.bmp, offset_weapon_list_x, renderer.render_res_y - 40 + i * 8, ammo_bar_width,
+                    5, ammo_bar_width / 6 + 245);
           }
         }
-        if (worm.currentWeapon == i) {
-          common.font.drawText(renderer.bmp, worm.weapons[i].type->name, offsetWeaponListX,
-                               renderer.renderResY - 40 + i * 8, 187);
+        if (worm.current_weapon == i) {
+          common.font.DrawText(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
+                               renderer.render_res_y - 40 + i * 8, 187);
         } else {
-          common.font.drawText(renderer.bmp, worm.weapons[i].type->name, offsetWeaponListX,
-                               renderer.renderResY - 40 + i * 8, 185);
+          common.font.DrawText(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
+                               renderer.render_res_y - 40 + i * 8, 185);
         }
       }
     }
 
-    int const stateColours[2][2] = {{6, 10}, {79, 4}};
+    int const kStateColours[2][2] = {{6, 10}, {79, 4}};
 
-    switch (game.settings->gameMode) {
-      case Settings::GMKillEmAll:
-      case Settings::GMScalesOfJustice: {
-        common.font.drawText(renderer.bmp, (LS(Lives) + toString(worm.lives)),
-                             offsetX + worm.statsX * multiplier, renderer.renderResY - 22, 6);
+    switch (game.settings->game_mode) {
+      case Settings::kGmKillEmAll:
+      case Settings::kGmScalesOfJustice: {
+        common.font.DrawText(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
+                             offset_x + worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
       } break;
 
-      case Settings::GMHoldazone: {
+      case Settings::kGmHoldazone: {
         int state = 0;
 
         for (auto const& w : game.worms)
           if (w.get() != &worm && w->timer <= worm.timer) state = 1;
 
-        int color = stateColours[game.holdazone.holderIdx != worm.index][state];
+        int color = kStateColours[game.holdazone.holder_idx != worm.index][state];
 
-        common.font.drawText(renderer.bmp, timeToString(worm.timer), 5, 106 + 84 * worm.index,
-                             renderer.renderResY - 39, color);
+        common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                             renderer.render_res_y - 39, color);
       } break;
 
-      case Settings::GMGameOfTag: {
+      case Settings::kGmGameOfTag: {
         int state = 0;
 
         for (auto const& w : game.worms)
           if (w.get() != &worm && w->timer >= worm.timer) state = 1;
 
-        int color = stateColours[game.lastKilledIdx != worm.index][state];
+        int color = kStateColours[game.last_killed_idx != worm.index][state];
 
-        common.font.drawText(renderer.bmp, timeToString(worm.timer), 5, 106 + 84 * worm.index,
-                             renderer.renderResY - 39, color);
+        common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                             renderer.render_res_y - 39, color);
       } break;
     }
   }
 
-  blitImageNoKeyColour(renderer.bmp, &game.level.data[0], offs.x, offs.y, game.level.width,
+  BlitImageNoKeyColour(renderer.bmp, &game.level.data[0], offs.x, offs.y, game.level.width,
                        game.level.height);
 
-  if (game.settings->gameMode == Settings::GMHoldazone) {
-    bool timingOut = game.holdazone.timeoutLeft < 70 * 4;
+  if (game.settings->game_mode == Settings::kGmHoldazone) {
+    bool timing_out = game.holdazone.timeout_left < 70 * 4;
 
-    int color = timingOut ? 168 : 50;
-    int contenderColor;
+    int color = timing_out ? 168 : 50;
+    int contender_color;
 
-    if (game.holdazone.contenderIdx >= 0) {
-      Worm* contender = game.wormByIdx(game.holdazone.contenderIdx);
-      if (timingOut)
-        contenderColor = contender->minimapColor();
+    if (game.holdazone.contender_idx >= 0) {
+      Worm* contender = game.WormByIdx(game.holdazone.contender_idx);
+      if (timing_out)
+        contender_color = contender->MinimapColor();
       else
-        contenderColor = Palette::wormColourIndexes[contender->index] + 5;
+        contender_color = Palette::kWormColourIndexes[contender->index] + 5;
     } else {
-      contenderColor = color;
+      contender_color = color;
     }
 
-    drawDashedLineBox(renderer.bmp, game.holdazone.rect.x1 + offs.x,
-                      game.holdazone.rect.y1 + offs.y, color, contenderColor,
-                      game.holdazone.contenderFrames, game.settings->zoneCaptureTime,
-                      game.holdazone.rect.width(), game.holdazone.rect.height(), game.cycles / 10);
+    DrawDashedLineBox(renderer.bmp, game.holdazone.rect.x1 + offs.x,
+                      game.holdazone.rect.y1 + offs.y, color, contender_color,
+                      game.holdazone.contender_frames, game.settings->kZoneCaptureTime,
+                      game.holdazone.rect.Width(), game.holdazone.rect.Height(), game.cycles / 10);
   }
 
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm const& worm = *game.worms[i];
-    if (!worm.visible && worm.killedTimer <= 0 && !worm.ready) {
-      if (game.settings->allowViewingSpawnPoint && worm.pressed(Worm::Change)) {
-        int tempX = ftoi(worm.pos.x) - 7 + offs.x;
-        int tempY = ftoi(worm.pos.y) - 5 + offs.y;
+    if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
+      if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
+        int temp_x = Ftoi(worm.pos.x) - 7 + offs.x;
+        int temp_y = Ftoi(worm.pos.y) - 5 + offs.y;
 
-        blitImageTrans(renderer.bmp,
-                       common.wormSpriteObj(worm.currentFrame, worm.direction, worm.index), tempX,
-                       tempY, game.cycles);
+        BlitImageTrans(renderer.bmp,
+                       common.WormSpriteObj(worm.current_frame, worm.direction, worm.index), temp_x,
+                       temp_y, game.cycles);
       }
     }
 
-    if (bannerY > -8 && worm.health <= 0) {
-      if (game.settings->gameMode == Settings::GMGameOfTag && game.gotChanged) {
-        common.font.drawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, bannerY + 1, 0);
-        common.font.drawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, bannerY, 50);
+    if (banner_y > -8 && worm.health <= 0) {
+      if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
+        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
       }
     }
   }
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm const& worm = *game.worms[i];
-    if (worm.health <= 0 && bannerY > -8) {
-      if (worm.lastKilledByIdx == worm.index) {
+    if (worm.health <= 0 && banner_y > -8) {
+      if (worm.last_killed_by_idx == worm.index) {
         std::string msg(worm.settings->name + LS(CommittedSuicideMsg));
-        common.font.drawText(renderer.bmp, msg, rect.x1 + 3, bannerY + 1, 0);
-        common.font.drawText(renderer.bmp, msg, rect.x1 + 2, bannerY, 50);
+        common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
       } else {
-        std::string msg(game.worms[worm.lastKilledByIdx]->settings->name + " killed " +
+        std::string msg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
                         worm.settings->name);
-        common.font.drawText(renderer.bmp, msg, rect.x1 + 3, bannerY + 1, 0);
-        common.font.drawText(renderer.bmp, msg, rect.x1 + 2, bannerY, 50);
+        common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
       }
     }
   }
 
-  auto br = game.bonuses.all();
-  for (Bonus* i; (i = br.next());) {
+  auto br = game.bonuses.All();
+  for (Bonus* i; (i = br.Next());) {
     if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
-      int f = common.bonusFrames[i->frame];
+      int f = common.bonus_frames[i->frame];
 
-      blitImage(renderer.bmp, common.smallSprites[f], ftoi(i->x) - 3 + offs.x,
-                ftoi(i->y) - 3 + offs.y);
+      BlitImage(renderer.bmp, common.small_sprites[f], Ftoi(i->x) - 3 + offs.x,
+                Ftoi(i->y) - 3 + offs.y);
 
       if (game.settings->shadow) {
-        blitShadowImage(common, renderer.bmp, common.smallSprites.spritePtr(f),
-                        ftoi(i->x) - 5 + offs.x,  // TODO: Use offsX
-                        ftoi(i->y) - 1 + offs.y, 7, 7);
+        BlitShadowImage(common, renderer.bmp, common.small_sprites.SpritePtr(f),
+                        Ftoi(i->x) - 5 + offs.x,  // TODO: Use offsX
+                        Ftoi(i->y) - 1 + offs.y, 7, 7);
       }
 
-      if (game.settings->namesOnBonuses && i->frame == 0) {
+      if (game.settings->names_on_bonuses && i->frame == 0) {
         std::string const& name = common.weapons[i->weapon].name;
         int len = int(name.size()) * 4;
 
-        common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(i->x) - len / 2 + offs.x,
-                             ftoi(i->y) - 10 + offs.y);
+        common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->x) - len / 2 + offs.x,
+                             Ftoi(i->y) - 10 + offs.y);
       }
     }
   }
 
-  auto sr = game.sobjects.all();
-  for (SObject* i; (i = sr.next());) {
-    SObjectType const& t = common.sobjectTypes[i->id];
-    int frame = i->curFrame + t.startFrame;
+  auto sr = game.sobjects.All();
+  for (SObject* i; (i = sr.Next());) {
+    SObjectType const& t = common.sobject_types[i->id];
+    int frame = i->cur_frame + t.start_frame;
 
-    blitImageR(renderer.bmp, common.largeSprites.spritePtr(frame), i->x + offs.x, i->y + offs.y, 16,
+    BlitImageR(renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x, i->y + offs.y, 16,
                16);
 
     if (game.settings->shadow) {
-      blitShadowImage(common, renderer.bmp, common.largeSprites.spritePtr(frame), i->x + offs.x - 3,
+      BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x - 3,
                       i->y + offs.y + 3,  // TODO: Original doesn't offset the shadow, which is
                                           // clearly wrong. Check that this offset is correct.
                       16, 16);
     }
   }
 
-  auto wr = game.wobjects.all();
-  for (WObject* i; (i = wr.next());) {
+  auto wr = game.wobjects.All();
+  for (WObject* i; (i = wr.Next());) {
     Weapon const& w = *i->type;
 
-    if (w.startFrame > -1) {
-      int curFrame = i->curFrame;
-      int shotType = w.shotType;
+    if (w.start_frame > -1) {
+      int cur_frame = i->cur_frame;
+      int shot_type = w.shot_type;
 
-      if (shotType == 2) {
-        curFrame += 4;
-        curFrame >>= 3;
-        if (curFrame < 0)
-          curFrame = 16;
-        else if (curFrame > 15)
-          curFrame -= 16;
-      } else if (shotType == 3) {
-        if (curFrame > 64) --curFrame;
-        curFrame -= 12;
-        curFrame >>= 3;
-        if (curFrame < 0)
-          curFrame = 0;
-        else if (curFrame > 12)
-          curFrame = 12;
+      if (shot_type == 2) {
+        cur_frame += 4;
+        cur_frame >>= 3;
+        if (cur_frame < 0)
+          cur_frame = 16;
+        else if (cur_frame > 15)
+          cur_frame -= 16;
+      } else if (shot_type == 3) {
+        if (cur_frame > 64) --cur_frame;
+        cur_frame -= 12;
+        cur_frame >>= 3;
+        if (cur_frame < 0)
+          cur_frame = 0;
+        else if (cur_frame > 12)
+          cur_frame = 12;
       }
 
-      int posX = ftoi(i->pos.x) - 3;
-      int posY = ftoi(i->pos.y) - 3;
+      int pos_x = Ftoi(i->pos.x) - 3;
+      int pos_y = Ftoi(i->pos.y) - 3;
 
       if (game.settings->shadow && w.shadow) {
-        blitShadowImage(common, renderer.bmp,
-                        common.smallSprites.spritePtr(w.startFrame + curFrame), posX - 3 + offs.x,
-                        posY + 3 + offs.y, 7, 7);
+        BlitShadowImage(common, renderer.bmp,
+                        common.small_sprites.SpritePtr(w.start_frame + cur_frame), pos_x - 3 + offs.x,
+                        pos_y + 3 + offs.y, 7, 7);
       }
 
-      blitImage(renderer.bmp, common.smallSprites[w.startFrame + curFrame], posX + offs.x,
-                posY + offs.y);
-    } else if (i->curFrame > 0) {
-      int posX = ftoi(i->pos.x) - x + rect.x1;
-      int posY = ftoi(i->pos.y) - y + rect.y1;
+      BlitImage(renderer.bmp, common.small_sprites[w.start_frame + cur_frame], pos_x + offs.x,
+                pos_y + offs.y);
+    } else if (i->cur_frame > 0) {
+      int pos_x = Ftoi(i->pos.x) - x + rect.x1;
+      int pos_y = Ftoi(i->pos.y) - y + rect.y1;
 
-      if (renderer.bmp.clip_rect.inside(posX, posY))
-        renderer.bmp.getPixel(posX, posY) = static_cast<PalIdx>(i->curFrame);
+      if (renderer.bmp.clip_rect.Inside(pos_x, pos_y))
+        renderer.bmp.GetPixel(pos_x, pos_y) = static_cast<PalIdx>(i->cur_frame);
 
       if (game.settings->shadow) {
-        posX -= 3;
-        posY += 3;
+        pos_x -= 3;
+        pos_y += 3;
 
-        if (renderer.bmp.clip_rect.inside(posX, posY)) {
-          PalIdx& pix = renderer.bmp.getPixel(posX, posY);
-          if (common.materials[pix].seeShadow()) pix += 4;
+        if (renderer.bmp.clip_rect.Inside(pos_x, pos_y)) {
+          PalIdx& pix = renderer.bmp.GetPixel(pos_x, pos_y);
+          if (common.materials[pix].SeeShadow()) pix += 4;
         }
       }
     }
 
-    if (!common.H[HRemExp] && i->type - &common.weapons[0] == 34 &&
-        game.settings->namesOnBonuses)  // TODO: Read from EXE
+    if (!common.h[HRemExp] && i->type - &common.weapons[0] == 34 &&
+        game.settings->names_on_bonuses)  // TODO: Read from EXE
     {
-      if (i->curFrame == 0) {
-        int nameNum = int(&*i - game.wobjects.arr) %
+      if (i->cur_frame == 0) {
+        int name_num = int(&*i - game.wobjects.arr) %
                       (int)common.weapons.size();  // TODO: Something nicer maybe
 
-        std::string const& name = common.weapons[nameNum].name;
+        std::string const& name = common.weapons[name_num].name;
         int width = int(name.size()) * 4;
 
-        common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(i->pos.x) - width / 2 + offs.x,
-                             ftoi(i->pos.y) - 10 + offs.y);
+        common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->pos.x) - width / 2 + offs.x,
+                             Ftoi(i->pos.y) - 10 + offs.y);
       }
     }
   }
 
-  auto nr = game.nobjects.all();
-  for (NObject* i; (i = nr.next());) {
+  auto nr = game.nobjects.All();
+  for (NObject* i; (i = nr.Next());) {
     NObjectType const& t = *i->type;
 
-    if (t.startFrame > 0) {
-      auto pos = ftoi(i->pos) - IVec2(3, 3);
+    if (t.start_frame > 0) {
+      auto pos = Ftoi(i->pos) - IVec2(3, 3);
 
       if (game.settings->shadow) {
-        blitShadowImage(common, renderer.bmp,
-                        common.smallSprites.spritePtr(t.startFrame + i->curFrame),
+        BlitShadowImage(common, renderer.bmp,
+                        common.small_sprites.SpritePtr(t.start_frame + i->cur_frame),
                         pos.x - 3 + offs.x, pos.y + 3 + offs.y, 7, 7);
       }
 
-      blitImage(renderer.bmp, common.smallSprites[t.startFrame + i->curFrame], pos.x + offs.x,
+      BlitImage(renderer.bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + offs.x,
                 pos.y + offs.y);
 
-    } else if (i->curFrame > 1) {
-      auto pos = ftoi(i->pos) + offs;
-      if (renderer.bmp.clip_rect.encloses(pos))
-        renderer.bmp.getPixel(pos.x, pos.y) = PalIdx(i->curFrame);
+    } else if (i->cur_frame > 1) {
+      auto pos = Ftoi(i->pos) + offs;
+      if (renderer.bmp.clip_rect.Encloses(pos))
+        renderer.bmp.GetPixel(pos.x, pos.y) = PalIdx(i->cur_frame);
 
       if (game.settings->shadow) {
         pos.x -= 3;
         pos.y += 3;
 
-        if (renderer.bmp.clip_rect.encloses(pos)) {
-          PalIdx& pix = renderer.bmp.getPixel(pos.x, pos.y);
-          if (common.materials[pix].seeShadow()) pix += 4;
+        if (renderer.bmp.clip_rect.Encloses(pos)) {
+          PalIdx& pix = renderer.bmp.GetPixel(pos.x, pos.y);
+          if (common.materials[pix].SeeShadow()) pix += 4;
         }
       }
     }
@@ -367,61 +367,61 @@ void SpectatorViewport::draw(Game& game, Renderer& renderer, GameState state, bo
     Worm const& w = *game.worms[i];
 
     if (w.visible) {
-      int tempX = ftoi(w.pos.x) - 7 + offs.x;
-      int tempY = ftoi(w.pos.y) - 5 + offs.y;
-      int angleFrame = w.angleFrame();
+      int temp_x = Ftoi(w.pos.x) - 7 + offs.x;
+      int temp_y = Ftoi(w.pos.y) - 5 + offs.y;
+      int angle_frame = w.AngleFrame();
 
-      if (w.weapons[w.currentWeapon].available()) {
-        int hotspotX = w.hotspotX + offs.x;
-        int hotspotY = w.hotspotY + offs.y;
+      if (w.weapons[w.current_weapon].Available()) {
+        int hotspot_x = w.hotspot_x + offs.x;
+        int hotspot_y = w.hotspot_y + offs.y;
 
-        WormWeapon const& ww = w.weapons[w.currentWeapon];
+        WormWeapon const& ww = w.weapons[w.current_weapon];
         Weapon const& weapon = *ww.type;
 
-        if (weapon.laserSight) {
-          drawLaserSight(renderer.bmp, rand, hotspotX, hotspotY, tempX + 7, tempY + 4);
+        if (weapon.laser_sight) {
+          DrawLaserSight(renderer.bmp, rand, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4);
         }
 
-        if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.pressed(Worm::Fire)) {
-          drawLine(renderer.bmp, hotspotX, hotspotY, tempX + 7, tempY + 4, weapon.colorBullets);
+        if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
+          DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4, weapon.color_bullets);
         }
       }
 
       if (w.ninjarope.out) {
-        int ninjaropeX = ftoi(w.ninjarope.pos.x) + offs.x;
-        int ninjaropeY = ftoi(w.ninjarope.pos.y) + offs.y;
+        int ninjarope_x = Ftoi(w.ninjarope.pos.x) + offs.x;
+        int ninjarope_y = Ftoi(w.ninjarope.pos.y) + offs.y;
 
-        drawNinjarope(common, renderer.bmp, ninjaropeX, ninjaropeY, tempX + 7, tempY + 4);
+        DrawNinjarope(common, renderer.bmp, ninjarope_x, ninjarope_y, temp_x + 7, temp_y + 4);
 
-        blitImage(renderer.bmp, common.largeSprites[84], ninjaropeX - 1, ninjaropeY - 1);
+        BlitImage(renderer.bmp, common.large_sprites[84], ninjarope_x - 1, ninjarope_y - 1);
 
         if (game.settings->shadow) {
-          drawShadowLine(common, renderer.bmp, ninjaropeX - 3, ninjaropeY + 3, tempX + 7 - 3,
-                         tempY + 4 + 3);
-          blitShadowImage(common, renderer.bmp, common.largeSprites.spritePtr(84), ninjaropeX - 4,
-                          ninjaropeY + 2, 16, 16);
+          DrawShadowLine(common, renderer.bmp, ninjarope_x - 3, ninjarope_y + 3, temp_x + 7 - 3,
+                         temp_y + 4 + 3);
+          BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(84), ninjarope_x - 4,
+                          ninjarope_y + 2, 16, 16);
         }
       }
 
-      if (w.weapons[w.currentWeapon].type->fireCone > 0 && w.fireCone > 0) {
+      if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
         /* TODO
         //NOTE! Check fctab so it's correct
         //NOTE! Check function 1071C and see what it actually does*/
 
-        blitFireCone(renderer.bmp, w.fireCone / 2, common.fireConeSprite(angleFrame, w.direction),
-                     common.fireConeOffset[w.direction][angleFrame][0] + tempX,
-                     common.fireConeOffset[w.direction][angleFrame][1] + tempY);
+        BlitFireCone(renderer.bmp, w.fire_cone / 2, common.FireConeSprite(angle_frame, w.direction),
+                     common.fire_cone_offset[w.direction][angle_frame][0] + temp_x,
+                     common.fire_cone_offset[w.direction][angle_frame][1] + temp_y);
       }
 
-      blitImage(renderer.bmp, common.wormSpriteObj(w.currentFrame, w.direction, w.index), tempX,
-                tempY);
+      BlitImage(renderer.bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), temp_x,
+                temp_y);
       if (game.settings->shadow)
-        blitShadowImage(common, renderer.bmp,
-                        common.wormSprite(w.currentFrame, w.direction, w.index), tempX - 3,
-                        tempY + 3, 16, 16);
+        BlitShadowImage(common, renderer.bmp,
+                        common.WormSprite(w.current_frame, w.direction, w.index), temp_x - 3,
+                        temp_y + 3, 16, 16);
     }
 
-    if (w.ai) w.ai->drawDebug(game, w, renderer, offs.x, offs.y);
+    if (w.ai) w.ai->DrawDebug(game, w, renderer, offs.x, offs.y);
   }
 
   /*
@@ -440,35 +440,35 @@ void SpectatorViewport::draw(Game& game, Renderer& renderer, GameState state, bo
     Worm const& worm = *game.worms[i];
     if (worm.visible) {
       auto temp =
-          ftoi(worm.pos) - IVec2(1, 2) + ftoi(cossinTable[ftoi(worm.aimingAngle)] * 16) + offs;
+          Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16) + offs;
       // int tempX = ftoi(worm.pos.x) - 1 + ftoi(cosTable[ftoi(worm.aimingAngle)] * 16) + offs.x;
       // int tempY = ftoi(worm.pos.y) - 2 + ftoi(sinTable[ftoi(worm.aimingAngle)] * 16) + offs.y;
 
-      blitImage(renderer.bmp, common.smallSprites[worm.makeSightGreen ? 44 : 43], temp.x, temp.y);
+      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
 
-      if (worm.pressed(Worm::Change)) {
-        std::string const& name = worm.weapons[worm.currentWeapon].type->name;
+      if (worm.Pressed(Worm::kChange)) {
+        std::string const& name = worm.weapons[worm.current_weapon].type->name;
 
         int len = int(name.size()) * 4;  // TODO: Read 4 from exe? (SW_CHARWID)
 
-        common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(worm.pos.x) - len / 2 + 1 + offs.x,
-                             ftoi(worm.pos.y) - 10 + offs.y);
+        common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(worm.pos.x) - len / 2 + 1 + offs.x,
+                             Ftoi(worm.pos.y) - 10 + offs.y);
       }
     }
   }
 
-  for (Game::BObjectList::iterator i = game.bobjects.begin(); i != game.bobjects.end(); ++i) {
-    auto ipos = ftoi(i->pos) + offs;
-    if (renderer.bmp.clip_rect.encloses(ipos))
-      renderer.bmp.getPixel(ipos.x, ipos.y) = PalIdx(i->color);
+  for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
+    auto ipos = Ftoi(i->pos) + offs;
+    if (renderer.bmp.clip_rect.Encloses(ipos))
+      renderer.bmp.GetPixel(ipos.x, ipos.y) = PalIdx(i->color);
 
     if (game.settings->shadow) {
       ipos.x -= 3;
       ipos.y += 3;
 
-      if (renderer.bmp.clip_rect.encloses(ipos)) {
-        PalIdx& pix = renderer.bmp.getPixel(ipos.x, ipos.y);
-        if (common.materials[pix].seeShadow()) pix += 4;
+      if (renderer.bmp.clip_rect.Encloses(ipos)) {
+        PalIdx& pix = renderer.bmp.GetPixel(ipos.x, ipos.y);
+        if (common.materials[pix].SeeShadow()) pix += 4;
       }
     }
   }

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -93,8 +93,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     // always display player names, color and time in spectator view
     common.font.DrawText(renderer.bmp, worm.settings->name, offset_x + worm.stats_x * multiplier,
                          renderer.render_res_y - 15, 7);
-    FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier - 1, renderer.render_res_y - 7 - 1, 8,
-             8, 7);
+    FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier - 1, renderer.render_res_y - 7 - 1,
+             8, 8, 7);
     FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 7, 6, 6,
              worm.settings->color);
     // time
@@ -110,8 +110,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
           int ammo_bar_width = ww.ammo * 60 / ww.type->ammo;
 
           if (ammo_bar_width > 0) {
-            DrawBar(renderer.bmp, offset_weapon_list_x, renderer.render_res_y - 40 + i * 8, ammo_bar_width,
-                    5, ammo_bar_width / 6 + 245);
+            DrawBar(renderer.bmp, offset_weapon_list_x, renderer.render_res_y - 40 + i * 8,
+                    ammo_bar_width, 5, ammo_bar_width / 6 + 245);
           }
         }
         if (worm.current_weapon == i) {
@@ -249,11 +249,12 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     SObjectType const& t = common.sobject_types[i->id];
     int frame = i->cur_frame + t.start_frame;
 
-    BlitImageR(renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x, i->y + offs.y, 16,
-               16);
+    BlitImageR(renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x, i->y + offs.y,
+               16, 16);
 
     if (game.settings->shadow) {
-      BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x - 3,
+      BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(frame),
+                      i->x + offs.x - 3,
                       i->y + offs.y + 3,  // TODO: Original doesn't offset the shadow, which is
                                           // clearly wrong. Check that this offset is correct.
                       16, 16);
@@ -290,8 +291,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
       if (game.settings->shadow && w.shadow) {
         BlitShadowImage(common, renderer.bmp,
-                        common.small_sprites.SpritePtr(w.start_frame + cur_frame), pos_x - 3 + offs.x,
-                        pos_y + 3 + offs.y, 7, 7);
+                        common.small_sprites.SpritePtr(w.start_frame + cur_frame),
+                        pos_x - 3 + offs.x, pos_y + 3 + offs.y, 7, 7);
       }
 
       BlitImage(renderer.bmp, common.small_sprites[w.start_frame + cur_frame], pos_x + offs.x,
@@ -319,7 +320,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       if (i->cur_frame == 0) {
         int name_num = int(&*i - game.wobjects.arr) %
-                      (int)common.weapons.size();  // TODO: Something nicer maybe
+                       (int)common.weapons.size();  // TODO: Something nicer maybe
 
         std::string const& name = common.weapons[name_num].name;
         int width = int(name.size()) * 4;
@@ -383,7 +384,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
         }
 
         if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
-          DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4, weapon.color_bullets);
+          DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4,
+                   weapon.color_bullets);
         }
       }
 
@@ -444,7 +446,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       // int tempX = ftoi(worm.pos.x) - 1 + ftoi(cosTable[ftoi(worm.aimingAngle)] * 16) + offs.x;
       // int tempY = ftoi(worm.pos.y) - 2 + ftoi(sinTable[ftoi(worm.aimingAngle)] * 16) + offs.y;
 
-      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
+      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
+                temp.y);
 
       if (worm.Pressed(Worm::kChange)) {
         std::string const& name = worm.weapons[worm.current_weapon].type->name;

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -82,25 +82,25 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
                 ammo_bar_width, ammo_bar_width / 10 + 245);
 
       if ((game.cycles % 20) > 10 && worm.visible) {
-        common.font.DrawText(renderer.bmp, LS(Reloading), offset_x + worm.stats_x * multiplier, 164,
-                             50);
+        common.font.DrawString(renderer.bmp, LS(Reloading), offset_x + worm.stats_x * multiplier,
+                               164, 50);
       }
     }
 
-    common.font.DrawText(renderer.bmp, (LS(Kills) + ToString(worm.kills)),
-                         offset_x + worm.stats_x * multiplier, renderer.render_res_y - 29, 10);
+    common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)),
+                           offset_x + worm.stats_x * multiplier, renderer.render_res_y - 29, 10);
 
     // always display player names, color and time in spectator view
-    common.font.DrawText(renderer.bmp, worm.settings->name, offset_x + worm.stats_x * multiplier,
-                         renderer.render_res_y - 15, 7);
+    common.font.DrawString(renderer.bmp, worm.settings->name, offset_x + worm.stats_x * multiplier,
+                           renderer.render_res_y - 15, 7);
     FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier - 1, renderer.render_res_y - 7 - 1,
              8, 8, 7);
     FillRect(renderer.bmp, offset_x + worm.stats_x * multiplier, renderer.render_res_y - 7, 6, 6,
              worm.settings->color);
     // time
     // FIXME: only draw this once, not once per worm
-    common.font.DrawText(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true), center_x - 15,
-                         renderer.render_res_y - 15, 7);
+    common.font.DrawString(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true),
+                           center_x - 15, renderer.render_res_y - 15, 7);
 
     // draw available/selected weapons
     if (state == kStateGame) {
@@ -115,11 +115,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
           }
         }
         if (worm.current_weapon == i) {
-          common.font.DrawText(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
-                               renderer.render_res_y - 40 + i * 8, 187);
+          common.font.DrawString(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
+                                 renderer.render_res_y - 40 + i * 8, 187);
         } else {
-          common.font.DrawText(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
-                               renderer.render_res_y - 40 + i * 8, 185);
+          common.font.DrawString(renderer.bmp, worm.weapons[i].type->name, offset_weapon_list_x,
+                                 renderer.render_res_y - 40 + i * 8, 185);
         }
       }
     }
@@ -129,8 +129,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     switch (game.settings->game_mode) {
       case Settings::kGmKillEmAll:
       case Settings::kGmScalesOfJustice: {
-        common.font.DrawText(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
-                             offset_x + worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
+        common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
+                               offset_x + worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
       } break;
 
       case Settings::kGmHoldazone: {
@@ -141,8 +141,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
         int color = kStateColours[game.holdazone.holder_idx != worm.index][state];
 
-        common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                             renderer.render_res_y - 39, color);
+        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                               renderer.render_res_y - 39, color);
       } break;
 
       case Settings::kGmGameOfTag: {
@@ -153,8 +153,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
         int color = kStateColours[game.last_killed_idx != worm.index][state];
 
-        common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                             renderer.render_res_y - 39, color);
+        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                               renderer.render_res_y - 39, color);
       } break;
     }
   }
@@ -199,8 +199,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
     if (banner_y > -8 && worm.health <= 0) {
       if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
-        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
       }
     }
   }
@@ -209,13 +209,13 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     if (worm.health <= 0 && banner_y > -8) {
       if (worm.last_killed_by_idx == worm.index) {
         std::string msg(worm.settings->name + LS(CommittedSuicideMsg));
-        common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
+        common.font.DrawString(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
       } else {
         std::string msg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
                         worm.settings->name);
-        common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
+        common.font.DrawString(renderer.bmp, msg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, msg, rect.x1 + 2, banner_y, 50);
       }
     }
   }

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -13,6 +13,6 @@ struct SpectatorViewport : Viewport {
   SpectatorViewport(Rect rect, int levwidth, int levheight)
       : Viewport(rect, 0, levwidth, levheight) {}
 
-  void draw(Game& game, Renderer& renderer, GameState state, bool isReplay);
-  void process(Game& game);
+  void Draw(Game& game, Renderer& renderer, GameState state, bool is_replay);
+  void Process(Game& game);
 };

--- a/src/game/state.hpp
+++ b/src/game/state.hpp
@@ -13,29 +13,29 @@ struct AppState {
   virtual ~AppState() = default;
 
   // Called once when the state is pushed onto the stack.
-  virtual void enter() {}
+  virtual void Enter() {}
 
   // Called once when the state is popped from the stack.
-  virtual void leave() {}
+  virtual void Leave() {}
 
   // Handle a single SDL event. Called once per event during the frame's
   // event processing phase.
-  virtual void handleEvent(SDL_Event& ev) = 0;
+  virtual void HandleEvent(SDL_Event& ev) = 0;
 
   // Advance the state by one frame tick.
   // Return false to signal that this state is done and should be popped.
-  virtual bool update() = 0;
+  virtual bool Update() = 0;
 
   // Render this state. Called after update().
-  virtual void draw() = 0;
+  virtual void Draw() = 0;
 
   // If true, the state below this one on the stack will also be drawn
   // (before this state). Useful for modal dialogs/text input overlays.
-  virtual bool isOverlay() const { return false; }
+  virtual bool IsOverlay() const { return false; }
 
   // If true, the frame loop calls menuFlip() (palette rotation + flip).
   // If false, it calls flip() (just present + timing).
-  virtual bool wantsMenuFlip() const { return true; }
+  virtual bool WantsMenuFlip() const { return true; }
 
   // Back-pointer to the graphics context, set by StateStack on push.
   Gfx* gfx = nullptr;
@@ -47,16 +47,16 @@ struct AppState {
 class StateStack {
  public:
   // Push a new state onto the stack. Calls enter() on it.
-  void push(std::unique_ptr<AppState> state, Gfx* gfx) {
+  void Push(std::unique_ptr<AppState> state, Gfx* gfx) {
     state->gfx = gfx;
-    state->enter();
+    state->Enter();
     stack_.push_back(std::move(state));
   }
 
   // Pop the top state. Calls leave() on it before removal.
-  void pop() {
+  void Pop() {
     if (!stack_.empty()) {
-      stack_.back()->leave();
+      stack_.back()->Leave();
       stack_.pop_back();
     }
   }
@@ -65,43 +65,43 @@ class StateStack {
   // When called from outside a state's update(), this takes effect immediately.
   // When called from inside update(), prefer scheduleReplaceTop() instead to
   // avoid destroying the calling state while still inside its update() method.
-  void replaceTop(std::unique_ptr<AppState> state, Gfx* gfx) {
-    pop();
-    push(std::move(state), gfx);
+  void ReplaceTop(std::unique_ptr<AppState> state, Gfx* gfx) {
+    Pop();
+    Push(std::move(state), gfx);
   }
 
   // Schedule a replacement of the top state, applied after update() returns.
   // Safe to call from inside a state's update() — avoids destroying `this`.
-  void scheduleReplaceTop(std::unique_ptr<AppState> state) { pendingReplace_ = std::move(state); }
+  void ScheduleReplaceTop(std::unique_ptr<AppState> state) { pendingReplace_ = std::move(state); }
 
   // Access the topmost state, or nullptr if empty.
-  AppState* top() { return stack_.empty() ? nullptr : stack_.back().get(); }
+  AppState* Top() { return stack_.empty() ? nullptr : stack_.back().get(); }
 
-  bool empty() const { return stack_.empty(); }
-  std::size_t size() const { return stack_.size(); }
+  bool Empty() const { return stack_.empty(); }
+  std::size_t Size() const { return stack_.size(); }
 
   // Dispatch an event to the topmost state.
-  void handleEvent(SDL_Event& ev) {
-    if (auto* s = top()) s->handleEvent(ev);
+  void HandleEvent(SDL_Event& ev) {
+    if (auto* s = Top()) s->HandleEvent(ev);
   }
 
   // Update the topmost state. Returns false if the stack is empty
   // (application should quit) or if the top state signals completion.
-  bool update() {
+  bool Update() {
     if (stack_.empty()) return false;
 
-    bool keepRunning = stack_.back()->update();
+    bool keep_running = stack_.back()->Update();
     Gfx* g = stack_.back()->gfx;
 
     // Apply deferred replacement (set via scheduleReplaceTop)
     if (pendingReplace_) {
-      pop();
-      push(std::move(pendingReplace_), g);
+      Pop();
+      Push(std::move(pendingReplace_), g);
       return !stack_.empty();
     }
 
-    if (!keepRunning) {
-      pop();
+    if (!keep_running) {
+      Pop();
       // The state completed. If there's still something on the
       // stack, keep running; otherwise signal "done".
       return !stack_.empty();
@@ -110,18 +110,18 @@ class StateStack {
   }
 
   // Draw states, respecting overlay transparency.
-  void draw() {
+  void Draw() {
     if (stack_.empty()) return;
 
     // Find the lowest state we need to draw
     std::size_t bottom = stack_.size() - 1;
-    while (bottom > 0 && stack_[bottom]->isOverlay()) --bottom;
+    while (bottom > 0 && stack_[bottom]->IsOverlay()) --bottom;
 
-    for (std::size_t i = bottom; i < stack_.size(); ++i) stack_[i]->draw();
+    for (std::size_t i = bottom; i < stack_.size(); ++i) stack_[i]->Draw();
   }
 
   // Access the topmost state (for querying flip mode, etc.)
-  AppState* top() const { return stack_.empty() ? nullptr : stack_.back().get(); }
+  AppState* Top() const { return stack_.empty() ? nullptr : stack_.back().get(); }
 
  private:
   std::vector<std::unique_ptr<AppState>> stack_;

--- a/src/game/stateHash.hpp
+++ b/src/game/stateHash.hpp
@@ -12,7 +12,7 @@
 
 // Comprehensive hash of all simulation-relevant state.
 // Used for determinism verification in tests and the desync fuzzer.
-inline uint32_t hashGameState(Game& game) {
+inline uint32_t HashGameState(Game& game) {
   uint32_t h = 1;
 
   h = h * 31 + game.rand.last;
@@ -27,18 +27,18 @@ inline uint32_t hashGameState(Game& game) {
     h = h * 31 + static_cast<uint32_t>(w->pos.y);
     h = h * 31 + static_cast<uint32_t>(w->vel.x);
     h = h * 31 + static_cast<uint32_t>(w->vel.y);
-    h = h * 31 + static_cast<uint32_t>(w->aimingAngle);
+    h = h * 31 + static_cast<uint32_t>(w->aiming_angle);
     h = h * 31 + static_cast<uint32_t>(w->health);
     h = h * 31 + static_cast<uint32_t>(w->lives);
     h = h * 31 + static_cast<uint32_t>(w->kills);
     h = h * 31 + static_cast<uint32_t>(w->timer);
     h = h * 31 + static_cast<uint32_t>(w->visible);
-    h = h * 31 + w->controlStates.pack();
+    h = h * 31 + w->control_states.Pack();
 
     for (int i = 0; i < NUM_WEAPONS; ++i) {
       h = h * 31 + static_cast<uint32_t>(w->weapons[i].ammo);
-      h = h * 31 + static_cast<uint32_t>(w->weapons[i].delayLeft);
-      h = h * 31 + static_cast<uint32_t>(w->weapons[i].loadingLeft);
+      h = h * 31 + static_cast<uint32_t>(w->weapons[i].delay_left);
+      h = h * 31 + static_cast<uint32_t>(w->weapons[i].loading_left);
       if (w->weapons[i].type) h = h * 31 + static_cast<uint32_t>(w->weapons[i].type->id);
     }
 
@@ -48,17 +48,17 @@ inline uint32_t hashGameState(Game& game) {
   }
 
   {
-    auto br = game.bobjects.begin();
-    for (; br != game.bobjects.end(); ++br) {
+    auto br = game.bobjects.Begin();
+    for (; br != game.bobjects.End(); ++br) {
       h = h * 31 + static_cast<uint32_t>(br->pos.x);
       h = h * 31 + static_cast<uint32_t>(br->pos.y);
     }
   }
 
   {
-    auto r = game.bonuses.all();
+    auto r = game.bonuses.All();
     Bonus* b;
-    while ((b = r.next())) {
+    while ((b = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(b->x);
       h = h * 31 + static_cast<uint32_t>(b->y);
       h = h * 31 + static_cast<uint32_t>(b->timer);
@@ -68,37 +68,37 @@ inline uint32_t hashGameState(Game& game) {
   }
 
   {
-    auto r = game.sobjects.all();
+    auto r = game.sobjects.All();
     SObject* s;
-    while ((s = r.next())) {
+    while ((s = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(s->id);
-      h = h * 31 + static_cast<uint32_t>(s->curFrame);
+      h = h * 31 + static_cast<uint32_t>(s->cur_frame);
     }
   }
 
   {
-    auto r = game.nobjects.all();
+    auto r = game.nobjects.All();
     NObject* n;
-    while ((n = r.next())) {
+    while ((n = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(n->pos.x);
       h = h * 31 + static_cast<uint32_t>(n->pos.y);
       h = h * 31 + static_cast<uint32_t>(n->vel.x);
       h = h * 31 + static_cast<uint32_t>(n->vel.y);
-      h = h * 31 + static_cast<uint32_t>(n->curFrame);
+      h = h * 31 + static_cast<uint32_t>(n->cur_frame);
       if (n->type) h = h * 31 + static_cast<uint32_t>(n->type->id);
     }
   }
 
   {
-    auto r = game.wobjects.all();
+    auto r = game.wobjects.All();
     WObject* wo;
-    while ((wo = r.next())) {
+    while ((wo = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(wo->pos.x);
       h = h * 31 + static_cast<uint32_t>(wo->pos.y);
       h = h * 31 + static_cast<uint32_t>(wo->vel.x);
       h = h * 31 + static_cast<uint32_t>(wo->vel.y);
-      h = h * 31 + static_cast<uint32_t>(wo->curFrame);
-      h = h * 31 + static_cast<uint32_t>(wo->timeLeft);
+      h = h * 31 + static_cast<uint32_t>(wo->cur_frame);
+      h = h * 31 + static_cast<uint32_t>(wo->time_left);
       if (wo->type) h = h * 31 + static_cast<uint32_t>(wo->type->id);
     }
   }
@@ -107,12 +107,12 @@ inline uint32_t hashGameState(Game& game) {
 }
 
 // Per-component hashes for diagnostic output on desync.
-static constexpr size_t NumPlayers = 2;
+static constexpr size_t kNumPlayers = 2;
 
 struct ComponentHashes {
   uint32_t rng;
   uint32_t level;
-  uint32_t worms[NumPlayers];
+  uint32_t worms[kNumPlayers];
   uint32_t bobjects;
   uint32_t bonuses;
   uint32_t sobjects;
@@ -120,7 +120,7 @@ struct ComponentHashes {
   uint32_t wobjects;
 };
 
-inline ComponentHashes hashGameComponents(Game& game) {
+inline ComponentHashes HashGameComponents(Game& game) {
   ComponentHashes c{};
 
   c.rng = game.rand.last;
@@ -131,7 +131,7 @@ inline ComponentHashes hashGameComponents(Game& game) {
     c.level = h;
   }
 
-  for (size_t wi = 0; wi < game.worms.size() && wi < NumPlayers; ++wi) {
+  for (size_t wi = 0; wi < game.worms.size() && wi < kNumPlayers; ++wi) {
     auto const& w = game.worms[wi];
     uint32_t h = 1;
     h = h * 31 + static_cast<uint32_t>(w->pos.x);
@@ -147,8 +147,8 @@ inline ComponentHashes hashGameComponents(Game& game) {
 
   {
     uint32_t h = 1;
-    auto br = game.bobjects.begin();
-    for (; br != game.bobjects.end(); ++br) {
+    auto br = game.bobjects.Begin();
+    for (; br != game.bobjects.End(); ++br) {
       h = h * 31 + static_cast<uint32_t>(br->pos.x);
       h = h * 31 + static_cast<uint32_t>(br->pos.y);
     }
@@ -157,9 +157,9 @@ inline ComponentHashes hashGameComponents(Game& game) {
 
   {
     uint32_t h = 1;
-    auto r = game.bonuses.all();
+    auto r = game.bonuses.All();
     Bonus* b;
-    while ((b = r.next())) {
+    while ((b = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(b->x);
       h = h * 31 + static_cast<uint32_t>(b->y);
       h = h * 31 + static_cast<uint32_t>(b->timer);
@@ -170,20 +170,20 @@ inline ComponentHashes hashGameComponents(Game& game) {
 
   {
     uint32_t h = 1;
-    auto r = game.sobjects.all();
+    auto r = game.sobjects.All();
     SObject* s;
-    while ((s = r.next())) {
+    while ((s = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(s->id);
-      h = h * 31 + static_cast<uint32_t>(s->curFrame);
+      h = h * 31 + static_cast<uint32_t>(s->cur_frame);
     }
     c.sobjects = h;
   }
 
   {
     uint32_t h = 1;
-    auto r = game.nobjects.all();
+    auto r = game.nobjects.All();
     NObject* n;
-    while ((n = r.next())) {
+    while ((n = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(n->pos.x);
       h = h * 31 + static_cast<uint32_t>(n->pos.y);
     }
@@ -192,9 +192,9 @@ inline ComponentHashes hashGameComponents(Game& game) {
 
   {
     uint32_t h = 1;
-    auto r = game.wobjects.all();
+    auto r = game.wobjects.All();
     WObject* wo;
-    while ((wo = r.next())) {
+    while ((wo = r.Next())) {
       h = h * 31 + static_cast<uint32_t>(wo->pos.x);
       h = h * 31 + static_cast<uint32_t>(wo->pos.y);
     }

--- a/src/game/stats.hpp
+++ b/src/game/stats.hpp
@@ -6,7 +6,7 @@
 using std::vector;
 
 template <typename D, typename T>
-vector<D> convert(vector<T> const& src) {
+vector<D> Convert(vector<T> const& src) {
   vector<D> v;
 
   for (auto& e : src) v.push_back(e);
@@ -15,7 +15,7 @@ vector<D> convert(vector<T> const& src) {
 }
 
 template <typename T, typename C>
-vector<T> pluck(vector<C> const& src, T(C::* a)) {
+vector<T> Pluck(vector<C> const& src, T(C::* a)) {
   vector<T> v;
 
   for (auto& e : src) v.push_back(e.*a);
@@ -24,7 +24,7 @@ vector<T> pluck(vector<C> const& src, T(C::* a)) {
 }
 
 template <typename T>
-vector<T> stretch(vector<T> const& src, size_t len) {
+vector<T> Stretch(vector<T> const& src, size_t len) {
   size_t n = src.size();
   vector<T> v(len);
 
@@ -52,13 +52,13 @@ vector<T> stretch(vector<T> const& src, size_t len) {
 }
 
 template <typename T>
-void cumulative(vector<T>& src) {
+void Cumulative(vector<T>& src) {
   T prev = T();
   for (auto& v : src) prev = (v += prev);
 }
 
 template <typename T>
-void normalize(vector<T>& src, size_t limit, bool balance = true) {
+void Normalize(vector<T>& src, size_t limit, bool balance = true) {
   if (src.empty()) return;
 
   T max = *std::max_element(src.begin(), src.end());
@@ -82,7 +82,7 @@ void normalize(vector<T>& src, size_t limit, bool balance = true) {
 }
 
 template <typename T, typename Op>
-vector<T> zip(vector<T>& src, vector<T> const& other, Op op) {
+vector<T> Zip(vector<T>& src, vector<T> const& other, Op op) {
   auto max = std::min(src.size(), other.size());
   vector<T> n(max);
   for (std::size_t i = 0; i < max; ++i) {

--- a/src/game/statsState.cpp
+++ b/src/game/statsState.cpp
@@ -70,8 +70,8 @@ struct StatsRenderer {
         BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
         cell c(i == 0 ? TextCell::kRight : TextCell::kLeft);
-        common.font.DrawText(renderer.bmp, c << game.worms[i]->settings->name,
-                             x + (i == 0 ? -16 : 16), y + 2, kTextColor);
+        common.font.DrawString(renderer.bmp, c << game.worms[i]->settings->name,
+                               x + (i == 0 ? -16 : 16), y + 2, kTextColor);
       }
     });
   }
@@ -82,8 +82,8 @@ struct StatsRenderer {
       BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
       cell c(i == 0 ? TextCell::kRight : TextCell::kLeft);
-      common.font.DrawText(renderer.bmp, c << game.worms[i]->settings->name,
-                           x + (i == 0 ? -16 : 16), y + 2, kTextColor);
+      common.font.DrawString(renderer.bmp, c << game.worms[i]->settings->name,
+                             x + (i == 0 ? -16 : 16), y + 2, kTextColor);
     });
 
     if (!visible) {
@@ -95,8 +95,8 @@ struct StatsRenderer {
   template <typename Ws>
   void DrawWormStat(char const* name, Ws worm_stat) {
     Hblock(11, [this, name, &worm_stat] {
-      common.font.DrawText(renderer.bmp, cell(TextCell::kCenter).Ref() << name,
-                           renderer.render_res_x / 2 + offs_x, y, kTextColor);
+      common.font.DrawString(renderer.bmp, cell(TextCell::kCenter).Ref() << name,
+                             renderer.render_res_x / 2 + offs_x, y, kTextColor);
 
       for (int i = 0; i < 2; ++i) {
         TextCell::Placement p = i == 0 ? TextCell::kRight : TextCell::kLeft;
@@ -105,7 +105,7 @@ struct StatsRenderer {
         WormStats& w = stats.worms[i];
         cell c(p);
         worm_stat(w, c);
-        common.font.DrawText(renderer.bmp, c, x, y, kTextColor);
+        common.font.DrawString(renderer.bmp, c, x, y, kTextColor);
       }
     });
   }
@@ -113,14 +113,14 @@ struct StatsRenderer {
   template <typename Stat>
   void DrawStat(char const* name, Stat stat) {
     Hblock(11, [this, name, &stat] {
-      common.font.DrawText(renderer.bmp, cell(TextCell::kRight).Ref() << name,
-                           renderer.render_res_x / 2 + offs_x, y, kTextColor);
+      common.font.DrawString(renderer.bmp, cell(TextCell::kRight).Ref() << name,
+                             renderer.render_res_x / 2 + offs_x, y, kTextColor);
 
       int x = renderer.render_res_x / 2 + 10 + offs_x;
 
       cell c(TextCell::kLeft);
       stat(c);
-      common.font.DrawText(renderer.bmp, c, x, y, kTextColor);
+      common.font.DrawString(renderer.bmp, c, x, y, kTextColor);
     });
   }
 
@@ -136,7 +136,7 @@ struct StatsRenderer {
       color = 3;
     }
 
-    common.font.DrawText(renderer.bmp, c, x, y, color);
+    common.font.DrawString(renderer.bmp, c, x, y, color);
 
     if (level == 0) y += 11;
   }

--- a/src/game/statsState.cpp
+++ b/src/game/statsState.cpp
@@ -65,7 +65,8 @@ struct StatsRenderer {
   void DrawWorms() {
     Hblock(20, [this] {
       for (int i = 0; i < 2; ++i) {
-        int x = renderer.render_res_x / 2 + (i == 0 ? -1 : 1) * (renderer.render_res_x / 4) + offs_x;
+        int x =
+            renderer.render_res_x / 2 + (i == 0 ? -1 : 1) * (renderer.render_res_x / 4) + offs_x;
         BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
         cell c(i == 0 ? TextCell::kRight : TextCell::kLeft);
@@ -208,9 +209,9 @@ void StatsState::Enter() {
   int graph_width = gfx->play_renderer.render_res_x - 20 - 20;
 
   for (int i = 0; i < 2; ++i) {
-    wormDamages_[i] =
-        Stretch(Convert<double>(Pluck(recorder_.worms[i].worm_frame_stats, &WormFrameStats::damage)),
-                graph_width);
+    wormDamages_[i] = Stretch(
+        Convert<double>(Pluck(recorder_.worms[i].worm_frame_stats, &WormFrameStats::damage)),
+        graph_width);
     Cumulative(wormDamages_[i]);
     Normalize(wormDamages_[i], 50);
   }
@@ -220,7 +221,8 @@ void StatsState::Enter() {
     worm_total_hp[i] =
         Convert<double>(Pluck(recorder_.worms[i].worm_frame_stats, &WormFrameStats::total_hp));
 
-  wormTotalHpDiff_ = Stretch(Zip(worm_total_hp[0], worm_total_hp[1], std::minus<double>()), graph_width);
+  wormTotalHpDiff_ =
+      Stretch(Zip(worm_total_hp[0], worm_total_hp[1], std::minus<double>()), graph_width);
   Normalize(wormTotalHpDiff_, 100);
 
   for (int i = 0; i < 40; ++i) {

--- a/src/game/statsState.cpp
+++ b/src/game/statsState.cpp
@@ -14,36 +14,36 @@
 using cell = TextCell;
 using std::vector;
 
-static std::string percent(int nom, int den) {
+static std::string Percent(int nom, int den) {
   if (den == 0) return "";
 
-  const int BUF_MAX = 256;
-  char buf[BUF_MAX];
-  std::snprintf(buf, BUF_MAX * sizeof(char), "%.2f%%", double(nom) * 100.0 / den);
+  const int kBufMax = 256;
+  char buf[kBufMax];
+  std::snprintf(buf, kBufMax * sizeof(char), "%.2f%%", double(nom) * 100.0 / den);
   return buf;
 }
 
 struct StatsRenderer {
-  static int const textColor = 7;
+  static int const kTextColor = 7;
 
   StatsRenderer(Renderer& renderer, Game& game, NormalStatsRecorder& stats, Common& common)
       : renderer(renderer),
         game(game),
         stats(stats),
         common(common),
-        paneWidth(renderer.renderResX - 20) {}
+        pane_width(renderer.render_res_x - 20) {}
 
-  static int const paneX = 10;
+  static int const kPaneX = 10;
 
   template <typename P>
-  void pane(int n, int leftX, int topY, P const& p) {
-    offsX = n * renderer.renderResX + leftX;
+  void Pane(int n, int left_x, int top_y, P const& p) {
+    offs_x = n * renderer.render_res_x + left_x;
 
-    if (offsX >= -renderer.renderResX && offsX < renderer.renderResX) {
-      y = topY;
+    if (offs_x >= -renderer.render_res_x && offs_x < renderer.render_res_x) {
+      y = top_y;
       y += 10;
 
-      drawRoundedBox(renderer.bmp, offsX + paneX, y, 0, 2000, paneWidth);
+      DrawRoundedBox(renderer.bmp, offs_x + kPaneX, y, 0, 2000, pane_width);
 
       y += 10;
 
@@ -52,9 +52,9 @@ struct StatsRenderer {
   }
 
   template <typename B>
-  bool hblock(int height, B const& b) {
+  bool Hblock(int height, B const& b) {
     bool ran = false;
-    if (y < renderer.renderResY && y + height > 0) {
+    if (y < renderer.render_res_y && y + height > 0) {
       b();
       ran = true;
     }
@@ -62,124 +62,124 @@ struct StatsRenderer {
     return ran;
   }
 
-  void drawWorms() {
-    hblock(20, [this] {
+  void DrawWorms() {
+    Hblock(20, [this] {
       for (int i = 0; i < 2; ++i) {
-        int x = renderer.renderResX / 2 + (i == 0 ? -1 : 1) * (renderer.renderResX / 4) + offsX;
-        blitImage(renderer.bmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
+        int x = renderer.render_res_x / 2 + (i == 0 ? -1 : 1) * (renderer.render_res_x / 4) + offs_x;
+        BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
-        cell c(i == 0 ? TextCell::Right : TextCell::Left);
-        common.font.drawText(renderer.bmp, c << game.worms[i]->settings->name,
-                             x + (i == 0 ? -16 : 16), y + 2, textColor);
+        cell c(i == 0 ? TextCell::kRight : TextCell::kLeft);
+        common.font.DrawText(renderer.bmp, c << game.worms[i]->settings->name,
+                             x + (i == 0 ? -16 : 16), y + 2, kTextColor);
       }
     });
   }
 
-  void drawWorm(int i) {
-    bool visible = hblock(20, [this, i] {
-      int x = renderer.renderResX / 2 + offsX;
-      blitImage(renderer.bmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
+  void DrawWorm(int i) {
+    bool visible = Hblock(20, [this, i] {
+      int x = renderer.render_res_x / 2 + offs_x;
+      BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, y);
 
-      cell c(i == 0 ? TextCell::Right : TextCell::Left);
-      common.font.drawText(renderer.bmp, c << game.worms[i]->settings->name,
-                           x + (i == 0 ? -16 : 16), y + 2, textColor);
+      cell c(i == 0 ? TextCell::kRight : TextCell::kLeft);
+      common.font.DrawText(renderer.bmp, c << game.worms[i]->settings->name,
+                           x + (i == 0 ? -16 : 16), y + 2, kTextColor);
     });
 
     if (!visible) {
-      int x = 18 + offsX;
-      blitImage(renderer.bmp, common.wormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, 10);
+      int x = 18 + offs_x;
+      BlitImage(renderer.bmp, common.WormSpriteObj(2, i == 0 ? 1 : 0, i), x - 8, 10);
     }
   }
 
   template <typename Ws>
-  void drawWormStat(char const* name, Ws wormStat) {
-    hblock(11, [this, name, &wormStat] {
-      common.font.drawText(renderer.bmp, cell(TextCell::Center).ref() << name,
-                           renderer.renderResX / 2 + offsX, y, textColor);
+  void DrawWormStat(char const* name, Ws worm_stat) {
+    Hblock(11, [this, name, &worm_stat] {
+      common.font.DrawText(renderer.bmp, cell(TextCell::kCenter).Ref() << name,
+                           renderer.render_res_x / 2 + offs_x, y, kTextColor);
 
       for (int i = 0; i < 2; ++i) {
-        TextCell::Placement p = i == 0 ? TextCell::Right : TextCell::Left;
-        int x = renderer.renderResX / 2 + (i == 0 ? -40 : 40) + offsX;
+        TextCell::Placement p = i == 0 ? TextCell::kRight : TextCell::kLeft;
+        int x = renderer.render_res_x / 2 + (i == 0 ? -40 : 40) + offs_x;
 
         WormStats& w = stats.worms[i];
         cell c(p);
-        wormStat(w, c);
-        common.font.drawText(renderer.bmp, c, x, y, textColor);
+        worm_stat(w, c);
+        common.font.DrawText(renderer.bmp, c, x, y, kTextColor);
       }
     });
   }
 
   template <typename Stat>
-  void drawStat(char const* name, Stat stat) {
-    hblock(11, [this, name, &stat] {
-      common.font.drawText(renderer.bmp, cell(TextCell::Right).ref() << name,
-                           renderer.renderResX / 2 + offsX, y, textColor);
+  void DrawStat(char const* name, Stat stat) {
+    Hblock(11, [this, name, &stat] {
+      common.font.DrawText(renderer.bmp, cell(TextCell::kRight).Ref() << name,
+                           renderer.render_res_x / 2 + offs_x, y, kTextColor);
 
-      int x = renderer.renderResX / 2 + 10 + offsX;
+      int x = renderer.render_res_x / 2 + 10 + offs_x;
 
-      cell c(TextCell::Left);
+      cell c(TextCell::kLeft);
       stat(c);
-      common.font.drawText(renderer.bmp, c, x, y, textColor);
+      common.font.DrawText(renderer.bmp, c, x, y, kTextColor);
     });
   }
 
-  void drawWormStat(char const* name, int(WormStats::* field)) {
-    drawWormStat(name, [field](WormStats& w, cell& c) { c << w.*field; });
+  void DrawWormStat(char const* name, int(WormStats::* field)) {
+    DrawWormStat(name, [field](WormStats& w, cell& c) { c << w.*field; });
   }
 
-  void section(cell const& c, int level = 1) {
-    int x = offsX + 20;
-    int color = textColor;
+  void Section(cell const& c, int level = 1) {
+    int x = offs_x + 20;
+    int color = kTextColor;
     if (level > 0) {
       x += 20;
       color = 3;
     }
 
-    common.font.drawText(renderer.bmp, c, x, y, color);
+    common.font.DrawText(renderer.bmp, c, x, y, color);
 
     if (level == 0) y += 11;
   }
 
-  void gap(int n = 5) { y += n; }
+  void Gap(int n = 5) { y += n; }
 
-  void weaponStats(vector<WeaponStats> const& list) {
+  void WeaponStats(vector<WeaponStats> const& list) {
     for (auto& ws : list) {
-      if (ws.totalHp > 0) {
-        section(cell().ref() << common.weapons[ws.index].name);
-        drawStat("hits", [ws](cell& c) {
-          c << ws.actualHits << "/" << ws.potentialHits << " ("
-            << percent(ws.actualHits, ws.potentialHits) << ")";
+      if (ws.total_hp > 0) {
+        Section(cell().Ref() << common.weapons[ws.index].name);
+        DrawStat("hits", [ws](cell& c) {
+          c << ws.actual_hits << "/" << ws.potential_hits << " ("
+            << Percent(ws.actual_hits, ws.potential_hits) << ")";
         });
-        if (ws.potentialHp > 0) {
-          drawStat("damage", [ws](cell& c) {
-            c << ws.actualHp << "/" << ws.potentialHp << " ("
-              << percent(ws.actualHp, ws.potentialHp) << ")";
+        if (ws.potential_hp > 0) {
+          DrawStat("damage", [ws](cell& c) {
+            c << ws.actual_hp << "/" << ws.potential_hp << " ("
+              << Percent(ws.actual_hp, ws.potential_hp) << ")";
           });
         }
-        if (ws.totalHp != ws.actualHp) {
-          drawStat("total damage", [ws](cell& c) { c << ws.totalHp; });
+        if (ws.total_hp != ws.actual_hp) {
+          DrawStat("total damage", [ws](cell& c) { c << ws.total_hp; });
         }
-        gap();
+        Gap();
       }
     }
   }
 
-  void graph(vector<double> const& data, int height, int color, int negColor, bool balanced) {
+  void Graph(vector<double> const& data, int height, int color, int neg_color, bool balanced) {
     y += 2;
-    hblock(height, [&, this] {
-      int start = 20 + offsX;
-      drawGraph(renderer.bmp, data, height, start, y, color, negColor, balanced);
+    Hblock(height, [&, this] {
+      int start = 20 + offs_x;
+      DrawGraph(renderer.bmp, data, height, start, y, color, neg_color, balanced);
     });
     y += 7;
   }
 
-  void heatmap(Heatmap& hm) {
+  void Heatmap(Heatmap& hm) {
     y += 2;
-    hblock(hm.height, [&] {
-      int startX = paneX + paneWidth / 2 - (hm.width / 2) + offsX;
-      int startY = y;
+    Hblock(hm.height, [&] {
+      int start_x = kPaneX + pane_width / 2 - (hm.width / 2) + offs_x;
+      int start_y = y;
 
-      drawHeatmap(renderer.bmp, startX, startY, hm);
+      DrawHeatmap(renderer.bmp, start_x, start_y, hm);
     });
     y += 7;
   }
@@ -188,94 +188,94 @@ struct StatsRenderer {
   Game& game;
   NormalStatsRecorder& stats;
   Common& common;
-  int paneWidth = 300;
-  int offsX, y;
+  int pane_width = 300;
+  int offs_x, y;
 };
 
-static void sortWeaponStats(vector<WeaponStats>& ws) {
+static void SortWeaponStats(vector<WeaponStats>& ws) {
   std::sort(ws.begin(), ws.end(),
-            [](WeaponStats const& a, WeaponStats const& b) { return a.actualHp > b.actualHp; });
+            [](WeaponStats const& a, WeaponStats const& b) { return a.actual_hp > b.actual_hp; });
 }
 
-StatsState::StatsState(NormalStatsRecorder& recorder, Game& game, bool isMultiplayer)
-    : recorder_(recorder), game_(game), isMultiplayer_(isMultiplayer) {}
+StatsState::StatsState(NormalStatsRecorder& recorder, Game& game, bool is_multiplayer)
+    : recorder_(recorder), game_(game), isMultiplayer_(is_multiplayer) {}
 
-void StatsState::enter() {
-  gfx->clearKeys();
+void StatsState::Enter() {
+  gfx->ClearKeys();
 
   Common& common = *game_.common;
 
-  int graphWidth = gfx->playRenderer.renderResX - 20 - 20;
+  int graph_width = gfx->play_renderer.render_res_x - 20 - 20;
 
   for (int i = 0; i < 2; ++i) {
     wormDamages_[i] =
-        stretch(convert<double>(pluck(recorder_.worms[i].wormFrameStats, &WormFrameStats::damage)),
-                graphWidth);
-    cumulative(wormDamages_[i]);
-    normalize(wormDamages_[i], 50);
+        Stretch(Convert<double>(Pluck(recorder_.worms[i].worm_frame_stats, &WormFrameStats::damage)),
+                graph_width);
+    Cumulative(wormDamages_[i]);
+    Normalize(wormDamages_[i], 50);
   }
 
-  vector<double> wormTotalHp[2];
+  vector<double> worm_total_hp[2];
   for (int i = 0; i < 2; ++i)
-    wormTotalHp[i] =
-        convert<double>(pluck(recorder_.worms[i].wormFrameStats, &WormFrameStats::totalHp));
+    worm_total_hp[i] =
+        Convert<double>(Pluck(recorder_.worms[i].worm_frame_stats, &WormFrameStats::total_hp));
 
-  wormTotalHpDiff_ = stretch(zip(wormTotalHp[0], wormTotalHp[1], std::minus<double>()), graphWidth);
-  normalize(wormTotalHpDiff_, 100);
+  wormTotalHpDiff_ = Stretch(Zip(worm_total_hp[0], worm_total_hp[1], std::minus<double>()), graph_width);
+  Normalize(wormTotalHpDiff_, 100);
 
   for (int i = 0; i < 40; ++i) {
     auto ws = recorder_.worms[0].weapons[i];
-    ws.combine(recorder_.worms[1].weapons[i]);
+    ws.Combine(recorder_.worms[1].weapons[i]);
     combinedWeaponStats_.push_back(ws);
 
     weaponStats_[0].push_back(recorder_.worms[0].weapons[i]);
     weaponStats_[1].push_back(recorder_.worms[1].weapons[i]);
   }
 
-  sortWeaponStats(combinedWeaponStats_);
-  sortWeaponStats(weaponStats_[0]);
-  sortWeaponStats(weaponStats_[1]);
+  SortWeaponStats(combinedWeaponStats_);
+  SortWeaponStats(weaponStats_[0]);
+  SortWeaponStats(weaponStats_[1]);
 
-  bg_.copy(gfx->playRenderer.bmp);
+  bg_.Copy(gfx->play_renderer.bmp);
 }
 
-void StatsState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void StatsState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool StatsState::update() {
+bool StatsState::Update() {
   // Keep the network session alive while viewing stats
-  if (isMultiplayer_ && gfx->netSession) {
-    gfx->netSession->update();
-    auto state = gfx->netSession->sessionState();
-    if (state == NetSession::Disconnected || state == NetSession::Failed) {
-      gfx->netSession.reset();
+  if (isMultiplayer_ && gfx->net_session) {
+    gfx->net_session->Update();
+    auto state = gfx->net_session->State();
+    if (state == NetSession::kDisconnected || state == NetSession::kFailed) {
+      gfx->net_session.reset();
       isMultiplayer_ = false;
     }
   }
 
-  if (gfx->testSDLKey(SDL_SCANCODE_DOWN) || gfx->testControl(WormSettingsExtensions::Down) ||
-      gfx->testGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+  if (gfx->TestSdlKey(SDL_SCANCODE_DOWN) || gfx->TestControl(WormSettingsExtensions::kDown) ||
+      gfx->TestGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
     destOffset_ -= 10;
-  } else if (gfx->testSDLKey(SDL_SCANCODE_UP) || gfx->testControl(WormSettingsExtensions::Up) ||
-             gfx->testGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+  } else if (gfx->TestSdlKey(SDL_SCANCODE_UP) || gfx->TestControl(WormSettingsExtensions::kUp) ||
+             gfx->TestGamepadDir(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
     destOffset_ = std::min(destOffset_ + 10.0, 0.0);
-  } else if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT) ||
-             gfx->testControlOnce(WormSettingsExtensions::Right) ||
-             gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
+  } else if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RIGHT) ||
+             gfx->TestControlOnce(WormSettingsExtensions::kRight) ||
+             gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
     destPane_ = std::min(destPane_ + 1.0, 1.0);
-  } else if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT) ||
-             gfx->testControlOnce(WormSettingsExtensions::Left) ||
-             gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
+  } else if (gfx->TestSdlKeyOnce(SDL_SCANCODE_LEFT) ||
+             gfx->TestControlOnce(WormSettingsExtensions::kLeft) ||
+             gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
     destPane_ = std::max(destPane_ - 1.0, -1.0);
-  } else if (gfx->testSDLKeyOnce(SDL_SCANCODE_RETURN) || gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
-             gfx->testControlOnce(WormSettingsExtensions::Fire) ||
-             gfx->testControlOnce(WormSettingsExtensions::Jump) ||
-             gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH) ||
-             gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
-    fill(gfx->playRenderer.bmp, 0);
-    gfx->clearKeys();
+  } else if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RETURN) || gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
+             gfx->TestControlOnce(WormSettingsExtensions::kFire) ||
+             gfx->TestControlOnce(WormSettingsExtensions::kJump) ||
+             gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH) ||
+             gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST)) {
+    Fill(gfx->play_renderer.bmp, 0);
+    gfx->ClearKeys();
 
-    if (isMultiplayer_ && gfx->netSession) {
-      gfx->stateStack.scheduleReplaceTop(std::make_unique<RematchState>(game_));
+    if (isMultiplayer_ && gfx->net_session) {
+      gfx->state_stack.ScheduleReplaceTop(std::make_unique<RematchState>(game_));
       return true;
     }
 
@@ -290,87 +290,87 @@ bool StatsState::update() {
   return true;
 }
 
-void StatsState::draw() {
+void StatsState::Draw() {
   Common& common = *game_.common;
 
-  gfx->playRenderer.bmp.copy(bg_);
+  gfx->play_renderer.bmp.Copy(bg_);
 
-  StatsRenderer renderer(gfx->playRenderer, game_, recorder_, common);
+  StatsRenderer renderer(gfx->play_renderer, game_, recorder_, common);
 
-  int offsX = (int)std::floor(pane_ * -renderer.renderer.renderResX);
-  int offsY = (int)offset_;
+  int offs_x = (int)std::floor(pane_ * -renderer.renderer.render_res_x);
+  int offs_y = (int)offset_;
 
-  renderer.pane(0, offsX, offsY, [&] {
-    renderer.drawWorms();
+  renderer.Pane(0, offs_x, offs_y, [&] {
+    renderer.DrawWorms();
 
     int oldy = renderer.y;
     renderer.y -= 20;
 
-    renderer.drawStat(common.texts.gameModes[game_.settings->gameMode].c_str(),
-                      [&](cell& c) { c << timeToStringFrames(recorder_.gameTime); });
+    renderer.DrawStat(common.texts.game_modes[game_.settings->game_mode].c_str(),
+                      [&](cell& c) { c << TimeToStringFrames(recorder_.game_time); });
 
     renderer.y = oldy;
 
-    renderer.drawWormStat("ai processing", [&](WormStats& w, cell& c) {
-      c << (int)(std::chrono::duration_cast<std::chrono::milliseconds>(w.aiProcessTime).count())
+    renderer.DrawWormStat("ai processing", [&](WormStats& w, cell& c) {
+      c << (int)(std::chrono::duration_cast<std::chrono::milliseconds>(w.ai_process_time).count())
         << "ms";
     });
 
-    if (game_.settings->gameMode == Settings::GMHoldazone ||
-        game_.settings->gameMode == Settings::GMGameOfTag) {
-      renderer.drawWormStat("timer", [&](WormStats& w, cell& c) { c << timeToString(w.timer); });
+    if (game_.settings->game_mode == Settings::kGmHoldazone ||
+        game_.settings->game_mode == Settings::kGmGameOfTag) {
+      renderer.DrawWormStat("timer", [&](WormStats& w, cell& c) { c << TimeToString(w.timer); });
     } else {
-      renderer.drawWormStat("lives left", &WormStats::lives);
+      renderer.DrawWormStat("lives left", &WormStats::lives);
     }
-    renderer.drawWormStat("kills", &WormStats::kills);
-    renderer.drawWormStat("damage dealt", &WormStats::damageDealt);
-    renderer.drawWormStat("damage received", &WormStats::damage);
-    renderer.drawWormStat("damage to self", &WormStats::selfDamage);
+    renderer.DrawWormStat("kills", &WormStats::kills);
+    renderer.DrawWormStat("damage dealt", &WormStats::damage_dealt);
+    renderer.DrawWormStat("damage received", &WormStats::damage);
+    renderer.DrawWormStat("damage to self", &WormStats::self_damage);
 
-    renderer.drawWormStat("shortest life", [](WormStats& w, cell& c) {
+    renderer.DrawWormStat("shortest life", [](WormStats& w, cell& c) {
       int min, max;
-      w.lifeStats(min, max);
-      c << timeToStringFrames(min);
+      w.LifeStats(min, max);
+      c << TimeToStringFrames(min);
     });
 
-    renderer.drawWormStat("longest life", [](WormStats& w, cell& c) {
+    renderer.DrawWormStat("longest life", [](WormStats& w, cell& c) {
       int min, max;
-      w.lifeStats(min, max);
-      c << timeToStringFrames(max);
+      w.LifeStats(min, max);
+      c << TimeToStringFrames(max);
     });
 
-    renderer.drawWormStat("loading efficiency", [](WormStats& w, cell& c) {
-      c << percent(w.weaponChangeGood, w.weaponChangeGood + w.weaponChangeBad);
+    renderer.DrawWormStat("loading efficiency", [](WormStats& w, cell& c) {
+      c << Percent(w.weapon_change_good, w.weapon_change_good + w.weapon_change_bad);
     });
 
-    renderer.gap();
+    renderer.Gap();
 
-    renderer.weaponStats(combinedWeaponStats_);
+    renderer.WeaponStats(combinedWeaponStats_);
 
-    renderer.section(cell().ref() << "Total health difference", 0);
+    renderer.Section(cell().Ref() << "Total health difference", 0);
 
-    renderer.graph(wormTotalHpDiff_, 100, Palette::wormColourIndexes[0],
-                   Palette::wormColourIndexes[1], true);
+    renderer.Graph(wormTotalHpDiff_, 100, Palette::kWormColourIndexes[0],
+                   Palette::kWormColourIndexes[1], true);
 
-    renderer.section(cell().ref() << "Presence", 0);
-    renderer.heatmap(recorder_.presence);
+    renderer.Section(cell().Ref() << "Presence", 0);
+    renderer.Heatmap(recorder_.presence);
   });
 
   for (int i = 0; i < 2; ++i) {
-    renderer.pane(i == 0 ? -1 : 1, offsX, offsY, [&] {
-      renderer.drawWorm(i);
+    renderer.Pane(i == 0 ? -1 : 1, offs_x, offs_y, [&] {
+      renderer.DrawWorm(i);
 
-      renderer.weaponStats(weaponStats_[i]);
+      renderer.WeaponStats(weaponStats_[i]);
 
-      renderer.section(cell().ref() << "Damage over time", 0);
-      renderer.graph(wormDamages_[i], 50, Palette::wormColourIndexes[i], 0, false);
+      renderer.Section(cell().Ref() << "Damage over time", 0);
+      renderer.Graph(wormDamages_[i], 50, Palette::kWormColourIndexes[i], 0, false);
 
-      renderer.section(cell().ref() << "Presence", 0);
-      renderer.heatmap(recorder_.worms[i].presence);
-      renderer.section(cell().ref() << "Damage", 0);
-      renderer.heatmap(recorder_.worms[i].damageHm);
+      renderer.Section(cell().Ref() << "Presence", 0);
+      renderer.Heatmap(recorder_.worms[i].presence);
+      renderer.Section(cell().Ref() << "Damage", 0);
+      renderer.Heatmap(recorder_.worms[i].damage_hm);
     });
   }
 
-  gfx->playRenderer.pal = common.exepal;
+  gfx->play_renderer.pal = common.exepal;
 }

--- a/src/game/statsState.hpp
+++ b/src/game/statsState.hpp
@@ -9,13 +9,13 @@ struct Game;
 
 // Post-game statistics display.
 struct StatsState : AppState {
-  StatsState(NormalStatsRecorder& recorder, Game& game, bool isMultiplayer = false);
+  StatsState(NormalStatsRecorder& recorder, Game& game, bool is_multiplayer = false);
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
-  bool wantsMenuFlip() const override { return false; }
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
+  bool WantsMenuFlip() const override { return false; }
 
  private:
   NormalStatsRecorder& recorder_;

--- a/src/game/stats_recorder.cpp
+++ b/src/game/stats_recorder.cpp
@@ -129,7 +129,8 @@ void NormalStatsRecorder::Tick(Game& game) {
       bool ok = true;
       if (!w->control_states[Worm::Control::kFire] &&
           (!w->control_states[Worm::Control::kChange] ||
-           (!w->control_states[Worm::Control::kLeft] && !w->control_states[Worm::Control::kRight])) &&
+           (!w->control_states[Worm::Control::kLeft] &&
+            !w->control_states[Worm::Control::kRight])) &&
           w->weapons[w->current_weapon].loading_left == 0 &&
           std::find_if(w->weapons, w->weapons + 5,
                        [](WormWeapon& ww) { return ww.loading_left > 0; }) != w->weapons + 5) {

--- a/src/game/stats_recorder.cpp
+++ b/src/game/stats_recorder.cpp
@@ -5,163 +5,163 @@
 #include "game.hpp"
 #include "text.hpp"
 
-void StatsRecorder::damagePotential(Worm* byWorm, WormWeapon* weapon, int hp) {}
+void StatsRecorder::DamagePotential(Worm* by_worm, WormWeapon* weapon, int hp) {}
 
-void StatsRecorder::damageDealt(Worm* byWorm, WormWeapon* weapon, Worm* toWorm, int hp,
-                                bool hasHit) {}
+void StatsRecorder::DamageDealt(Worm* by_worm, WormWeapon* weapon, Worm* to_worm, int hp,
+                                bool has_hit) {}
 
-void StatsRecorder::shot(Worm* byWorm, WormWeapon* weapon) {}
+void StatsRecorder::Shot(Worm* by_worm, WormWeapon* weapon) {}
 
-void StatsRecorder::hit(Worm* byWorm, WormWeapon* weapon, Worm* toWorm) {}
+void StatsRecorder::Hit(Worm* by_worm, WormWeapon* weapon, Worm* to_worm) {}
 
-void StatsRecorder::afterSpawn(Worm* worm) {}
+void StatsRecorder::AfterSpawn(Worm* worm) {}
 
-void StatsRecorder::afterDeath(Worm* worm) {}
+void StatsRecorder::AfterDeath(Worm* worm) {}
 
-void StatsRecorder::finish(Game& game) {}
+void StatsRecorder::Finish(Game& game) {}
 
-void StatsRecorder::preTick(Game& game) {}
+void StatsRecorder::PreTick(Game& game) {}
 
-void StatsRecorder::tick(Game& game) {}
+void StatsRecorder::Tick(Game& game) {}
 
-void StatsRecorder::aiProcessTime(Worm* worm, std::chrono::nanoseconds time) {}
+void StatsRecorder::AiProcessTime(Worm* worm, std::chrono::nanoseconds time) {}
 
-void NormalStatsRecorder::damagePotential(Worm* byWorm, WormWeapon* weapon, int hp) {
+void NormalStatsRecorder::DamagePotential(Worm* by_worm, WormWeapon* weapon, int hp) {
   if (speculative) return;
-  if (!byWorm || !weapon) return;
+  if (!by_worm || !weapon) return;
 
-  WormStats& ws = worms[byWorm->index];
+  WormStats& ws = worms[by_worm->index];
   WeaponStats& weap = ws.weapons[weapon->type->id];
-  weap.potentialHp += hp;
+  weap.potential_hp += hp;
 }
 
-void NormalStatsRecorder::damageDealt(Worm* byWorm, WormWeapon* weapon, Worm* toWorm, int hp,
-                                      bool hasHit) {
+void NormalStatsRecorder::DamageDealt(Worm* by_worm, WormWeapon* weapon, Worm* to_worm, int hp,
+                                      bool has_hit) {
   if (speculative) return;
-  assert(toWorm);
+  assert(to_worm);
 
-  auto& w = worms[toWorm->index];
+  auto& w = worms[to_worm->index];
   w.damage += hp;
-  w.wormFrameStats.back().damage += hp;
-  w.damageHm.incArea(ftoi(toWorm->pos.x), ftoi(toWorm->pos.y), hp);
+  w.worm_frame_stats.back().damage += hp;
+  w.damage_hm.IncArea(Ftoi(to_worm->pos.x), Ftoi(to_worm->pos.y), hp);
 
-  if (byWorm) {
-    if (byWorm != toWorm)
-      worms[byWorm->index].damageDealt += hp;
+  if (by_worm) {
+    if (by_worm != to_worm)
+      worms[by_worm->index].damage_dealt += hp;
     else
-      worms[byWorm->index].selfDamage += hp;
+      worms[by_worm->index].self_damage += hp;
   }
 
-  if (!byWorm || !weapon) return;
+  if (!by_worm || !weapon) return;
 
-  if (byWorm != toWorm)  // Don't count if projectile already hit
+  if (by_worm != to_worm)  // Don't count if projectile already hit
   {
-    WormStats& ws = worms[byWorm->index];
+    WormStats& ws = worms[by_worm->index];
     WeaponStats& weap = ws.weapons[weapon->type->id];
-    if (!hasHit) weap.actualHp += hp;
-    weap.totalHp += hp;
+    if (!has_hit) weap.actual_hp += hp;
+    weap.total_hp += hp;
   }
 }
 
-void NormalStatsRecorder::shot(Worm* byWorm, WormWeapon* weapon) {
+void NormalStatsRecorder::Shot(Worm* by_worm, WormWeapon* weapon) {
   if (speculative) return;
-  if (!byWorm || !weapon) return;
+  if (!by_worm || !weapon) return;
 
-  WormStats& ws = worms[byWorm->index];
+  WormStats& ws = worms[by_worm->index];
   WeaponStats& weap = ws.weapons[weapon->type->id];
-  weap.potentialHits += 1;
+  weap.potential_hits += 1;
 }
 
-void NormalStatsRecorder::hit(Worm* byWorm, WormWeapon* weapon, Worm* toWorm) {
+void NormalStatsRecorder::Hit(Worm* by_worm, WormWeapon* weapon, Worm* to_worm) {
   if (speculative) return;
-  assert(toWorm);
+  assert(to_worm);
 
-  if (!byWorm || !weapon) return;
+  if (!by_worm || !weapon) return;
 
-  if (byWorm != toWorm) {
-    WormStats& ws = worms[byWorm->index];
+  if (by_worm != to_worm) {
+    WormStats& ws = worms[by_worm->index];
     WeaponStats& weap = ws.weapons[weapon->type->id];
-    weap.actualHits += 1;
+    weap.actual_hits += 1;
   }
 }
 
-void NormalStatsRecorder::afterSpawn(Worm* worm) {
+void NormalStatsRecorder::AfterSpawn(Worm* worm) {
   if (speculative) return;
   WormStats& w = worms[worm->index];
-  w.spawnTime = frame;
+  w.spawn_time = frame;
 }
 
-void NormalStatsRecorder::afterDeath(Worm* worm) {
+void NormalStatsRecorder::AfterDeath(Worm* worm) {
   if (speculative) return;
   WormStats& w = worms[worm->index];
-  w.lifeSpans.push_back(std::make_pair(w.spawnTime, frame));
-  w.spawnTime = -1;
+  w.life_spans.push_back(std::make_pair(w.spawn_time, frame));
+  w.spawn_time = -1;
 }
 
-void NormalStatsRecorder::preTick(Game& game) {
+void NormalStatsRecorder::PreTick(Game& game) {
   if (speculative) return;
-  frameStart = std::chrono::steady_clock::now();
+  frame_start = std::chrono::steady_clock::now();
 
   for (auto& w : worms) {
-    w.wormFrameStats.push_back(WormFrameStats());
+    w.worm_frame_stats.push_back(WormFrameStats());
 
     Worm& worm = *game.worms[w.index];
 
     int h = std::max(worm.health, 0);
     if (!worm.visible) h = worm.settings->health;
 
-    w.wormFrameStats.back().totalHp = worm.lives * worm.settings->health + h;
+    w.worm_frame_stats.back().total_hp = worm.lives * worm.settings->health + h;
   }
 }
 
-void NormalStatsRecorder::tick(Game& game) {
+void NormalStatsRecorder::Tick(Game& game) {
   if (speculative) return;
-  auto frameEnd = std::chrono::steady_clock::now();
-  processTimeTotal +=
-      std::chrono::duration_cast<std::chrono::milliseconds>(frameEnd - frameStart).count();
+  auto frame_end = std::chrono::steady_clock::now();
+  process_time_total +=
+      std::chrono::duration_cast<std::chrono::milliseconds>(frame_end - frame_start).count();
 
   for (auto const& w : game.worms) {
     auto& ws = worms[w->index];
     if (w->visible) {
-      presence.inc(ftoi(w->pos.x), ftoi(w->pos.y));
-      ws.presence.inc(ftoi(w->pos.x), ftoi(w->pos.y));
+      presence.Inc(Ftoi(w->pos.x), Ftoi(w->pos.y));
+      ws.presence.Inc(Ftoi(w->pos.x), Ftoi(w->pos.y));
 
       bool ok = true;
-      if (!w->controlStates[Worm::Control::Fire] &&
-          (!w->controlStates[Worm::Control::Change] ||
-           (!w->controlStates[Worm::Control::Left] && !w->controlStates[Worm::Control::Right])) &&
-          w->weapons[w->currentWeapon].loadingLeft == 0 &&
+      if (!w->control_states[Worm::Control::kFire] &&
+          (!w->control_states[Worm::Control::kChange] ||
+           (!w->control_states[Worm::Control::kLeft] && !w->control_states[Worm::Control::kRight])) &&
+          w->weapons[w->current_weapon].loading_left == 0 &&
           std::find_if(w->weapons, w->weapons + 5,
-                       [](WormWeapon& ww) { return ww.loadingLeft > 0; }) != w->weapons + 5) {
+                       [](WormWeapon& ww) { return ww.loading_left > 0; }) != w->weapons + 5) {
         ok = false;
       }
 
-      ws.weaponChangeGood += ok;
-      ws.weaponChangeBad += !ok;
+      ws.weapon_change_good += ok;
+      ws.weapon_change_bad += !ok;
     }
   }
 
   ++frame;
 }
 
-void NormalStatsRecorder::finish(Game& game) {
+void NormalStatsRecorder::Finish(Game& game) {
   for (int i = 0; i < 2; ++i) {
     auto const& gw = game.worms[i];
     WormStats& w = worms[i];
-    if (w.spawnTime >= 0) {
-      w.lifeSpans.push_back(std::make_pair(w.spawnTime, frame));
-      w.spawnTime = -1;
+    if (w.spawn_time >= 0) {
+      w.life_spans.push_back(std::make_pair(w.spawn_time, frame));
+      w.spawn_time = -1;
     }
     w.lives = gw->lives;
     w.timer = gw->timer;
     w.kills = gw->kills;
   }
 
-  gameTime = frame;
+  game_time = frame;
 }
 
-void NormalStatsRecorder::aiProcessTime(Worm* worm, std::chrono::nanoseconds time) {
+void NormalStatsRecorder::AiProcessTime(Worm* worm, std::chrono::nanoseconds time) {
   if (speculative) return;
   WormStats& w = worms[worm->index];
-  w.aiProcessTime += time;
+  w.ai_process_time += time;
 }

--- a/src/game/stats_recorder.hpp
+++ b/src/game/stats_recorder.hpp
@@ -10,19 +10,19 @@ struct Renderer;
 struct StatsRecorder {
   virtual ~StatsRecorder() = default;
 
-  virtual void damagePotential(Worm* byWorm, WormWeapon* weapon, int hp);
-  virtual void damageDealt(Worm* byWorm, WormWeapon* weapon, Worm* toWorm, int hp, bool hasHit);
+  virtual void DamagePotential(Worm* by_worm, WormWeapon* weapon, int hp);
+  virtual void DamageDealt(Worm* by_worm, WormWeapon* weapon, Worm* to_worm, int hp, bool has_hit);
 
-  virtual void shot(Worm* byWorm, WormWeapon* weapon);
-  virtual void hit(Worm* byWorm, WormWeapon* weapon, Worm* toWorm);
+  virtual void Shot(Worm* by_worm, WormWeapon* weapon);
+  virtual void Hit(Worm* by_worm, WormWeapon* weapon, Worm* to_worm);
 
-  virtual void afterSpawn(Worm* worm);
-  virtual void afterDeath(Worm* worm);
-  virtual void preTick(Game& game);
-  virtual void tick(Game& game);
-  virtual void finish(Game& game);
+  virtual void AfterSpawn(Worm* worm);
+  virtual void AfterDeath(Worm* worm);
+  virtual void PreTick(Game& game);
+  virtual void Tick(Game& game);
+  virtual void Finish(Game& game);
 
-  virtual void aiProcessTime(Worm* worm, std::chrono::nanoseconds time);
+  virtual void AiProcessTime(Worm* worm, std::chrono::nanoseconds time);
 
   // When true, all recording is suppressed. Set during predicted /
   // resim frames to avoid double-counting.
@@ -30,83 +30,83 @@ struct StatsRecorder {
 };
 
 struct WeaponStats {
-  WeaponStats() : potentialHp(0), actualHp(0), potentialHits(0), actualHits(0), totalHp(0) {}
+  WeaponStats() : potential_hp(0), actual_hp(0), potential_hits(0), actual_hits(0), total_hp(0) {}
 
-  void combine(WeaponStats const& other) {
-    potentialHits += other.potentialHits;
-    potentialHp += other.potentialHp;
-    actualHits += other.actualHits;
-    actualHp += other.actualHp;
-    totalHp += other.totalHp;
+  void Combine(WeaponStats const& other) {
+    potential_hits += other.potential_hits;
+    potential_hp += other.potential_hp;
+    actual_hits += other.actual_hits;
+    actual_hp += other.actual_hp;
+    total_hp += other.total_hp;
   }
 
-  int potentialHp, actualHp;
-  int potentialHits, actualHits;
-  int totalHp;
+  int potential_hp, actual_hp;
+  int potential_hits, actual_hits;
+  int total_hp;
   int index;
 };
 
 struct WormFrameStats {
-  WormFrameStats() : damage(0), totalHp(0) {}
+  WormFrameStats() : damage(0), total_hp(0) {}
 
   int damage;
-  int totalHp;
+  int total_hp;
 };
 
 struct WormStats {
   WormStats()
       : damage(0),
-        damageDealt(0),
-        selfDamage(0),
-        damageHm(504 / 2, 350 / 2, 504, 350),
+        damage_dealt(0),
+        self_damage(0),
+        damage_hm(504 / 2, 350 / 2, 504, 350),
         presence(504 / 2, 350 / 2, 504, 350),
-        weaponChangeGood(0),
-        weaponChangeBad(0),
-        spawnTime(-1),
+        weapon_change_good(0),
+        weapon_change_bad(0),
+        spawn_time(-1),
         lives(0),
         timer(0),
         kills(0),
-        aiProcessTime(0) {
+        ai_process_time(0) {
     for (int i = 0; i < 40; ++i) weapons[i].index = i;
   }
 
-  std::vector<std::pair<int, int> > lifeSpans;
+  std::vector<std::pair<int, int> > life_spans;
 
-  void lifeStats(int& min, int& max) {
+  void LifeStats(int& min, int& max) {
     min = 0;
     max = 0;
-    if (lifeSpans.empty()) return;
+    if (life_spans.empty()) return;
 
-    min = lifeSpans[0].second - lifeSpans[0].first;
+    min = life_spans[0].second - life_spans[0].first;
     max = min;
 
-    for (size_t i = 1; i < lifeSpans.size(); ++i) {
-      int len = lifeSpans[i].second - lifeSpans[i].first;
+    for (size_t i = 1; i < life_spans.size(); ++i) {
+      int len = life_spans[i].second - life_spans[i].first;
       max = std::max(len, max);
       min = std::min(len, min);
     }
   }
 
   WeaponStats weapons[40];
-  int damage, damageDealt, selfDamage;
-  Heatmap damageHm, presence;
-  int weaponChangeGood, weaponChangeBad;
+  int damage, damage_dealt, self_damage;
+  Heatmap damage_hm, presence;
+  int weapon_change_good, weapon_change_bad;
 
-  std::vector<WormFrameStats> wormFrameStats;
+  std::vector<WormFrameStats> worm_frame_stats;
 
-  int spawnTime;
+  int spawn_time;
   int index;
 
   int lives, timer, kills;
-  std::chrono::nanoseconds aiProcessTime;
+  std::chrono::nanoseconds ai_process_time;
 };
 
 struct NormalStatsRecorder : StatsRecorder {
   NormalStatsRecorder()
       : frame(0),
-        frameStart(std::chrono::steady_clock::now()),
-        processTimeTotal(0),
-        gameTime(0),
+        frame_start(std::chrono::steady_clock::now()),
+        process_time_total(0),
+        game_time(0),
         presence(504 / 2, 350 / 2, 504, 350) {
     for (int i = 0; i < 2; ++i) {
       worms[i].index = i;
@@ -115,23 +115,23 @@ struct NormalStatsRecorder : StatsRecorder {
 
   int frame;
   WormStats worms[2];
-  std::chrono::time_point<std::chrono::steady_clock> frameStart;
-  int64_t processTimeTotal;
-  int gameTime;
+  std::chrono::time_point<std::chrono::steady_clock> frame_start;
+  int64_t process_time_total;
+  int game_time;
 
   Heatmap presence;
 
-  void damagePotential(Worm* byWorm, WormWeapon* weapon, int hp);
-  void damageDealt(Worm* byWorm, WormWeapon* weapon, Worm* toWorm, int hp, bool hasHit);
+  void DamagePotential(Worm* by_worm, WormWeapon* weapon, int hp);
+  void DamageDealt(Worm* by_worm, WormWeapon* weapon, Worm* to_worm, int hp, bool has_hit);
 
-  void shot(Worm* byWorm, WormWeapon* weapon);
-  void hit(Worm* byWorm, WormWeapon* weapon, Worm* toWorm);
+  void Shot(Worm* by_worm, WormWeapon* weapon);
+  void Hit(Worm* by_worm, WormWeapon* weapon, Worm* to_worm);
 
-  void afterSpawn(Worm* worm);
-  void afterDeath(Worm* worm);
-  void preTick(Game& game);
-  void tick(Game& game);
+  void AfterSpawn(Worm* worm);
+  void AfterDeath(Worm* worm);
+  void PreTick(Game& game);
+  void Tick(Game& game);
 
-  void finish(Game& game);
-  void aiProcessTime(Worm* worm, std::chrono::nanoseconds time);
+  void Finish(Game& game);
+  void AiProcessTime(Worm* worm, std::chrono::nanoseconds time);
 };

--- a/src/game/text.cpp
+++ b/src/game/text.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <cctype>
 
-char const* timeToString(int sec) {
+char const* TimeToString(int sec) {
   static char ret[6];
 
   ret[0] = '0' + (sec / 600);
@@ -15,16 +15,16 @@ char const* timeToString(int sec) {
   return ret;
 }
 
-char const* timeToStringEx(int ms, bool forceHours, bool forceMinutes) {
+char const* TimeToStringEx(int ms, bool force_hours, bool force_minutes) {
   static char ret[10];
 
   int c = 0;
-  if (ms >= 6000000 || forceHours) {
+  if (ms >= 6000000 || force_hours) {
     ret[c++] = '0' + (ms / 6000000);
     ms %= 6000000;
   }
 
-  if (ms >= 60000 || forceMinutes) {
+  if (ms >= 60000 || force_minutes) {
     ret[c++] = '0' + (ms / 600000);
     ms %= 600000;
     ret[c++] = '0' + (ms / 60000);
@@ -44,36 +44,36 @@ char const* timeToStringEx(int ms, bool forceHours, bool forceMinutes) {
   return ret;
 }
 
-char const* timeToStringFrames(int frames) { return timeToStringEx(frames * 14, false, false); }
+char const* TimeToStringFrames(int frames) { return TimeToStringEx(frames * 14, false, false); }
 
-int safeToUpper(char ch) { return std::toupper(static_cast<unsigned char>(ch)); }
+int SafeToUpper(char ch) { return std::toupper(static_cast<unsigned char>(ch)); }
 
-bool ciCompare(std::string const& a, std::string const& b) {
+bool CiCompare(std::string const& a, std::string const& b) {
   if (a.size() != b.size()) return false;
 
   for (std::size_t i = 0; i < a.size(); ++i) {
-    if (safeToUpper(a[i]) != safeToUpper(b[i])) return false;
+    if (SafeToUpper(a[i]) != SafeToUpper(b[i])) return false;
   }
 
   return true;
 }
 
-bool ciStartsWith(std::string const& text, std::string const& startsWith) {
-  if (startsWith.size() > text.size()) return false;
+bool CiStartsWith(std::string const& text, std::string const& starts_with) {
+  if (starts_with.size() > text.size()) return false;
 
-  for (std::size_t i = 0; i < startsWith.size(); ++i) {
-    if (safeToUpper(text[i]) != safeToUpper(startsWith[i])) return false;
+  for (std::size_t i = 0; i < starts_with.size(); ++i) {
+    if (SafeToUpper(text[i]) != SafeToUpper(starts_with[i])) return false;
   }
 
   return true;
 }
 
-bool ciLess(std::string const& a, std::string const& b) {
+bool CiLess(std::string const& a, std::string const& b) {
   for (std::size_t i = 0; i < a.size(); ++i) {
     if (i >= b.size())  // a is longer, thus a > b
       return false;
-    int ach = safeToUpper(a[i]);
-    int bch = safeToUpper(b[i]);
+    int ach = SafeToUpper(a[i]);
+    int bch = SafeToUpper(b[i]);
     if (ach < bch)
       return true;
     else if (ach > bch)
@@ -83,7 +83,7 @@ bool ciLess(std::string const& a, std::string const& b) {
   return b.size() > a.size();  // if b is longer, then a < b, otherwise a == b
 }
 
-char utf8ToDOS(const char* str) {
+char Utf8ToDos(const char* str) {
   if (str[1] == 0) {
     return str[0];
   }

--- a/src/game/text.hpp
+++ b/src/game/text.hpp
@@ -4,18 +4,18 @@
 #include <cstring>
 #include <string>
 
-inline std::string toString(int v) {
-  const int BUF_MAX = 20;
-  char buf[BUF_MAX];
-  std::snprintf(buf, BUF_MAX * sizeof(char), "%d", v);
+inline std::string ToString(int v) {
+  const int kBufMax = 20;
+  char buf[kBufMax];
+  std::snprintf(buf, kBufMax * sizeof(char), "%d", v);
   return buf;
 }
 
-char const* timeToString(int sec);
-char const* timeToStringEx(int ms, bool forceHours, bool forceMinutes);
-char const* timeToStringFrames(int frames);
+char const* TimeToString(int sec);
+char const* TimeToStringEx(int ms, bool force_hours, bool force_minutes);
+char const* TimeToStringFrames(int frames);
 
-inline void rtrim(std::string& str) {
+inline void Rtrim(std::string& str) {
   std::string::size_type e = str.find_last_not_of(" \t\r\n");
   if (e == std::string::npos)
     str.clear();
@@ -23,18 +23,18 @@ inline void rtrim(std::string& str) {
     str.erase(e + 1);
 }
 
-inline void findReplace(std::string& str, std::string const& find, std::string const& replace) {
+inline void FindReplace(std::string& str, std::string const& find, std::string const& replace) {
   std::string::size_type p = str.find(find);
   if (p != std::string::npos) str.replace(p, find.size(), replace);
 }
 
-inline bool endsWith(std::string const& str, char const* end) {
+inline bool EndsWith(std::string const& str, char const* end) {
   auto pos = str.find(end);
   return pos != std::string::npos && pos + std::strlen(end) == str.size();
 }
 
-bool ciStartsWith(std::string const& a, std::string const& b);
-bool ciCompare(std::string const& a, std::string const& b);
-bool ciLess(std::string const& a, std::string const& b);
+bool CiStartsWith(std::string const& a, std::string const& b);
+bool CiCompare(std::string const& a, std::string const& b);
+bool CiLess(std::string const& a, std::string const& b);
 // converts an extremely limited subset of UTF-8 to extended ASCII
-char utf8ToDOS(const char* str);
+char Utf8ToDos(const char* str);

--- a/src/game/version.hpp
+++ b/src/game/version.hpp
@@ -1,3 +1,3 @@
 #pragma once
 
-static int const myReplayVersion = 6;
+static int const kMyReplayVersion = 6;

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -16,37 +16,37 @@ struct PreserveClipRect {
   Rect rect;
 };
 
-void Viewport::process(Game& game) {
-  Worm& worm = *game.wormByIdx(wormIdx);
+void Viewport::Process(Game& game) {
+  Worm& worm = *game.WormByIdx(worm_idx);
 
-  if (worm.killedTimer <= 0) {
+  if (worm.killed_timer <= 0) {
     if (worm.visible) {
-      if (worm.steerableCount > 0) {
-        setCenter(worm.steerableSumX / worm.steerableCount,
-                  worm.steerableSumY / worm.steerableCount);
+      if (worm.steerable_count > 0) {
+        SetCenter(worm.steerable_sum_x / worm.steerable_count,
+                  worm.steerable_sum_y / worm.steerable_count);
       } else {
-        setCenter(ftoi(worm.pos.x), ftoi(worm.pos.y));
+        SetCenter(Ftoi(worm.pos.x), Ftoi(worm.pos.y));
       }
     } else {
-      scrollTo(ftoi(worm.pos.x), ftoi(worm.pos.y), 4);
+      ScrollTo(Ftoi(worm.pos.x), Ftoi(worm.pos.y), 4);
     }
   } else if (worm.health <= 0) {
-    setCenter(ftoi(worm.pos.x), ftoi(worm.pos.y));
+    SetCenter(Ftoi(worm.pos.x), Ftoi(worm.pos.y));
 
-    if (worm.killedTimer == Worm::KilledTimerInitial) bannerY = -8;
+    if (worm.killed_timer == Worm::kKilledTimerInitial) banner_y = -8;
   }
 
-  int realShake = ftoi(shake);
+  int real_shake = Ftoi(shake);
 
-  if (realShake > 0) {
-    x += rand(realShake * 2) - realShake;
-    y += rand(realShake * 2) - realShake;
+  if (real_shake > 0) {
+    x += rand(real_shake * 2) - real_shake;
+    y += rand(real_shake * 2) - real_shake;
   }
 
   if (x < 0) x = 0;
   if (y < 0) y = 0;
-  if (x > maxX) x = maxX;
-  if (y > maxY) y = maxY;
+  if (x > max_x) x = max_x;
+  if (y > max_y) y = max_y;
 
   /*
   if(worm->health <= 0)
@@ -67,211 +67,211 @@ void Viewport::process(Game& game) {
   }*/
 }
 
-void Viewport::draw(Game& game, Renderer& renderer, GameState state, bool isReplay) {
+void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_replay) {
   Common& common = *game.common;
-  Worm& worm = *game.wormByIdx(wormIdx);
-  int multiplier = renderer.renderResX / 320;
-  int centerX = renderer.renderResX / 2;
+  Worm& worm = *game.WormByIdx(worm_idx);
+  int multiplier = renderer.render_res_x / 320;
+  int center_x = renderer.render_res_x / 2;
 
   if (worm.visible) {
-    int lifebarWidth = worm.health * 100 / worm.settings->health;
-    drawBar(renderer.bmp, worm.statsX * multiplier, renderer.renderResY - 39, lifebarWidth,
-            lifebarWidth / 10 + 234);
+    int lifebar_width = worm.health * 100 / worm.settings->health;
+    DrawBar(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 39, lifebar_width,
+            lifebar_width / 10 + 234);
   } else {
-    int lifebarWidth = 100 - (worm.killedTimer * 25) / 37;
-    if (lifebarWidth > 0) {
-      if (lifebarWidth > 100) lifebarWidth = 100;
-      drawBar(renderer.bmp, worm.statsX * multiplier, renderer.renderResY - 39, lifebarWidth,
-              lifebarWidth / 10 + 234);
+    int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
+    if (lifebar_width > 0) {
+      if (lifebar_width > 100) lifebar_width = 100;
+      DrawBar(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 39, lifebar_width,
+              lifebar_width / 10 + 234);
     }
   }
 
   // Draw kills status
 
-  WormWeapon const& ww = worm.weapons[worm.currentWeapon];
+  WormWeapon const& ww = worm.weapons[worm.current_weapon];
 
-  if (ww.available()) {
+  if (ww.Available()) {
     if (ww.ammo > 0) {
-      int ammoBarWidth = ww.ammo * 100 / ww.type->ammo;
+      int ammo_bar_width = ww.ammo * 100 / ww.type->ammo;
 
-      if (ammoBarWidth > 0)
-        drawBar(renderer.bmp, worm.statsX * multiplier, renderer.renderResY - 34, ammoBarWidth,
-                ammoBarWidth / 10 + 245);
+      if (ammo_bar_width > 0)
+        DrawBar(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 34, ammo_bar_width,
+                ammo_bar_width / 10 + 245);
     }
   } else {
-    int ammoBarWidth = 0;
+    int ammo_bar_width = 0;
 
-    if (ww.type->loadingTime != 0) {
-      int computedLoadingTime = ww.type->computedLoadingTime(*game.settings);
-      ammoBarWidth = 100 - ww.loadingLeft * 100 / computedLoadingTime;
+    if (ww.type->loading_time != 0) {
+      int computed_loading_time = ww.type->ComputedLoadingTime(*game.settings);
+      ammo_bar_width = 100 - ww.loading_left * 100 / computed_loading_time;
     } else {
-      ammoBarWidth = 100 - ww.loadingLeft * 100;
+      ammo_bar_width = 100 - ww.loading_left * 100;
     }
 
-    if (ammoBarWidth > 0)
-      drawBar(renderer.bmp, worm.statsX * multiplier, renderer.renderResY - 34, ammoBarWidth,
-              ammoBarWidth / 10 + 245);
+    if (ammo_bar_width > 0)
+      DrawBar(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 34, ammo_bar_width,
+              ammo_bar_width / 10 + 245);
 
     if ((game.cycles % 20) > 10 && worm.visible) {
-      common.font.drawText(renderer.bmp, LS(Reloading), worm.statsX * multiplier, 164 * multiplier,
+      common.font.DrawText(renderer.bmp, LS(Reloading), worm.stats_x * multiplier, 164 * multiplier,
                            50);
     }
   }
 
-  common.font.drawText(renderer.bmp, (LS(Kills) + toString(worm.kills)), worm.statsX * multiplier,
-                       renderer.renderResY - 29, 10);
+  common.font.DrawText(renderer.bmp, (LS(Kills) + ToString(worm.kills)), worm.stats_x * multiplier,
+                       renderer.render_res_y - 29, 10);
 
-  if (isReplay) {
-    common.font.drawText(renderer.bmp, worm.settings->name, worm.statsX * multiplier,
-                         renderer.renderResY - 15, 7);
-    fillRect(renderer.bmp, worm.statsX * multiplier, renderer.renderResY - 7 - 1, 8, 8, 7);
-    fillRect(renderer.bmp, (worm.statsX + 1) * multiplier, renderer.renderResY - 7, 6, 6,
+  if (is_replay) {
+    common.font.DrawText(renderer.bmp, worm.settings->name, worm.stats_x * multiplier,
+                         renderer.render_res_y - 15, 7);
+    FillRect(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 7 - 1, 8, 8, 7);
+    FillRect(renderer.bmp, (worm.stats_x + 1) * multiplier, renderer.render_res_y - 7, 6, 6,
              worm.settings->color);
-    common.font.drawText(renderer.bmp, timeToStringEx(game.cycles * 14, false, true),
-                         95 * multiplier, renderer.renderResY - 15, 7);
+    common.font.DrawText(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true),
+                         95 * multiplier, renderer.render_res_y - 15, 7);
   }
 
-  int const stateColours[2][2] = {{6, 10}, {79, 4}};
+  int const kStateColours[2][2] = {{6, 10}, {79, 4}};
 
-  switch (game.settings->gameMode) {
-    case Settings::GMKillEmAll:
-    case Settings::GMScalesOfJustice: {
-      common.font.drawText(renderer.bmp, (LS(Lives) + toString(worm.lives)),
-                           worm.statsX * multiplier, renderer.renderResY - 22, 6);
+  switch (game.settings->game_mode) {
+    case Settings::kGmKillEmAll:
+    case Settings::kGmScalesOfJustice: {
+      common.font.DrawText(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
+                           worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
     } break;
 
-    case Settings::GMHoldazone: {
+    case Settings::kGmHoldazone: {
       int state = 0;
 
       for (auto const& w : game.worms)
         if (w.get() != &worm && w->timer <= worm.timer) state = 1;
 
-      int color = stateColours[game.holdazone.holderIdx != worm.index][state];
+      int color = kStateColours[game.holdazone.holder_idx != worm.index][state];
 
-      common.font.drawText(renderer.bmp, timeToString(worm.timer), 5 * multiplier,
+      common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
                            106 * multiplier + 84 * worm.index * multiplier,
-                           renderer.renderResY - 39, color);
+                           renderer.render_res_y - 39, color);
     } break;
 
-    case Settings::GMGameOfTag: {
+    case Settings::kGmGameOfTag: {
       int state = 0;
 
       for (auto const& w : game.worms)
         if (w.get() != &worm && w->timer >= worm.timer) state = 1;
 
-      int color = stateColours[game.lastKilledIdx != worm.index][state];
+      int color = kStateColours[game.last_killed_idx != worm.index][state];
 
-      common.font.drawText(renderer.bmp, timeToString(worm.timer), 5 * multiplier,
+      common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
                            106 * multiplier + 84 * worm.index * multiplier,
-                           renderer.renderResY - 39, color);
+                           renderer.render_res_y - 39, color);
     } break;
   }
 
-  IVec2 renderPos(x, y);
+  IVec2 render_pos(x, y);
 
   {
     PreserveClipRect pcr(renderer.bmp);
 
     renderer.bmp.clip_rect = rect;
 
-    fixedvec offs = rect.ul() - renderPos;
+    fixedvec offs = rect.Ul() - render_pos;
 
-    blitImageNoKeyColour(renderer.bmp, &game.level.data[0], offs.x, offs.y, game.level.width,
+    BlitImageNoKeyColour(renderer.bmp, &game.level.data[0], offs.x, offs.y, game.level.width,
                          game.level.height);
 
-    if (game.settings->gameMode == Settings::GMHoldazone) {
-      bool timingOut = game.holdazone.timeoutLeft < 70 * 4;
+    if (game.settings->game_mode == Settings::kGmHoldazone) {
+      bool timing_out = game.holdazone.timeout_left < 70 * 4;
 
-      int color = timingOut ? 168 : 50;
-      int contenderColor;
+      int color = timing_out ? 168 : 50;
+      int contender_color;
 
-      if (game.holdazone.contenderIdx >= 0) {
-        Worm* contender = game.wormByIdx(game.holdazone.contenderIdx);
-        if (timingOut)
-          contenderColor = contender->minimapColor();
+      if (game.holdazone.contender_idx >= 0) {
+        Worm* contender = game.WormByIdx(game.holdazone.contender_idx);
+        if (timing_out)
+          contender_color = contender->MinimapColor();
         else
-          contenderColor = Palette::wormColourIndexes[contender->index] + 5;
+          contender_color = Palette::kWormColourIndexes[contender->index] + 5;
       } else {
-        contenderColor = color;
+        contender_color = color;
       }
 
-      drawDashedLineBox(
+      DrawDashedLineBox(
           renderer.bmp, game.holdazone.rect.x1 + offs.x, game.holdazone.rect.y1 + offs.y, color,
-          contenderColor, game.holdazone.contenderFrames, game.settings->zoneCaptureTime,
-          game.holdazone.rect.width(), game.holdazone.rect.height(), game.cycles / 10);
+          contender_color, game.holdazone.contender_frames, game.settings->kZoneCaptureTime,
+          game.holdazone.rect.Width(), game.holdazone.rect.Height(), game.cycles / 10);
     }
 
-    if (!worm.visible && worm.killedTimer <= 0 && !worm.ready) {
-      common.font.drawText(renderer.bmp, LS(PressFire), rect.center_x() - 30, 76, 0);
-      common.font.drawText(renderer.bmp, LS(PressFire), rect.center_x() - 31, 75, 50);
+    if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
+      common.font.DrawText(renderer.bmp, LS(PressFire), rect.CenterX() - 30, 76, 0);
+      common.font.DrawText(renderer.bmp, LS(PressFire), rect.CenterX() - 31, 75, 50);
 
-      if (game.settings->allowViewingSpawnPoint && worm.pressed(Worm::Change)) {
-        int tempX = ftoi(worm.pos.x) - 7 + offs.x;
-        int tempY = ftoi(worm.pos.y) - 5 + offs.y;
+      if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
+        int temp_x = Ftoi(worm.pos.x) - 7 + offs.x;
+        int temp_y = Ftoi(worm.pos.y) - 5 + offs.y;
 
-        blitImageTrans(renderer.bmp,
-                       common.wormSpriteObj(worm.currentFrame, worm.direction, worm.index), tempX,
-                       tempY, game.cycles);
+        BlitImageTrans(renderer.bmp,
+                       common.WormSpriteObj(worm.current_frame, worm.direction, worm.index), temp_x,
+                       temp_y, game.cycles);
       }
     }
 
-    if (bannerY > -8 && worm.health <= 0) {
-      if (game.settings->gameMode == Settings::GMGameOfTag && game.gotChanged) {
-        common.font.drawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, bannerY + 1, 0);
-        common.font.drawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, bannerY, 50);
+    if (banner_y > -8 && worm.health <= 0) {
+      if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
+        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
       }
     }
 
     for (std::size_t i = 0; i < game.viewports.size(); ++i) {
       Viewport* v = game.viewports[i];
-      Worm& otherWorm = *game.wormByIdx(v->wormIdx);
-      if (v != this && otherWorm.health <= 0 && v->bannerY > -8) {
-        if (otherWorm.lastKilledByIdx == worm.index) {
-          std::string msg(LS(KilledMsg) + otherWorm.settings->name);
-          common.font.drawText(renderer.bmp, msg, rect.x1 + 3, v->bannerY + 1, 0);
-          common.font.drawText(renderer.bmp, msg, rect.x1 + 2, v->bannerY, 50);
+      Worm& other_worm = *game.WormByIdx(v->worm_idx);
+      if (v != this && other_worm.health <= 0 && v->banner_y > -8) {
+        if (other_worm.last_killed_by_idx == worm.index) {
+          std::string msg(LS(KilledMsg) + other_worm.settings->name);
+          common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
+          common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
         } else {
-          std::string msg(otherWorm.settings->name + LS(CommittedSuicideMsg));
-          common.font.drawText(renderer.bmp, msg, rect.x1 + 3, v->bannerY + 1, 0);
-          common.font.drawText(renderer.bmp, msg, rect.x1 + 2, v->bannerY, 50);
+          std::string msg(other_worm.settings->name + LS(CommittedSuicideMsg));
+          common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
+          common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
         }
       }
     }
 
-    auto br = game.bonuses.all();
-    for (Bonus* i; (i = br.next());) {
+    auto br = game.bonuses.All();
+    for (Bonus* i; (i = br.Next());) {
       if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
-        int f = common.bonusFrames[i->frame];
+        int f = common.bonus_frames[i->frame];
 
-        blitImage(renderer.bmp, common.smallSprites[f], ftoi(i->x) - 3 + offs.x,
-                  ftoi(i->y) - 3 + offs.y);
+        BlitImage(renderer.bmp, common.small_sprites[f], Ftoi(i->x) - 3 + offs.x,
+                  Ftoi(i->y) - 3 + offs.y);
 
         if (game.settings->shadow) {
-          blitShadowImage(common, renderer.bmp, common.smallSprites.spritePtr(f),
-                          ftoi(i->x) - 5 + offs.x,  // TODO: Use offsX
-                          ftoi(i->y) - 1 + offs.y, 7, 7);
+          BlitShadowImage(common, renderer.bmp, common.small_sprites.SpritePtr(f),
+                          Ftoi(i->x) - 5 + offs.x,  // TODO: Use offsX
+                          Ftoi(i->y) - 1 + offs.y, 7, 7);
         }
 
-        if (game.settings->namesOnBonuses && i->frame == 0) {
+        if (game.settings->names_on_bonuses && i->frame == 0) {
           std::string const& name = common.weapons[i->weapon].name;
           int len = int(name.size()) * 4;
 
-          common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(i->x) - len / 2 + offs.x,
-                               ftoi(i->y) - 10 + offs.y);
+          common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->x) - len / 2 + offs.x,
+                               Ftoi(i->y) - 10 + offs.y);
         }
       }
     }
 
-    auto sr = game.sobjects.all();
-    for (SObject* i; (i = sr.next());) {
-      SObjectType const& t = common.sobjectTypes[i->id];
-      int frame = i->curFrame + t.startFrame;
+    auto sr = game.sobjects.All();
+    for (SObject* i; (i = sr.Next());) {
+      SObjectType const& t = common.sobject_types[i->id];
+      int frame = i->cur_frame + t.start_frame;
 
-      blitImageR(renderer.bmp, common.largeSprites.spritePtr(frame), i->x + offs.x, i->y + offs.y,
+      BlitImageR(renderer.bmp, common.large_sprites.SpritePtr(frame), i->x + offs.x, i->y + offs.y,
                  16, 16);
 
       if (game.settings->shadow) {
-        blitShadowImage(common, renderer.bmp, common.largeSprites.spritePtr(frame),
+        BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(frame),
                         i->x + offs.x - 3,
                         i->y + offs.y + 3,  // TODO: Original doesn't offset the shadow, which is
                                             // clearly wrong. Check that this offset is correct.
@@ -279,104 +279,104 @@ void Viewport::draw(Game& game, Renderer& renderer, GameState state, bool isRepl
       }
     }
 
-    auto wr = game.wobjects.all();
-    for (WObject* i; (i = wr.next());) {
+    auto wr = game.wobjects.All();
+    for (WObject* i; (i = wr.Next());) {
       Weapon const& w = *i->type;
 
-      if (w.startFrame > -1) {
-        int curFrame = i->curFrame;
-        int shotType = w.shotType;
+      if (w.start_frame > -1) {
+        int cur_frame = i->cur_frame;
+        int shot_type = w.shot_type;
 
-        if (shotType == 2) {
-          curFrame += 4;
-          curFrame >>= 3;
-          if (curFrame < 0)
-            curFrame = 16;
-          else if (curFrame > 15)
-            curFrame -= 16;
-        } else if (shotType == 3) {
-          if (curFrame > 64) --curFrame;
-          curFrame -= 12;
-          curFrame >>= 3;
-          if (curFrame < 0)
-            curFrame = 0;
-          else if (curFrame > 12)
-            curFrame = 12;
+        if (shot_type == 2) {
+          cur_frame += 4;
+          cur_frame >>= 3;
+          if (cur_frame < 0)
+            cur_frame = 16;
+          else if (cur_frame > 15)
+            cur_frame -= 16;
+        } else if (shot_type == 3) {
+          if (cur_frame > 64) --cur_frame;
+          cur_frame -= 12;
+          cur_frame >>= 3;
+          if (cur_frame < 0)
+            cur_frame = 0;
+          else if (cur_frame > 12)
+            cur_frame = 12;
         }
 
-        int posX = ftoi(i->pos.x) - 3;
-        int posY = ftoi(i->pos.y) - 3;
+        int pos_x = Ftoi(i->pos.x) - 3;
+        int pos_y = Ftoi(i->pos.y) - 3;
 
         if (game.settings->shadow && w.shadow) {
-          blitShadowImage(common, renderer.bmp,
-                          common.smallSprites.spritePtr(w.startFrame + curFrame), posX - 3 + offs.x,
-                          posY + 3 + offs.y, 7, 7);
+          BlitShadowImage(common, renderer.bmp,
+                          common.small_sprites.SpritePtr(w.start_frame + cur_frame), pos_x - 3 + offs.x,
+                          pos_y + 3 + offs.y, 7, 7);
         }
 
-        blitImage(renderer.bmp, common.smallSprites[w.startFrame + curFrame], posX + offs.x,
-                  posY + offs.y);
-      } else if (i->curFrame > 0) {
-        int posX = ftoi(i->pos.x) - x + rect.x1;
-        int posY = ftoi(i->pos.y) - y + rect.y1;
+        BlitImage(renderer.bmp, common.small_sprites[w.start_frame + cur_frame], pos_x + offs.x,
+                  pos_y + offs.y);
+      } else if (i->cur_frame > 0) {
+        int pos_x = Ftoi(i->pos.x) - x + rect.x1;
+        int pos_y = Ftoi(i->pos.y) - y + rect.y1;
 
-        if (renderer.bmp.clip_rect.inside(posX, posY))
-          renderer.bmp.getPixel(posX, posY) = static_cast<PalIdx>(i->curFrame);
+        if (renderer.bmp.clip_rect.Inside(pos_x, pos_y))
+          renderer.bmp.GetPixel(pos_x, pos_y) = static_cast<PalIdx>(i->cur_frame);
 
         if (game.settings->shadow) {
-          posX -= 3;
-          posY += 3;
+          pos_x -= 3;
+          pos_y += 3;
 
-          if (renderer.bmp.clip_rect.inside(posX, posY)) {
-            PalIdx& pix = renderer.bmp.getPixel(posX, posY);
-            if (common.materials[pix].seeShadow()) pix += 4;
+          if (renderer.bmp.clip_rect.Inside(pos_x, pos_y)) {
+            PalIdx& pix = renderer.bmp.GetPixel(pos_x, pos_y);
+            if (common.materials[pix].SeeShadow()) pix += 4;
           }
         }
       }
 
-      if (!common.H[HRemExp] && i->type - &common.weapons[0] == 34 &&
-          game.settings->namesOnBonuses)  // TODO: Read from EXE
+      if (!common.h[HRemExp] && i->type - &common.weapons[0] == 34 &&
+          game.settings->names_on_bonuses)  // TODO: Read from EXE
       {
-        if (i->curFrame == 0) {
-          int nameNum = int(&*i - game.wobjects.arr) %
+        if (i->cur_frame == 0) {
+          int name_num = int(&*i - game.wobjects.arr) %
                         (int)common.weapons.size();  // TODO: Something nicer maybe
 
-          std::string const& name = common.weapons[nameNum].name;
+          std::string const& name = common.weapons[name_num].name;
           int width = int(name.size()) * 4;
 
-          common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(i->pos.x) - width / 2 + offs.x,
-                               ftoi(i->pos.y) - 10 + offs.y);
+          common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->pos.x) - width / 2 + offs.x,
+                               Ftoi(i->pos.y) - 10 + offs.y);
         }
       }
     }
 
-    auto nr = game.nobjects.all();
-    for (NObject* i; (i = nr.next());) {
+    auto nr = game.nobjects.All();
+    for (NObject* i; (i = nr.Next());) {
       NObjectType const& t = *i->type;
 
-      if (t.startFrame > 0) {
-        auto pos = ftoi(i->pos) - IVec2(3, 3);
+      if (t.start_frame > 0) {
+        auto pos = Ftoi(i->pos) - IVec2(3, 3);
 
         if (game.settings->shadow) {
-          blitShadowImage(common, renderer.bmp,
-                          common.smallSprites.spritePtr(t.startFrame + i->curFrame),
+          BlitShadowImage(common, renderer.bmp,
+                          common.small_sprites.SpritePtr(t.start_frame + i->cur_frame),
                           pos.x - 3 + offs.x, pos.y + 3 + offs.y, 7, 7);
         }
 
-        blitImage(renderer.bmp, common.smallSprites[t.startFrame + i->curFrame], pos.x + offs.x,
+        BlitImage(renderer.bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + offs.x,
                   pos.y + offs.y);
 
-      } else if (i->curFrame > 1) {
-        auto pos = ftoi(i->pos) + offs;
-        if (renderer.bmp.clip_rect.encloses(pos))
-          renderer.bmp.getPixel(pos.x, pos.y) = PalIdx(i->curFrame);
+      } else if (i->cur_frame > 1) {
+        auto pos = Ftoi(i->pos) + offs;
+        if (renderer.bmp.clip_rect.Encloses(pos))
+          renderer.bmp.GetPixel(pos.x, pos.y) = PalIdx(i->cur_frame);
 
         if (game.settings->shadow) {
           pos.x -= 3;
           pos.y += 3;
 
-          if (renderer.bmp.clip_rect.encloses(pos)) {
-            PalIdx& pix = renderer.bmp.getPixel(pos.x, pos.y);
-            if (common.materials[pix].seeShadow()) pix += 4;
+          if (renderer.bmp.clip_rect.Encloses(pos)) {
+            PalIdx& pix = renderer.bmp.GetPixel(pos.x, pos.y);
+            if (common.materials[pix].SeeShadow()) pix += 4;
           }
         }
       }
@@ -386,61 +386,61 @@ void Viewport::draw(Game& game, Renderer& renderer, GameState state, bool isRepl
       Worm const& w = *game.worms[i];
 
       if (w.visible) {
-        int tempX = ftoi(w.pos.x) - 7 + offs.x;
-        int tempY = ftoi(w.pos.y) - 5 + offs.y;
-        int angleFrame = w.angleFrame();
+        int temp_x = Ftoi(w.pos.x) - 7 + offs.x;
+        int temp_y = Ftoi(w.pos.y) - 5 + offs.y;
+        int angle_frame = w.AngleFrame();
 
-        if (w.weapons[w.currentWeapon].available()) {
-          int hotspotX = w.hotspotX + offs.x;
-          int hotspotY = w.hotspotY + offs.y;
+        if (w.weapons[w.current_weapon].Available()) {
+          int hotspot_x = w.hotspot_x + offs.x;
+          int hotspot_y = w.hotspot_y + offs.y;
 
-          WormWeapon const& ww = w.weapons[w.currentWeapon];
+          WormWeapon const& ww = w.weapons[w.current_weapon];
           Weapon const& weapon = *ww.type;
 
-          if (weapon.laserSight) {
-            drawLaserSight(renderer.bmp, rand, hotspotX, hotspotY, tempX + 7, tempY + 4);
+          if (weapon.laser_sight) {
+            DrawLaserSight(renderer.bmp, rand, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4);
           }
 
-          if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.pressed(Worm::Fire)) {
-            drawLine(renderer.bmp, hotspotX, hotspotY, tempX + 7, tempY + 4, weapon.colorBullets);
+          if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
+            DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4, weapon.color_bullets);
           }
         }
 
         if (w.ninjarope.out) {
-          int ninjaropeX = ftoi(w.ninjarope.pos.x) + offs.x;
-          int ninjaropeY = ftoi(w.ninjarope.pos.y) + offs.y;
+          int ninjarope_x = Ftoi(w.ninjarope.pos.x) + offs.x;
+          int ninjarope_y = Ftoi(w.ninjarope.pos.y) + offs.y;
 
-          drawNinjarope(common, renderer.bmp, ninjaropeX, ninjaropeY, tempX + 7, tempY + 4);
+          DrawNinjarope(common, renderer.bmp, ninjarope_x, ninjarope_y, temp_x + 7, temp_y + 4);
 
-          blitImage(renderer.bmp, common.largeSprites[84], ninjaropeX - 1, ninjaropeY - 1);
+          BlitImage(renderer.bmp, common.large_sprites[84], ninjarope_x - 1, ninjarope_y - 1);
 
           if (game.settings->shadow) {
-            drawShadowLine(common, renderer.bmp, ninjaropeX - 3, ninjaropeY + 3, tempX + 7 - 3,
-                           tempY + 4 + 3);
-            blitShadowImage(common, renderer.bmp, common.largeSprites.spritePtr(84), ninjaropeX - 4,
-                            ninjaropeY + 2, 16, 16);
+            DrawShadowLine(common, renderer.bmp, ninjarope_x - 3, ninjarope_y + 3, temp_x + 7 - 3,
+                           temp_y + 4 + 3);
+            BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(84), ninjarope_x - 4,
+                            ninjarope_y + 2, 16, 16);
           }
         }
 
-        if (w.weapons[w.currentWeapon].type->fireCone > 0 && w.fireCone > 0) {
+        if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
           /* TODO
           //NOTE! Check fctab so it's correct
           //NOTE! Check function 1071C and see what it actually does*/
 
-          blitFireCone(renderer.bmp, w.fireCone / 2, common.fireConeSprite(angleFrame, w.direction),
-                       common.fireConeOffset[w.direction][angleFrame][0] + tempX,
-                       common.fireConeOffset[w.direction][angleFrame][1] + tempY);
+          BlitFireCone(renderer.bmp, w.fire_cone / 2, common.FireConeSprite(angle_frame, w.direction),
+                       common.fire_cone_offset[w.direction][angle_frame][0] + temp_x,
+                       common.fire_cone_offset[w.direction][angle_frame][1] + temp_y);
         }
 
-        blitImage(renderer.bmp, common.wormSpriteObj(w.currentFrame, w.direction, w.index), tempX,
-                  tempY);
+        BlitImage(renderer.bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), temp_x,
+                  temp_y);
         if (game.settings->shadow)
-          blitShadowImage(common, renderer.bmp,
-                          common.wormSprite(w.currentFrame, w.direction, w.index), tempX - 3,
-                          tempY + 3, 16, 16);
+          BlitShadowImage(common, renderer.bmp,
+                          common.WormSprite(w.current_frame, w.direction, w.index), temp_x - 3,
+                          temp_y + 3, 16, 16);
       }
 
-      if (w.ai) w.ai->drawDebug(game, w, renderer, offs.x, offs.y);
+      if (w.ai) w.ai->DrawDebug(game, w, renderer, offs.x, offs.y);
     }
 
     /*
@@ -457,75 +457,75 @@ void Viewport::draw(Game& game, Renderer& renderer, GameState state, bool isRepl
 
     if (worm.visible) {
       auto temp =
-          ftoi(worm.pos) - IVec2(1, 2) + ftoi(cossinTable[ftoi(worm.aimingAngle)] * 16) + offs;
+          Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16) + offs;
       // int tempX = ftoi(worm.pos.x) - 1 + ftoi(cosTable[ftoi(worm.aimingAngle)] * 16) + offs.x;
       // int tempY = ftoi(worm.pos.y) - 2 + ftoi(sinTable[ftoi(worm.aimingAngle)] * 16) + offs.y;
 
-      blitImage(renderer.bmp, common.smallSprites[worm.makeSightGreen ? 44 : 43], temp.x, temp.y);
+      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
 
-      if (worm.pressed(Worm::Change)) {
-        std::string const& name = worm.weapons[worm.currentWeapon].type->name;
+      if (worm.Pressed(Worm::kChange)) {
+        std::string const& name = worm.weapons[worm.current_weapon].type->name;
 
         int len = int(name.size()) * 4;  // TODO: Read 4 from exe? (SW_CHARWID)
 
-        common.drawTextSmall(renderer.bmp, name.c_str(), ftoi(worm.pos.x) - len / 2 + 1 + offs.x,
-                             ftoi(worm.pos.y) - 10 + offs.y);
+        common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(worm.pos.x) - len / 2 + 1 + offs.x,
+                             Ftoi(worm.pos.y) - 10 + offs.y);
       }
     }
 
-    for (Game::BObjectList::iterator i = game.bobjects.begin(); i != game.bobjects.end(); ++i) {
-      auto ipos = ftoi(i->pos) + offs;
-      if (renderer.bmp.clip_rect.encloses(ipos))
-        renderer.bmp.getPixel(ipos.x, ipos.y) = PalIdx(i->color);
+    for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
+      auto ipos = Ftoi(i->pos) + offs;
+      if (renderer.bmp.clip_rect.Encloses(ipos))
+        renderer.bmp.GetPixel(ipos.x, ipos.y) = PalIdx(i->color);
 
       if (game.settings->shadow) {
         ipos.x -= 3;
         ipos.y += 3;
 
-        if (renderer.bmp.clip_rect.encloses(ipos)) {
-          PalIdx& pix = renderer.bmp.getPixel(ipos.x, ipos.y);
-          if (common.materials[pix].seeShadow()) pix += 4;
+        if (renderer.bmp.clip_rect.Encloses(ipos)) {
+          PalIdx& pix = renderer.bmp.GetPixel(ipos.x, ipos.y);
+          if (common.materials[pix].SeeShadow()) pix += 4;
         }
       }
     }
   }
 
   if (game.settings->map) {
-    int mapX = centerX - 26;
-    int mapY = renderer.renderResY - 38;
+    int map_x = center_x - 26;
+    int map_y = renderer.render_res_y - 38;
 
-    game.level.drawMiniature(renderer.bmp, mapX, mapY, 10);
+    game.level.DrawMiniature(renderer.bmp, map_x, map_y, 10);
 
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm const& w = *game.worms[i];
 
       if (w.visible) {
-        int x = ftoi(w.pos.x) / 10 + mapX;
-        int y = ftoi(w.pos.y) / 10 + mapY;
+        int x = Ftoi(w.pos.x) / 10 + map_x;
+        int y = Ftoi(w.pos.y) / 10 + map_y;
 
-        renderer.bmp.getPixel(x, y) = w.minimapColor();
+        renderer.bmp.GetPixel(x, y) = w.MinimapColor();
       }
     }
 
-    if (game.settings->gameMode == Settings::GMHoldazone && game.holdazone.timeoutLeft > 0) {
-      int x = game.holdazone.rect.center_x() / 10 + mapX;
-      int y = game.holdazone.rect.center_y() / 10 + mapY;
+    if (game.settings->game_mode == Settings::kGmHoldazone && game.holdazone.timeout_left > 0) {
+      int x = game.holdazone.rect.CenterX() / 10 + map_x;
+      int y = game.holdazone.rect.CenterY() / 10 + map_y;
 
       int color = 168;
 
-      if (game.holdazone.holderIdx >= 0) {
-        Worm* holder = game.wormByIdx(game.holdazone.holderIdx);
-        color = holder->minimapColor();
+      if (game.holdazone.holder_idx >= 0) {
+        Worm* holder = game.WormByIdx(game.holdazone.holder_idx);
+        color = holder->MinimapColor();
       }
 
-      renderer.bmp.setPixel(x - 1, y, color);
-      renderer.bmp.setPixel(x + 1, y, color);
-      renderer.bmp.setPixel(x, y - 1, color);
-      renderer.bmp.setPixel(x, y + 1, color);
-      renderer.bmp.setPixel(x - 1, y - 1, color);
-      renderer.bmp.setPixel(x + 1, y - 1, color);
-      renderer.bmp.setPixel(x - 1, y + 1, color);
-      renderer.bmp.setPixel(x + 1, y + 1, color);
+      renderer.bmp.SetPixel(x - 1, y, color);
+      renderer.bmp.SetPixel(x + 1, y, color);
+      renderer.bmp.SetPixel(x, y - 1, color);
+      renderer.bmp.SetPixel(x, y + 1, color);
+      renderer.bmp.SetPixel(x - 1, y - 1, color);
+      renderer.bmp.SetPixel(x + 1, y - 1, color);
+      renderer.bmp.SetPixel(x - 1, y + 1, color);
+      renderer.bmp.SetPixel(x + 1, y + 1, color);
     }
   }
 }

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -309,8 +309,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
 
         if (game.settings->shadow && w.shadow) {
           BlitShadowImage(common, renderer.bmp,
-                          common.small_sprites.SpritePtr(w.start_frame + cur_frame), pos_x - 3 + offs.x,
-                          pos_y + 3 + offs.y, 7, 7);
+                          common.small_sprites.SpritePtr(w.start_frame + cur_frame),
+                          pos_x - 3 + offs.x, pos_y + 3 + offs.y, 7, 7);
         }
 
         BlitImage(renderer.bmp, common.small_sprites[w.start_frame + cur_frame], pos_x + offs.x,
@@ -338,7 +338,7 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
       {
         if (i->cur_frame == 0) {
           int name_num = int(&*i - game.wobjects.arr) %
-                        (int)common.weapons.size();  // TODO: Something nicer maybe
+                         (int)common.weapons.size();  // TODO: Something nicer maybe
 
           std::string const& name = common.weapons[name_num].name;
           int width = int(name.size()) * 4;
@@ -402,7 +402,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
           }
 
           if (ww.type - &common.weapons[0] == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
-            DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4, weapon.color_bullets);
+            DrawLine(renderer.bmp, hotspot_x, hotspot_y, temp_x + 7, temp_y + 4,
+                     weapon.color_bullets);
           }
         }
 
@@ -417,8 +418,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
           if (game.settings->shadow) {
             DrawShadowLine(common, renderer.bmp, ninjarope_x - 3, ninjarope_y + 3, temp_x + 7 - 3,
                            temp_y + 4 + 3);
-            BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(84), ninjarope_x - 4,
-                            ninjarope_y + 2, 16, 16);
+            BlitShadowImage(common, renderer.bmp, common.large_sprites.SpritePtr(84),
+                            ninjarope_x - 4, ninjarope_y + 2, 16, 16);
           }
         }
 
@@ -427,7 +428,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
           //NOTE! Check fctab so it's correct
           //NOTE! Check function 1071C and see what it actually does*/
 
-          BlitFireCone(renderer.bmp, w.fire_cone / 2, common.FireConeSprite(angle_frame, w.direction),
+          BlitFireCone(renderer.bmp, w.fire_cone / 2,
+                       common.FireConeSprite(angle_frame, w.direction),
                        common.fire_cone_offset[w.direction][angle_frame][0] + temp_x,
                        common.fire_cone_offset[w.direction][angle_frame][1] + temp_y);
         }
@@ -461,7 +463,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
       // int tempX = ftoi(worm.pos.x) - 1 + ftoi(cosTable[ftoi(worm.aimingAngle)] * 16) + offs.x;
       // int tempY = ftoi(worm.pos.y) - 2 + ftoi(sinTable[ftoi(worm.aimingAngle)] * 16) + offs.y;
 
-      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
+      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
+                temp.y);
 
       if (worm.Pressed(Worm::kChange)) {
         std::string const& name = worm.weapons[worm.current_weapon].type->name;

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -113,22 +113,22 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
               ammo_bar_width / 10 + 245);
 
     if ((game.cycles % 20) > 10 && worm.visible) {
-      common.font.DrawText(renderer.bmp, LS(Reloading), worm.stats_x * multiplier, 164 * multiplier,
-                           50);
+      common.font.DrawString(renderer.bmp, LS(Reloading), worm.stats_x * multiplier,
+                             164 * multiplier, 50);
     }
   }
 
-  common.font.DrawText(renderer.bmp, (LS(Kills) + ToString(worm.kills)), worm.stats_x * multiplier,
-                       renderer.render_res_y - 29, 10);
+  common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)),
+                         worm.stats_x * multiplier, renderer.render_res_y - 29, 10);
 
   if (is_replay) {
-    common.font.DrawText(renderer.bmp, worm.settings->name, worm.stats_x * multiplier,
-                         renderer.render_res_y - 15, 7);
+    common.font.DrawString(renderer.bmp, worm.settings->name, worm.stats_x * multiplier,
+                           renderer.render_res_y - 15, 7);
     FillRect(renderer.bmp, worm.stats_x * multiplier, renderer.render_res_y - 7 - 1, 8, 8, 7);
     FillRect(renderer.bmp, (worm.stats_x + 1) * multiplier, renderer.render_res_y - 7, 6, 6,
              worm.settings->color);
-    common.font.DrawText(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true),
-                         95 * multiplier, renderer.render_res_y - 15, 7);
+    common.font.DrawString(renderer.bmp, TimeToStringEx(game.cycles * 14, false, true),
+                           95 * multiplier, renderer.render_res_y - 15, 7);
   }
 
   int const kStateColours[2][2] = {{6, 10}, {79, 4}};
@@ -136,8 +136,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
   switch (game.settings->game_mode) {
     case Settings::kGmKillEmAll:
     case Settings::kGmScalesOfJustice: {
-      common.font.DrawText(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
-                           worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
+      common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
+                             worm.stats_x * multiplier, renderer.render_res_y - 22, 6);
     } break;
 
     case Settings::kGmHoldazone: {
@@ -148,9 +148,9 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
 
       int color = kStateColours[game.holdazone.holder_idx != worm.index][state];
 
-      common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
-                           106 * multiplier + 84 * worm.index * multiplier,
-                           renderer.render_res_y - 39, color);
+      common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
+                             106 * multiplier + 84 * worm.index * multiplier,
+                             renderer.render_res_y - 39, color);
     } break;
 
     case Settings::kGmGameOfTag: {
@@ -161,9 +161,9 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
 
       int color = kStateColours[game.last_killed_idx != worm.index][state];
 
-      common.font.DrawText(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
-                           106 * multiplier + 84 * worm.index * multiplier,
-                           renderer.render_res_y - 39, color);
+      common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5 * multiplier,
+                             106 * multiplier + 84 * worm.index * multiplier,
+                             renderer.render_res_y - 39, color);
     } break;
   }
 
@@ -202,8 +202,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
     }
 
     if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
-      common.font.DrawText(renderer.bmp, LS(PressFire), rect.CenterX() - 30, 76, 0);
-      common.font.DrawText(renderer.bmp, LS(PressFire), rect.CenterX() - 31, 75, 50);
+      common.font.DrawString(renderer.bmp, LS(PressFire), rect.CenterX() - 30, 76, 0);
+      common.font.DrawString(renderer.bmp, LS(PressFire), rect.CenterX() - 31, 75, 50);
 
       if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
         int temp_x = Ftoi(worm.pos.x) - 7 + offs.x;
@@ -217,8 +217,8 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
 
     if (banner_y > -8 && worm.health <= 0) {
       if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
-        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawText(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
       }
     }
 
@@ -228,12 +228,12 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState state, bool is_rep
       if (v != this && other_worm.health <= 0 && v->banner_y > -8) {
         if (other_worm.last_killed_by_idx == worm.index) {
           std::string msg(LS(KilledMsg) + other_worm.settings->name);
-          common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
-          common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
+          common.font.DrawString(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
+          common.font.DrawString(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
         } else {
           std::string msg(other_worm.settings->name + LS(CommittedSuicideMsg));
-          common.font.DrawText(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
-          common.font.DrawText(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
+          common.font.DrawString(renderer.bmp, msg, rect.x1 + 3, v->banner_y + 1, 0);
+          common.font.DrawString(renderer.bmp, msg, rect.x1 + 2, v->banner_y, 50);
         }
       }
     }

--- a/src/game/viewport.hpp
+++ b/src/game/viewport.hpp
@@ -9,12 +9,12 @@
 struct Renderer;
 
 struct Viewport {
-  Viewport(Rect rect, int wormIdx, int levwidth, int levheight)
-      : wormIdx(wormIdx), bannerY(-8), rect(rect) {
-    maxX = levwidth - rect.width();
-    maxY = levheight - rect.height();
-    centerX = rect.width() >> 1;
-    centerY = rect.height() >> 1;
+  Viewport(Rect rect, int worm_idx, int levwidth, int levheight)
+      : worm_idx(worm_idx), banner_y(-8), rect(rect) {
+    max_x = levwidth - rect.Width();
+    max_y = levheight - rect.Height();
+    center_x = rect.Width() >> 1;
+    center_y = rect.Height() >> 1;
     x = 0;
     y = 0;
     shake = 0;
@@ -24,32 +24,32 @@ struct Viewport {
 
   int x, y;
   int shake;
-  int maxX, maxY;
-  int centerX, centerY;
-  int wormIdx;
-  int bannerY;
+  int max_x, max_y;
+  int center_x, center_y;
+  int worm_idx;
+  int banner_y;
   Rect rect;
   Rand rand;
 
-  void setCenter(int x, int y) {
-    this->x = x - centerX;
-    this->y = y - centerY;
+  void SetCenter(int x, int y) {
+    this->x = x - center_x;
+    this->y = y - center_y;
   }
 
-  void scrollTo(int destX, int destY, int iter) {
+  void ScrollTo(int dest_x, int dest_y, int iter) {
     for (int c = 0; c < iter; c++) {
-      if (x < destX - centerX)
+      if (x < dest_x - center_x)
         ++x;
-      else if (x > destX - centerX)
+      else if (x > dest_x - center_x)
         --x;
 
-      if (y < destY - centerY)
+      if (y < dest_y - center_y)
         ++y;
-      else if (y > destY - centerY)
+      else if (y > dest_y - center_y)
         --y;
     }
   }
 
-  virtual void draw(Game& game, Renderer& renderer, GameState state, bool isReplay);
-  virtual void process(Game& game);
+  virtual void Draw(Game& game, Renderer& renderer, GameState state, bool is_replay);
+  virtual void Process(Game& game);
 };

--- a/src/game/weapon.cpp
+++ b/src/game/weapon.cpp
@@ -5,124 +5,124 @@
 #include "math.hpp"
 #include "mixer/player.hpp"
 
-int Weapon::computedLoadingTime(Settings& settings) const {
-  int ret = (settings.loadingTime * loadingTime) / 100;
+int Weapon::ComputedLoadingTime(Settings& settings) const {
+  int ret = (settings.loading_time * loading_time) / 100;
   if (ret == 0) ret = 1;
   return ret;
 }
 
-void Weapon::fire(Game& game, int angle, fixedvec vel, int speed, fixedvec pos, int ownerIdx,
+void Weapon::Fire(Game& game, int angle, fixedvec vel, int speed, fixedvec pos, int owner_idx,
                   WormWeapon* ww) const {
-  WObject* obj = game.wobjects.newObjectReuse();
+  WObject* obj = game.wobjects.NewObjectReuse();
 
   obj->type = this;
   obj->pos = pos;
-  obj->ownerIdx = ownerIdx;
+  obj->owner_idx = owner_idx;
 
   // STATS
-  obj->firedBy = ww;
-  obj->hasHit = false;
+  obj->fired_by = ww;
+  obj->has_hit = false;
 
-  Worm* owner = game.wormByIdx(ownerIdx);
-  game.statsRecorder->damagePotential(owner, ww, hitDamage);
-  game.statsRecorder->shot(owner, ww);
+  Worm* owner = game.WormByIdx(owner_idx);
+  game.stats_recorder->DamagePotential(owner, ww, hit_damage);
+  game.stats_recorder->Shot(owner, ww);
 
-  obj->vel = cossinTable[angle] * speed / 100 + vel;
+  obj->vel = cossin_table[angle] * speed / 100 + vel;
 
   if (distribution) {
     obj->vel.x += game.rand(distribution * 2) - distribution;
     obj->vel.y += game.rand(distribution * 2) - distribution;
   }
 
-  if (startFrame >= 0) {
-    if (shotType == STNormal) {
-      if (loopAnim) {
-        if (numFrames)
-          obj->curFrame = game.rand(numFrames + 1);
+  if (start_frame >= 0) {
+    if (shot_type == kStNormal) {
+      if (loop_anim) {
+        if (num_frames)
+          obj->cur_frame = game.rand(num_frames + 1);
         else
-          obj->curFrame = game.rand(2);
+          obj->cur_frame = game.rand(2);
       } else
-        obj->curFrame = 0;
-    } else if (shotType == STDType1) {
+        obj->cur_frame = 0;
+    } else if (shot_type == kStdType1) {
       if (angle > 64) --angle;
 
-      int curFrame = (angle - 12) >> 3;
-      if (curFrame < 0)
-        curFrame = 0;
-      else if (curFrame > 12)
-        curFrame = 12;
-      obj->curFrame = curFrame;
-    } else if (shotType == STDType2 || shotType == STSteerable) {
-      obj->curFrame = angle;
+      int cur_frame = (angle - 12) >> 3;
+      if (cur_frame < 0)
+        cur_frame = 0;
+      else if (cur_frame > 12)
+        cur_frame = 12;
+      obj->cur_frame = cur_frame;
+    } else if (shot_type == kStdType2 || shot_type == kStSteerable) {
+      obj->cur_frame = angle;
     } else
-      obj->curFrame = 0;
+      obj->cur_frame = 0;
   } else {
-    obj->curFrame = colorBullets - game.rand(2);
+    obj->cur_frame = color_bullets - game.rand(2);
   }
 
-  obj->timeLeft = timeToExplo;
+  obj->time_left = time_to_explo;
 
-  if (timeToExploV) obj->timeLeft -= game.rand(timeToExploV);
+  if (time_to_explo_v) obj->time_left -= game.rand(time_to_explo_v);
 }
 
-void WObject::blowUpObject(Game& game, int causeIdx) {
+void WObject::BlowUpObject(Game& game, int cause_idx) {
   Common& common = *game.common;
   Weapon const& w = *type;
 
   fixed x = this->pos.x;
   fixed y = this->pos.y;
-  fixed velX = this->vel.x;
-  fixed velY = this->vel.y;
+  fixed vel_x = this->vel.x;
+  fixed vel_y = this->vel.y;
 
-  game.wobjects.free(this);
+  game.wobjects.Free(this);
 
-  if (w.createOnExp >= 0) {
-    common.sobjectTypes[w.createOnExp].create(game, ftoi(x), ftoi(y), causeIdx, firedBy, this);
+  if (w.create_on_exp >= 0) {
+    common.sobject_types[w.create_on_exp].Create(game, Ftoi(x), Ftoi(y), cause_idx, fired_by, this);
   }
 
-  game.soundPlayer->play(w.exploSound);
+  game.sound_player->Play(w.explo_sound);
 
-  int splinters = w.splinterAmount;
+  int splinters = w.splinter_amount;
 
   if (splinters > 0) {
-    if (w.splinterScatter == 0) {
+    if (w.splinter_scatter == 0) {
       for (int i = 0; i < splinters; ++i) {
         int angle = game.rand(128);
-        int colorSub = game.rand(2);
-        common.nobjectTypes[w.splinterType].create2(game, angle, fixedvec(), fixedvec(x, y),
-                                                    w.splinterColour - colorSub, causeIdx, firedBy);
+        int color_sub = game.rand(2);
+        common.nobject_types[w.splinter_type].Create2(game, angle, fixedvec(), fixedvec(x, y),
+                                                    w.splinter_colour - color_sub, cause_idx, fired_by);
       }
     } else {
       for (int i = 0; i < splinters; ++i) {
-        int colorSub = game.rand(2);
-        common.nobjectTypes[w.splinterType].create1(game, fixedvec(velX, velY), fixedvec(x, y),
-                                                    w.splinterColour - colorSub, causeIdx, firedBy);
+        int color_sub = game.rand(2);
+        common.nobject_types[w.splinter_type].Create1(game, fixedvec(vel_x, vel_y), fixedvec(x, y),
+                                                    w.splinter_colour - color_sub, cause_idx, fired_by);
       }
     }
   }
 
-  if (w.dirtEffect >= 0) {
-    int ix = ftoi(x), iy = ftoi(y);
-    drawDirtEffect(common, game.rand, game.level, w.dirtEffect, ftoi(x) - 7, ftoi(y) - 7);
+  if (w.dirt_effect >= 0) {
+    int ix = Ftoi(x), iy = Ftoi(y);
+    DrawDirtEffect(common, game.rand, game.level, w.dirt_effect, Ftoi(x) - 7, Ftoi(y) - 7);
     if (game.settings->shadow)
-      correctShadow(common, game.level, Rect(ix - 10, iy - 10, ix + 11, iy + 11));
+      CorrectShadow(common, game.level, Rect(ix - 10, iy - 10, ix + 11, iy + 11));
   }
 }
 
-void WObject::process(Game& game) {
+void WObject::Process(Game& game) {
   int iter = 0;
-  bool doExplode = false;
-  bool doRemove = false;
+  bool do_explode = false;
+  bool do_remove = false;
 
   Common& common = *game.common;
   Weapon const& w = *type;
 
-  Worm* owner = game.wormByIdx(ownerIdx);
+  Worm* owner = game.WormByIdx(owner_idx);
 
   // As liero would do this while rendering, we try to do it as early as possible
-  if (common.H[HRemExp] && type - &common.weapons[0] == LC(RemExpObject) - 1) {
-    if (owner->pressed(Worm::Change) && owner->pressed(Worm::Fire)) {
-      timeLeft = 0;
+  if (common.h[HRemExp] && type - &common.weapons[0] == LC(RemExpObject) - 1) {
+    if (owner->Pressed(Worm::kChange) && owner->Pressed(Worm::kFire)) {
+      time_left = 0;
     }
   }
 
@@ -130,20 +130,20 @@ void WObject::process(Game& game) {
     ++iter;
     pos += vel;
 
-    if (w.shotType == 2) {
-      fixedvec dir(cossinTable[curFrame]);
-      auto newVel = dir * w.speed / 100;
+    if (w.shot_type == 2) {
+      fixedvec dir(cossin_table[cur_frame]);
+      auto new_vel = dir * w.speed / 100;
 
-      if (owner->visible && owner->pressed(Worm::Up)) {
-        newVel += dir * w.addSpeed / 100;
+      if (owner->visible && owner->Pressed(Worm::kUp)) {
+        new_vel += dir * w.add_speed / 100;
       }
 
-      vel = ((vel * 8) + newVel) / 9;
-    } else if (w.shotType == 3) {
-      fixedvec dir(cossinTable[curFrame]);
-      auto addVel = dir * w.addSpeed / 100;
+      vel = ((vel * 8) + new_vel) / 9;
+    } else if (w.shot_type == 3) {
+      fixedvec dir(cossin_table[cur_frame]);
+      auto add_vel = dir * w.add_speed / 100;
 
-      vel += addVel;
+      vel += add_vel;
 
       if (w.distribution) {
         vel.x += game.rand(w.distribution * 2) - w.distribution;
@@ -152,10 +152,10 @@ void WObject::process(Game& game) {
     }
 
     if (w.bounce > 0) {
-      auto ipos = ftoi(pos);
-      auto inewPos = ftoi(pos + vel);
+      auto ipos = Ftoi(pos);
+      auto inew_pos = Ftoi(pos + vel);
 
-      if (!game.level.inside(inewPos.x, ipos.y) || game.pixelMat(inewPos.x, ipos.y).dirtRock()) {
+      if (!game.level.Inside(inew_pos.x, ipos.y) || game.PixelMat(inew_pos.x, ipos.y).DirtRock()) {
         if (w.bounce != 100) {
           vel.x = -vel.x * w.bounce / 100;
           vel.y = (vel.y * 4) / 5;  // TODO: Read from EXE
@@ -163,7 +163,7 @@ void WObject::process(Game& game) {
           vel.x = -vel.x;
       }
 
-      if (!game.level.inside(ipos.x, inewPos.y) || game.pixelMat(ipos.x, inewPos.y).dirtRock()) {
+      if (!game.level.Inside(ipos.x, inew_pos.y) || game.PixelMat(ipos.x, inew_pos.y).DirtRock()) {
         if (w.bounce != 100) {
           vel.y = -vel.y * w.bounce / 100;
           vel.x = (vel.x * 4) / 5;  // TODO: Read from EXE
@@ -172,127 +172,127 @@ void WObject::process(Game& game) {
       }
     }
 
-    if (w.multSpeed != 100) {
-      vel = vel * w.multSpeed / 100;
+    if (w.mult_speed != 100) {
+      vel = vel * w.mult_speed / 100;
     }
 
-    if (w.objTrailType >= 0 && (game.cycles % w.objTrailDelay) == 0) {
-      common.sobjectTypes[w.objTrailType].create(game, ftoi(pos.x), ftoi(pos.y), ownerIdx, firedBy);
+    if (w.obj_trail_type >= 0 && (game.cycles % w.obj_trail_delay) == 0) {
+      common.sobject_types[w.obj_trail_type].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
     }
 
-    if (w.partTrailObj >= 0 && (game.cycles % w.partTrailDelay) == 0) {
-      if (w.partTrailType == 1) {
-        common.nobjectTypes[w.partTrailObj].create1(game, vel / LC(SplinterLarpaVelDiv), pos, 0,
-                                                    ownerIdx, firedBy);
+    if (w.part_trail_obj >= 0 && (game.cycles % w.part_trail_delay) == 0) {
+      if (w.part_trail_type == 1) {
+        common.nobject_types[w.part_trail_obj].Create1(game, vel / LC(SplinterLarpaVelDiv), pos, 0,
+                                                    owner_idx, fired_by);
       } else {
         int angle = game.rand(128);
-        common.nobjectTypes[w.partTrailObj].create2(game, angle, vel / LC(SplinterCracklerVelDiv),
-                                                    pos, 0, ownerIdx, firedBy);
+        common.nobject_types[w.part_trail_obj].Create2(game, angle, vel / LC(SplinterCracklerVelDiv),
+                                                    pos, 0, owner_idx, fired_by);
       }
     }
 
-    if (w.collideWithObjects) {
-      auto impulse = vel * w.blowAway / 100;
+    if (w.collide_with_objects) {
+      auto impulse = vel * w.blow_away / 100;
 
-      auto wr = game.wobjects.all();
-      for (WObject* i; (i = wr.next());) {
-        if (i->type != type || i->ownerIdx != ownerIdx) {
-          if (pos.x >= i->pos.x - itof(2) && pos.x <= i->pos.x + itof(2) &&
-              pos.y >= i->pos.y - itof(2) && pos.y <= i->pos.y + itof(2)) {
+      auto wr = game.wobjects.All();
+      for (WObject* i; (i = wr.Next());) {
+        if (i->type != type || i->owner_idx != owner_idx) {
+          if (pos.x >= i->pos.x - Itof(2) && pos.x <= i->pos.x + Itof(2) &&
+              pos.y >= i->pos.y - Itof(2) && pos.y <= i->pos.y + Itof(2)) {
             i->vel += impulse;
           }
         }
       }
 
-      auto nr = game.nobjects.all();
-      for (NObject* i; (i = nr.next());) {
-        if (pos.x >= i->pos.x - itof(2) && pos.x <= i->pos.x + itof(2) &&
-            pos.y >= i->pos.y - itof(2) && pos.y <= i->pos.y + itof(2)) {
+      auto nr = game.nobjects.All();
+      for (NObject* i; (i = nr.Next());) {
+        if (pos.x >= i->pos.x - Itof(2) && pos.x <= i->pos.x + Itof(2) &&
+            pos.y >= i->pos.y - Itof(2) && pos.y <= i->pos.y + Itof(2)) {
           i->vel += impulse;
         }
       }
     }
 
-    auto inewPos = ftoi(pos + vel);
+    auto inew_pos = Ftoi(pos + vel);
 
-    if (inewPos.x < 0) pos.x = 0;
-    if (inewPos.y < 0) pos.y = 0;
-    if (inewPos.x >= game.level.width) pos.x = itof(game.level.width - 1);
-    if (inewPos.y >= game.level.height) pos.y = itof(game.level.height - 1);
+    if (inew_pos.x < 0) pos.x = 0;
+    if (inew_pos.y < 0) pos.y = 0;
+    if (inew_pos.x >= game.level.width) pos.x = Itof(game.level.width - 1);
+    if (inew_pos.y >= game.level.height) pos.y = Itof(game.level.height - 1);
 
-    if (!game.level.inside(inewPos) || game.pixelMat(inewPos.x, inewPos.y).dirtRock()) {
+    if (!game.level.Inside(inew_pos) || game.PixelMat(inew_pos.x, inew_pos.y).DirtRock()) {
       if (w.bounce == 0) {
-        if (w.explGround) {
-          doExplode = true;
+        if (w.expl_ground) {
+          do_explode = true;
         } else {
-          vel.zero();
+          vel.Zero();
         }
       }
     } else {
       vel.y += w.gravity;  // The original tested w.gravity first, which doesn't seem like a gain
 
-      if (w.numFrames > 0) {
+      if (w.num_frames > 0) {
         if ((game.cycles & 7) == 0) {
-          if (!w.loopAnim) {
-            if (++curFrame > w.numFrames) curFrame = 0;
+          if (!w.loop_anim) {
+            if (++cur_frame > w.num_frames) cur_frame = 0;
           } else {
             if (vel.x < 0) {
-              if (--curFrame < 0) curFrame = w.numFrames;
+              if (--cur_frame < 0) cur_frame = w.num_frames;
             } else if (vel.x > 0) {
-              if (++curFrame > w.numFrames) curFrame = 0;
+              if (++cur_frame > w.num_frames) cur_frame = 0;
             }
           }
         }
       }
     }
 
-    if (w.timeToExplo > 0) {
-      if (--timeLeft < 0) doExplode = true;
+    if (w.time_to_explo > 0) {
+      if (--time_left < 0) do_explode = true;
     }
 
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm& worm = *game.worms[i];
 
-      if ((w.hitDamage || w.blowAway || w.bloodOnHit || w.wormCollide) &&
-          checkForSpecWormHit(game, ftoi(pos.x), ftoi(pos.y), w.detectDistance, worm)) {
-        worm.vel += vel * w.blowAway / 100;
+      if ((w.hit_damage || w.blow_away || w.blood_on_hit || w.worm_collide) &&
+          CheckForSpecWormHit(game, Ftoi(pos.x), Ftoi(pos.y), w.detect_distance, worm)) {
+        worm.vel += vel * w.blow_away / 100;
 
-        game.doDamage(worm, w.hitDamage, ownerIdx);
-        game.statsRecorder->damageDealt(owner, firedBy, &worm, w.hitDamage, hasHit);
-        if (!hasHit) game.statsRecorder->hit(owner, firedBy, &worm);
-        hasHit = true;
+        game.DoDamage(worm, w.hit_damage, owner_idx);
+        game.stats_recorder->DamageDealt(owner, fired_by, &worm, w.hit_damage, has_hit);
+        if (!has_hit) game.stats_recorder->Hit(owner, fired_by, &worm);
+        has_hit = true;
 
-        int bloodAmount = w.bloodOnHit * game.settings->blood / 100;
+        int blood_amount = w.blood_on_hit * game.settings->blood / 100;
 
-        for (int i = 0; i < bloodAmount; ++i) {
+        for (int i = 0; i < blood_amount; ++i) {
           int angle = game.rand(128);
-          common.nobjectTypes[6].create2(game, angle, vel / 3, pos, 0, worm.index, firedBy);
+          common.nobject_types[6].Create2(game, angle, vel / 3, pos, 0, worm.index, fired_by);
         }
 
-        if (w.hitDamage > 0 && worm.health > 0 && game.rand(3) == 0) {
+        if (w.hit_damage > 0 && worm.health > 0 && game.rand(3) == 0) {
           int snd = game.rand(3) + 18;  // NOTE: MUST be outside the unpredictable branch below
-          if (!game.soundPlayer->isPlaying(&worm)) {
-            game.soundPlayer->play(snd, &worm);
+          if (!game.sound_player->IsPlaying(&worm)) {
+            game.sound_player->Play(snd, &worm);
           }
         }
 
-        if (w.wormCollide) {
-          if (game.rand(w.wormCollide) == 0) {
-            if (w.wormExplode) doExplode = true;
+        if (w.worm_collide) {
+          if (game.rand(w.worm_collide) == 0) {
+            if (w.worm_explode) do_explode = true;
 
-            doRemove = true;
+            do_remove = true;
           }
         }
       }
     }
 
-    if (doExplode) {
-      blowUpObject(game, ownerIdx);
+    if (do_explode) {
+      BlowUpObject(game, owner_idx);
       break;
-    } else if (doRemove) {
-      game.wobjects.free(this);
+    } else if (do_remove) {
+      game.wobjects.Free(this);
       break;
     }
-  } while (w.shotType == Weapon::STLaser && used  // TEMP
+  } while (w.shot_type == Weapon::kStLaser && used  // TEMP
            && (iter < 8 || w.id == 28));
 }

--- a/src/game/weapon.cpp
+++ b/src/game/weapon.cpp
@@ -90,13 +90,15 @@ void WObject::BlowUpObject(Game& game, int cause_idx) {
         int angle = game.rand(128);
         int color_sub = game.rand(2);
         common.nobject_types[w.splinter_type].Create2(game, angle, fixedvec(), fixedvec(x, y),
-                                                    w.splinter_colour - color_sub, cause_idx, fired_by);
+                                                      w.splinter_colour - color_sub, cause_idx,
+                                                      fired_by);
       }
     } else {
       for (int i = 0; i < splinters; ++i) {
         int color_sub = game.rand(2);
         common.nobject_types[w.splinter_type].Create1(game, fixedvec(vel_x, vel_y), fixedvec(x, y),
-                                                    w.splinter_colour - color_sub, cause_idx, fired_by);
+                                                      w.splinter_colour - color_sub, cause_idx,
+                                                      fired_by);
       }
     }
   }
@@ -177,17 +179,18 @@ void WObject::Process(Game& game) {
     }
 
     if (w.obj_trail_type >= 0 && (game.cycles % w.obj_trail_delay) == 0) {
-      common.sobject_types[w.obj_trail_type].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx, fired_by);
+      common.sobject_types[w.obj_trail_type].Create(game, Ftoi(pos.x), Ftoi(pos.y), owner_idx,
+                                                    fired_by);
     }
 
     if (w.part_trail_obj >= 0 && (game.cycles % w.part_trail_delay) == 0) {
       if (w.part_trail_type == 1) {
         common.nobject_types[w.part_trail_obj].Create1(game, vel / LC(SplinterLarpaVelDiv), pos, 0,
-                                                    owner_idx, fired_by);
+                                                       owner_idx, fired_by);
       } else {
         int angle = game.rand(128);
-        common.nobject_types[w.part_trail_obj].Create2(game, angle, vel / LC(SplinterCracklerVelDiv),
-                                                    pos, 0, owner_idx, fired_by);
+        common.nobject_types[w.part_trail_obj].Create2(
+            game, angle, vel / LC(SplinterCracklerVelDiv), pos, 0, owner_idx, fired_by);
       }
     }
 

--- a/src/game/weapon.hpp
+++ b/src/game/weapon.hpp
@@ -18,9 +18,9 @@ struct Weapon {
    * Type2 (3)
    * Laser (4)
    */
-  enum { STNormal, STDType1, STSteerable, STDType2, STLaser };
+  enum { kStNormal, kStdType1, kStSteerable, kStdType2, kStLaser };
 
-  void fire(Game& game, int angle, fixedvec vel, int speed, fixedvec pos, int ownerIdx,
+  void Fire(Game& game, int angle, fixedvec vel, int speed, fixedvec pos, int owner_idx,
             WormWeapon* ww) const;
 
   /*
@@ -30,18 +30,18 @@ struct Weapon {
   detectDistance < 0, then the worm will not receive damage from the object and also
   blowAway/wormCollide parameters will not work.
   */
-  int detectDistance;
+  int detect_distance;
   /*
   Whether the movement of the player affects the initial speed and direction of the object.
   */
-  bool affectByWorm;
+  bool affect_by_worm;
   /*
   Force affecting the worm on hit.
   Note: this will also work if the object has "wormCollide" set to false; in such case, the object
   will not disappear but push the worm continuously. Note: works only if the object is moving and
   detectDistance ⩾ 0!
   */
-  int blowAway;
+  int blow_away;
   /*
   Gravity of the object. Can also be negative.
   */
@@ -56,19 +56,19 @@ struct Weapon {
   displayed on special rock (undefined) on the map (or after it), however the bullet itself passes
   through such type of material.
   */
-  bool laserSight;
+  bool laser_sight;
   /*
   Sound played when the weapon is fired. Set -1 for none.
   */
-  int launchSound;
+  int launch_sound;
   /*
   Loop sound while fire key is pressed and cut off sound as soon as fire key is released. Buggy.
   */
-  bool loopSound;
+  bool loop_sound;
   /*
   Sound played when the object explodes. Set -1 for none.
   */
-  int exploSound;
+  int explo_sound;
   /*
   Initial speed of the bullet. 600 is about the max playable value for usual weapons.
   Note: if you set too high value for it, the bullet might pass through worms and even through
@@ -84,7 +84,7 @@ struct Weapon {
   is an additional speed added to the missile when pressing up. It has no impact on other shotType
   (0, 1 and 4).
   */
-  fixed addSpeed;
+  fixed add_speed;
   /*
   Spread of the bullet. This works by adding a random direction vector of random length to current
   speed vector of the projectile. Note: if you set its value to > 1 or < -1, then more than 1
@@ -105,7 +105,7 @@ struct Weapon {
   Speed multiplication each frame. Use it to have a weapon which accelerates or decelerates
   non-linearly, like proxy mine from promode.
   */
-  int multSpeed;
+  int mult_speed;
   /*
   Delay time (in frames) between individual shots of the same weapon.
   */
@@ -113,7 +113,7 @@ struct Weapon {
   /*
   Reload time.
   */
-  int loadingTime;
+  int loading_time;
   /*
   Number of shots before the weapon needs to be reloaded.
   */
@@ -121,55 +121,55 @@ struct Weapon {
   /*
   Which special object (sObject) to use on explosion. Set -1 for none.
   */
-  int createOnExp;
+  int create_on_exp;
   /*
   Which dirt mask to use on object explosion. Set -1 for none.
   */
-  int dirtEffect;
+  int dirt_effect;
   /*
   Frequency of shells ejected. Set to 0,1,2,3 or 4. 0=never, 1=always, 2=sometimes, 3=rarely, 4=very
   rarely.
   */
-  int leaveShells;
+  int leave_shells;
   /*
   Time between shot and shell ejected.
   */
-  int leaveShellDelay;
+  int leave_shell_delay;
   /*
   Play reload sound when the weapon is reloaded or not.
   */
-  bool playReloadSound;
+  bool play_reload_sound;
   /*
   Whether the object should explode (produce a sObject and a sound indicated in exploSound) on worm
   collision. Note: works only if "wormCollide" is set "true" too!
   */
-  bool wormExplode;
+  bool worm_explode;
   /*
   Whether the object should explode (produce a sObject and a sound indicated in exploSound) on
   ground collision. Note: works only if "bounce" parameter equals 0.
   */
-  bool explGround;
+  bool expl_ground;
   /*
   Whether the object should collide with the worm and get removed.
   */
-  bool wormCollide;
+  bool worm_collide;
   /*
   Duration of firecone sprite being displayed. It is taken from the sprite sheet, is not animated
   and always uses same sprites (9-15, depending on crosshair position).
   */
-  int fireCone;
+  int fire_cone;
   /*
   Whether the object should collide with other objects. If yes, they will bounce off themselves but
   none of them will be destroyed. If set to false, they pass through each other. Note: this property
   doesn't work if wObject "blowAway" parameter equals 0! Note: this property works also if
   "detectDistance" parameter of the wObject is < 0.
   */
-  bool collideWithObjects;
+  bool collide_with_objects;
   /*
   Whether the object is affected by explosions' push force (on collision with sObject).
   Note: works only if the colliding sObject has got detectRange > 0 and damage > 0 and blowAway ≠ 0!
   */
-  bool affectByExplosions;
+  bool affect_by_explosions;
   /*
   Speed multiply on hitting rock/dirt obstacle or the edge of the map. After every bounce, the
   projectile will get this percentage of its original speed. Note: if you set it to -100, then the
@@ -186,24 +186,24 @@ struct Weapon {
   other wObjects). Note: it is not recommended to set negative value for this property. Note: it is
   not recommended to set timeToExplo > 32767.
   */
-  int timeToExplo;
+  int time_to_explo;
   /*
   Maximum (negative) variation of time to explode in frames.
   */
-  int timeToExploV;
+  int time_to_explo_v;
   /*
   Damage inflicted on worm which was hit.
   Note: If the object has "wormCollide" property set to "false", this will be applied each frame the
   collision still occurs, leading to potentially huge damage values.
   */
-  int hitDamage;
+  int hit_damage;
   /*
   Determines how many blood particles (nObject6) should be created on worm hit, divided by 2.
   So, if you set it to "10", then 5 blood particles will be created on worm hit (per each frame -
   which means that the amount of blood particles is affected by "wormCollide" parameter). Note: this
   property works also if wObject "hitDamage" parameter equals 0.
   */
-  int bloodOnHit;
+  int blood_on_hit;
   /*
   First sprite of animation used for wObject.
   If -1, it will be a single pixel using a colour indicated in "colorBullets" parameter.
@@ -211,7 +211,7 @@ struct Weapon {
   pixel but its colour will be changing depending on the object position (the direction the object
   is moving).
   */
-  int startFrame;
+  int start_frame;
   /*
   Amount of sprites to use to animate the object, starting with "startFrame".
   Note: Animation begins on random frame, so it is suitable really only for objects which have
@@ -221,7 +221,7 @@ struct Weapon {
   affected by "repeat" value encoded for shottype: 4, which means that the higher the "repeat" value
   is, the delay before advancing to next frame will be lower.
   */
-  int numFrames;
+  int num_frames;
   /*
   Whether the animation should be looped.
   Note: loopAnim parameter is affected by "speed" parameter, which means that if you set it "true",
@@ -237,7 +237,7 @@ struct Weapon {
   default). Note: works properly only for shotType 0, 1 and 4 (it's recommended to set this
   parameter to "false" for shotType 2 and 3).
   */
-  bool loopAnim;
+  bool loop_anim;
   /*
   Defines general type of the weapon object (wObject).
   0 - a standard object being either a colored pixel or animated sprite.
@@ -255,48 +255,48 @@ struct Weapon {
   with hardcoded "repeat" value (for wObject 28 it has "repeat" set to 1000, and for other wObjects
   set to 8).
   */
-  int shotType;
+  int shot_type;
   /*
   Color of the object. Works only if you set a pixel (startFrame: -1) for a bullet.
   Note: this parameter also affects the colour of a laser beam used for a laser weapon (wObject 28).
   */
-  int colorBullets;
+  int color_bullets;
   /*
   Amount of nObjects to create on explosion. The wObject must actually explode, for example if
   "wormExplode" is set to false and "wormCollide" is set to true, no nObjects will be created. Note:
   NEVER set splinterAmount > 0 and splinterType to "null" for the same weapon object, otherwise the
   game will freeze!
   */
-  int splinterAmount;
+  int splinter_amount;
   /*
   Color used on nObjects (produced as splinters) when they are a single pixel (startFrame -1 or 0).
   If splinterColour is set to 0 or 1, then splinters will have a colour indicated in nObject
   "colorBullets" property. Note: if splinterColour is set to 2 or more, nObject splinter will
   actually use two colours: the one indicated in this parameter, and also the previous one.
   */
-  int splinterColour;
+  int splinter_colour;
   /*
   Type of nObject to create when the object explodes.
   */
-  int splinterType;
+  int splinter_type;
   /*
   Way in which the splinter (nObject) is scattered when the wObject explodes:
   0 = all directions (like in big nuke);
   1 = direction the wObject is moving (like in mini nuke).
   */
-  int splinterScatter;
+  int splinter_scatter;
   /*
   Defines which sObject (special Object) is created as a trail. Set -1 for none.
   Note: wObject keeps creating sObjects on its trail even when it stops moving (and even when it's
   spawned or "trapped" inside rock or dirt on the map).
   */
-  int objTrailType;
+  int obj_trail_type;
   /*
   Delay time (in frames) between creating trailing sObjects.
   Note: the delay is not referred to object's lifetime but game ticks, which means that it is
   measured in relation to the time elapsed since the game started, not since the object was created.
   */
-  int objTrailDelay;
+  int obj_trail_delay;
   /*
   Defines the way in which the weapon should drop nObjects (created on its trail):
   0 - crackler-type non-directional trail (objects are dropped in all directions); in this case, the
@@ -304,45 +304,45 @@ struct Weapon {
   larpa-type directional trail (objects are dropped in the direction the wObject is moving); in this
   case, the speed of nObject is affected by "SplinterLarpaVelDiv" parameter (section "constants").
   */
-  int partTrailType;
+  int part_trail_type;
   /*
   Defines which nObject is created as a trail. Set -1 for none.
   Note: wObject keeps creating nObjects on its trail even when it stops moving (and even when it's
   spawned or "trapped" inside rock or dirt on the map).
   */
-  int partTrailObj;
+  int part_trail_obj;
   /*
   Delay time (in frames) between creating trailed nObjects.
   Note: the delay is not referred to object's lifetime but game ticks, which means that it is
   measured in relation to the time elapsed since the game started, not since the object was created.
   */
-  int partTrailDelay;
+  int part_trail_delay;
   /*
   Defines whether the object would behave like bonuses or booby trap (i.e. whether the object would
   get removed on a collision with sObject). Note: works only if you set affectByExplosions parameter
   of the wObject to "true" AND if the colliding sObject has detectRange > 0 and damage > 0.
   */
-  bool chainExplosion;
+  bool chain_explosion;
 
-  int computedLoadingTime(Settings& settings) const;
+  int ComputedLoadingTime(Settings& settings) const;
 
   int id;
   std::string name;
-  std::string idStr;
+  std::string id_str;
 };
 
 struct WObject : ExactObjectListBase {
-  void blowUpObject(Game& game, int causeIdx);
-  void process(Game& game);
+  void BlowUpObject(Game& game, int cause_idx);
+  void Process(Game& game);
 
   fixedvec pos, vel;
   // int id;
   Weapon const* type;
-  int ownerIdx;
-  int curFrame;
-  int timeLeft;
+  int owner_idx;
+  int cur_frame;
+  int time_left;
 
   // STATS
-  WormWeapon* firedBy;
-  bool hasHit;
+  WormWeapon* fired_by;
+  bool has_hit;
 };

--- a/src/game/weaponMenuState.cpp
+++ b/src/game/weaponMenuState.cpp
@@ -113,8 +113,8 @@ void WeaponMenuState::Draw() {
   DrawRoundedBox(gfx->play_renderer.bmp, 179, 20, 0, 7, common.font.GetDims(LS(Weapon)));
   DrawRoundedBox(gfx->play_renderer.bmp, 249, 20, 0, 7, common.font.GetDims(LS(Availability)));
 
-  common.font.DrawText(gfx->play_renderer.bmp, LS(Weapon), 181, 21, 50);
-  common.font.DrawText(gfx->play_renderer.bmp, LS(Availability), 251, 21, 50);
+  common.font.DrawString(gfx->play_renderer.bmp, LS(Weapon), 181, 21, 50);
+  common.font.DrawString(gfx->play_renderer.bmp, LS(Availability), 251, 21, 50);
 
   weaponMenu_->Draw(common, gfx->play_renderer, false);
 }

--- a/src/game/weaponMenuState.cpp
+++ b/src/game/weaponMenuState.cpp
@@ -12,85 +12,85 @@
 struct WeaponMenu : Menu {
   WeaponMenu(int x, int y) : Menu(x, y) {}
 
-  ItemBehavior* getItemBehavior(Common& common, MenuItem& item) {
-    int index = common.weapOrder[item.id];
-    return new ArrayEnumBehavior(common, gfx.settings->weapTable[index], common.texts.weapStates);
+  ItemBehavior* GetItemBehavior(Common& common, MenuItem& item) {
+    int index = common.weap_order[item.id];
+    return new ArrayEnumBehavior(common, gfx.settings->weap_table[index], common.texts.weap_states);
   }
 };
 
 WeaponMenuState::WeaponMenuState() {}
 
-void WeaponMenuState::enter() {
+void WeaponMenuState::Enter() {
   Common& common = *gfx->common;
 
   auto menu = std::make_unique<WeaponMenu>(179, 28);
-  menu->setHeight(14);
-  menu->valueOffsetX = 89;
+  menu->SetHeight(14);
+  menu->value_offset_x = 89;
 
   for (int i = 0; i < (int)common.weapons.size(); ++i) {
-    int index = common.weapOrder[i];
-    menu->addItem(MenuItem(48, 7, common.weapons[index].name, i));
+    int index = common.weap_order[i];
+    menu->AddItem(MenuItem(48, 7, common.weapons[index].name, i));
   }
 
-  menu->moveToFirstVisible();
-  menu->updateItems(common);
+  menu->MoveToFirstVisible();
+  menu->UpdateItems(common);
 
   weaponMenu_ = std::move(menu);
 }
 
-void WeaponMenuState::handleEvent(SDL_Event& ev) { gfx->processEvent(ev); }
+void WeaponMenuState::HandleEvent(SDL_Event& ev) { gfx->ProcessEvent(ev); }
 
-bool WeaponMenuState::update() {
+bool WeaponMenuState::Update() {
   if (done_) return false;
 
   Common& common = *gfx->common;
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_UP) || gfx->testControlOnce(WormSettingsExtensions::Up) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-    weaponMenu_->movement(-1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_UP) || gfx->TestControlOnce(WormSettingsExtensions::kUp) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+    weaponMenu_->Movement(-1);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_DOWN) ||
-      gfx->testControlOnce(WormSettingsExtensions::Down) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
-    g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-    weaponMenu_->movement(1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kDown) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
+    g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+    weaponMenu_->Movement(1);
   }
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_LEFT) ||
-      gfx->testControlOnce(WormSettingsExtensions::Left) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
-    weaponMenu_->onLeftRight(common, -1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_LEFT) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kLeft) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_LEFT)) {
+    weaponMenu_->OnLeftRight(common, -1);
   }
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_RIGHT) ||
-      gfx->testControlOnce(WormSettingsExtensions::Right) ||
-      gfx->testGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
-    weaponMenu_->onLeftRight(common, 1);
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_RIGHT) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kRight) ||
+      gfx->TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) {
+    weaponMenu_->OnLeftRight(common, 1);
   }
 
-  if (gfx->settings->extensions) {
-    if (gfx->testSDLKeyOnce(SDL_SCANCODE_PAGEUP)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-      weaponMenu_->movementPage(-1);
+  if (gfx->settings->kExtensions) {
+    if (gfx->TestSdlKeyOnce(SDL_SCANCODE_PAGEUP)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+      weaponMenu_->MovementPage(-1);
     }
 
-    if (gfx->testSDLKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
-      g_soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-      weaponMenu_->movementPage(1);
+    if (gfx->TestSdlKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
+      g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+      weaponMenu_->MovementPage(1);
     }
   }
 
-  weaponMenu_->onKeys(gfx->keyBuf, gfx->keyBufPtr);
+  weaponMenu_->OnKeys(gfx->key_buf, gfx->key_buf_ptr);
 
-  if (gfx->testSDLKeyOnce(SDL_SCANCODE_ESCAPE) ||
-      gfx->testControlOnce(WormSettingsExtensions::Jump) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST) ||
-      gfx->testGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
+  if (gfx->TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
+      gfx->TestControlOnce(WormSettingsExtensions::kJump) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_EAST) ||
+      gfx->TestGamepadButtonOnce(SDL_GAMEPAD_BUTTON_SOUTH)) {
     int count = 0;
 
     for (int i = 0; i < 40; ++i) {
-      if (gfx->settings->weapTable[i] == 0) ++count;
+      if (gfx->settings->weap_table[i] == 0) ++count;
     }
 
     if (count > 0) {
@@ -98,23 +98,23 @@ bool WeaponMenuState::update() {
       return false;
     }
 
-    gfx->stateStack.push(std::make_unique<InfoBoxState>(LS(NoWeaps), 223, 68, false), gfx);
+    gfx->state_stack.Push(std::make_unique<InfoBoxState>(LS(NoWeaps), 223, 68, false), gfx);
   }
 
   return true;
 }
 
-void WeaponMenuState::draw() {
+void WeaponMenuState::Draw() {
   Common& common = *gfx->common;
 
-  gfx->playRenderer.bmp.copy(gfx->frozenScreen);
-  gfx->drawBasicMenu();
+  gfx->play_renderer.bmp.Copy(gfx->frozen_screen);
+  gfx->DrawBasicMenu();
 
-  drawRoundedBox(gfx->playRenderer.bmp, 179, 20, 0, 7, common.font.getDims(LS(Weapon)));
-  drawRoundedBox(gfx->playRenderer.bmp, 249, 20, 0, 7, common.font.getDims(LS(Availability)));
+  DrawRoundedBox(gfx->play_renderer.bmp, 179, 20, 0, 7, common.font.GetDims(LS(Weapon)));
+  DrawRoundedBox(gfx->play_renderer.bmp, 249, 20, 0, 7, common.font.GetDims(LS(Availability)));
 
-  common.font.drawText(gfx->playRenderer.bmp, LS(Weapon), 181, 21, 50);
-  common.font.drawText(gfx->playRenderer.bmp, LS(Availability), 251, 21, 50);
+  common.font.DrawText(gfx->play_renderer.bmp, LS(Weapon), 181, 21, 50);
+  common.font.DrawText(gfx->play_renderer.bmp, LS(Availability), 251, 21, 50);
 
-  weaponMenu_->draw(common, gfx->playRenderer, false);
+  weaponMenu_->Draw(common, gfx->play_renderer, false);
 }

--- a/src/game/weaponMenuState.hpp
+++ b/src/game/weaponMenuState.hpp
@@ -7,10 +7,10 @@
 struct WeaponMenuState : AppState {
   WeaponMenuState();
 
-  void enter() override;
-  void handleEvent(SDL_Event& ev) override;
-  bool update() override;
-  void draw() override;
+  void Enter() override;
+  void HandleEvent(SDL_Event& ev) override;
+  bool Update() override;
+  void Draw() override;
 
  private:
   std::unique_ptr<Menu> weaponMenu_;

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -139,10 +139,10 @@ void WeaponSelection::DrawNormalViewports(Renderer& renderer, GameState state) {
     game.Draw(renderer, state, false);
 
     if (game.settings->level_file.empty()) {
-      common.font.DrawText(renderer.bmp, LS(LevelRandom), 0, 162, 50);
+      common.font.DrawString(renderer.bmp, LS(LevelRandom), 0, 162, 50);
     } else {
       auto level_name = GetBasename(GetLeaf(gfx.settings->level_file));
-      common.font.DrawText(renderer.bmp, (LS(LevelIs1) + level_name + LS(LevelIs2)), 0, 162, 50);
+      common.font.DrawString(renderer.bmp, (LS(LevelIs1) + level_name + LS(LevelIs2)), 0, 162, 50);
     }
 
     gfx.frozen_screen.Copy(renderer.bmp);
@@ -155,7 +155,7 @@ void WeaponSelection::DrawNormalViewports(Renderer& renderer, GameState state) {
 
   DrawRoundedBox(renderer.bmp, 114, 2, 0, 7, common.font.GetDims(LS(SelWeap)));
 
-  common.font.DrawText(renderer.bmp, LS(SelWeap), 116, 3, 50);
+  common.font.DrawString(renderer.bmp, LS(SelWeap), 116, 3, 50);
 
   for (std::size_t i = 0; i < menus.size(); ++i) {
     Menu& weapon_menu = menus[i];
@@ -167,8 +167,8 @@ void WeaponSelection::DrawNormalViewports(Renderer& renderer, GameState state) {
 
     int width = common.font.GetDims(ws.name);
     DrawRoundedBox(renderer.bmp, weapon_menu.x + 29 - width / 2, weapon_menu.y - 11, 0, 7, width);
-    common.font.DrawText(renderer.bmp, ws.name, weapon_menu.x + 31 - width / 2, weapon_menu.y - 10,
-                         Palette::kWormSpriteColorBase[worm.index] + 1);
+    common.font.DrawString(renderer.bmp, ws.name, weapon_menu.x + 31 - width / 2,
+                           weapon_menu.y - 10, Palette::kWormSpriteColorBase[worm.index] + 1);
 
     if (!is_ready[i]) {
       menus[i].Draw(common, gfx.play_renderer, false);

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -128,7 +128,7 @@ void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState state
   // TODO: This just uses the currently activated palette, which might well be wrong.
   gfx.single_screen_renderer.pal = gfx.single_screen_renderer.origpal;
   gfx.single_screen_renderer.pal.RotateFrom(gfx.single_screen_renderer.origpal, 168, 174,
-                                          gfx.menu_cycles);
+                                            gfx.menu_cycles);
   gfx.single_screen_renderer.pal.Fade(gfx.single_screen_renderer.fade_value);
 }
 

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -13,56 +13,56 @@
 
 WeaponSelection::WeaponSelection(Game& game)
     : game(game),
-      enabledWeaps(0),
-      isReady(game.viewports.size()),
+      enabled_weaps(0),
+      is_ready(game.viewports.size()),
       menus(game.viewports.size()),
-      cachedBackground(false),
-      cachedSpectatorBackground(false),
+      cached_background(false),
+      cached_spectator_background(false),
       focused(true) {
   Common& common = *game.common;
 
   for (int i = 0; i < 40; ++i) {
-    if (game.settings->weapTable[i] == 0) ++enabledWeaps;
+    if (game.settings->weap_table[i] == 0) ++enabled_weaps;
   }
 
   for (std::size_t i = 0; i < menus.size(); ++i) {
-    bool weapUsed[256] = {};
+    bool weap_used[256] = {};
 
     Viewport& vp = *game.viewports[i];
 
-    Worm& worm = *game.wormByIdx(vp.wormIdx);
+    Worm& worm = *game.WormByIdx(vp.worm_idx);
     WormSettings& ws = *worm.settings;
 
     menus[i].items.push_back(MenuItem(57, 57, LS(Randomize)));
 
     {
-      int x = vp.rect.center_x() - 31;
-      int y = vp.rect.center_y() - 51;
-      menus[i].place(x, y);
+      int x = vp.rect.CenterX() - 31;
+      int y = vp.rect.CenterY() - 51;
+      menus[i].Place(x, y);
     }
 
-    bool randomWeapons = (ws.controller != 0 && game.settings->selectBotWeapons == 0);
+    bool random_weapons = (ws.controller != 0 && game.settings->select_bot_weapons == 0);
 
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
-      if (ws.weapons[j] == 0 || randomWeapons) {
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
+      if (ws.weapons[j] == 0 || random_weapons) {
         ws.weapons[j] = game.rand(1, 41);
       }
 
-      bool enoughWeapons = (enabledWeaps >= Settings::selectableWeapons);
+      bool enough_weapons = (enabled_weaps >= Settings::kSelectableWeapons);
 
-      if (game.settings->weapTable[common.weapOrder[ws.weapons[j] - 1]] > 0) {
+      if (game.settings->weap_table[common.weap_order[ws.weapons[j] - 1]] > 0) {
         while (true) {
           ws.weapons[j] = game.rand(1, 41);
 
-          int w = common.weapOrder[ws.weapons[j] - 1];
+          int w = common.weap_order[ws.weapons[j] - 1];
 
-          if ((!enoughWeapons || !weapUsed[w]) && game.settings->weapTable[w] <= 0) break;
+          if ((!enough_weapons || !weap_used[w]) && game.settings->weap_table[w] <= 0) break;
         }
       }
 
-      int w = common.weapOrder[ws.weapons[j] - 1];
+      int w = common.weap_order[ws.weapons[j] - 1];
 
-      weapUsed[w] = true;
+      weap_used[w] = true;
 
       WormWeapon& ww = worm.weapons[j];
 
@@ -74,255 +74,255 @@ WeaponSelection::WeaponSelection(Game& game)
 
     menus[i].items.push_back(MenuItem(10, 10, LS(Done)));
 
-    worm.currentWeapon = 0;
+    worm.current_weapon = 0;
 
-    menus[i].moveToFirstVisible();
-    isReady[i] = (ws.controller != 0 && game.settings->selectBotWeapons != 1);
+    menus[i].MoveToFirstVisible();
+    is_ready[i] = (ws.controller != 0 && game.settings->select_bot_weapons != 1);
   }
 }
 
-void WeaponSelection::drawSpectatorViewports(Renderer& renderer, GameState state) {
+void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState state) {
   Common& common = *game.common;
-  int centerX = renderer.renderResX / 2;
-  int centerY = renderer.renderResY / 4;
+  int center_x = renderer.render_res_x / 2;
+  int center_y = renderer.render_res_y / 4;
 
-  if (!cachedSpectatorBackground) {
-    if (game.settings->levelFile.empty()) {
-      common.font.drawCenteredText(renderer.bmp, LS(LevelRandom), centerX, centerY - 32, 7, 2);
+  if (!cached_spectator_background) {
+    if (game.settings->level_file.empty()) {
+      common.font.DrawCenteredText(renderer.bmp, LS(LevelRandom), center_x, center_y - 32, 7, 2);
     } else {
-      auto levelName = getBasename(getLeaf(gfx.settings->levelFile));
-      common.font.drawCenteredText(renderer.bmp, LS(LevelIs1) + levelName + LS(LevelIs2), centerX,
-                                   centerY - 32, 7, 2);
+      auto level_name = GetBasename(GetLeaf(gfx.settings->level_file));
+      common.font.DrawCenteredText(renderer.bmp, LS(LevelIs1) + level_name + LS(LevelIs2), center_x,
+                                   center_y - 32, 7, 2);
     }
 
-    Worm& worm0 = *game.wormByIdx(0);
-    Worm& worm1 = *game.wormByIdx(1);
-    std::string vsText = worm0.settings->name + " vs " + worm1.settings->name;
+    Worm& worm0 = *game.WormByIdx(0);
+    Worm& worm1 = *game.WormByIdx(1);
+    std::string vs_text = worm0.settings->name + " vs " + worm1.settings->name;
     // put worm color boxes on a nice spot even if no player names have been entered
-    int textSize = std::max(common.font.getDims(vsText) * 2, 48);
-    common.font.drawCenteredText(renderer.bmp, vsText, centerX, centerY, 7, 2);
-    fillRect(renderer.bmp, centerX - (textSize / 2) - 1, centerY + 23 - 1, 16, 16, 7);
-    fillRect(renderer.bmp, centerX - textSize / 2, centerY + 23, 14, 14,
-             Palette::wormSpriteColorBase[0]);
-    fillRect(renderer.bmp, centerX + (textSize / 2) - 16 - 1, centerY + 23 - 1, 16, 16, 7);
-    fillRect(renderer.bmp, centerX + textSize / 2 - 16, centerY + 23, 14, 14,
-             Palette::wormSpriteColorBase[1]);
-    common.font.drawCenteredText(renderer.bmp, "WEAPON SELECTION", centerX, centerY + 48, 7, 2);
-    game.level.drawMiniature(renderer.bmp, centerX - 126, renderer.renderResY - 208, 2);
+    int text_size = std::max(common.font.GetDims(vs_text) * 2, 48);
+    common.font.DrawCenteredText(renderer.bmp, vs_text, center_x, center_y, 7, 2);
+    FillRect(renderer.bmp, center_x - (text_size / 2) - 1, center_y + 23 - 1, 16, 16, 7);
+    FillRect(renderer.bmp, center_x - text_size / 2, center_y + 23, 14, 14,
+             Palette::kWormSpriteColorBase[0]);
+    FillRect(renderer.bmp, center_x + (text_size / 2) - 16 - 1, center_y + 23 - 1, 16, 16, 7);
+    FillRect(renderer.bmp, center_x + text_size / 2 - 16, center_y + 23, 14, 14,
+             Palette::kWormSpriteColorBase[1]);
+    common.font.DrawCenteredText(renderer.bmp, "WEAPON SELECTION", center_x, center_y + 48, 7, 2);
+    game.level.DrawMiniature(renderer.bmp, center_x - 126, renderer.render_res_y - 208, 2);
 
-    gfx.frozenSpectatorScreen.copy(renderer.bmp);
-    cachedSpectatorBackground = true;
+    gfx.frozen_spectator_screen.Copy(renderer.bmp);
+    cached_spectator_background = true;
   }
 
-  renderer.bmp.copy(gfx.frozenSpectatorScreen);
+  renderer.bmp.Copy(gfx.frozen_spectator_screen);
 
   if (!focused) return;
 
-  if (!isReady[0]) {
-    menus[0].draw(common, renderer, false, 10);
+  if (!is_ready[0]) {
+    menus[0].Draw(common, renderer, false, 10);
   }
-  if (!isReady[1]) {
-    menus[1].draw(common, renderer, false, 560);
+  if (!is_ready[1]) {
+    menus[1].Draw(common, renderer, false, 560);
   }
 
   // TODO: This just uses the currently activated palette, which might well be wrong.
-  gfx.singleScreenRenderer.pal = gfx.singleScreenRenderer.origpal;
-  gfx.singleScreenRenderer.pal.rotateFrom(gfx.singleScreenRenderer.origpal, 168, 174,
-                                          gfx.menuCycles);
-  gfx.singleScreenRenderer.pal.fade(gfx.singleScreenRenderer.fadeValue);
+  gfx.single_screen_renderer.pal = gfx.single_screen_renderer.origpal;
+  gfx.single_screen_renderer.pal.RotateFrom(gfx.single_screen_renderer.origpal, 168, 174,
+                                          gfx.menu_cycles);
+  gfx.single_screen_renderer.pal.Fade(gfx.single_screen_renderer.fade_value);
 }
 
-void WeaponSelection::drawNormalViewports(Renderer& renderer, GameState state) {
+void WeaponSelection::DrawNormalViewports(Renderer& renderer, GameState state) {
   Common& common = *game.common;
 
-  if (!cachedBackground) {
-    game.draw(renderer, state, false);
+  if (!cached_background) {
+    game.Draw(renderer, state, false);
 
-    if (game.settings->levelFile.empty()) {
-      common.font.drawText(renderer.bmp, LS(LevelRandom), 0, 162, 50);
+    if (game.settings->level_file.empty()) {
+      common.font.DrawText(renderer.bmp, LS(LevelRandom), 0, 162, 50);
     } else {
-      auto levelName = getBasename(getLeaf(gfx.settings->levelFile));
-      common.font.drawText(renderer.bmp, (LS(LevelIs1) + levelName + LS(LevelIs2)), 0, 162, 50);
+      auto level_name = GetBasename(GetLeaf(gfx.settings->level_file));
+      common.font.DrawText(renderer.bmp, (LS(LevelIs1) + level_name + LS(LevelIs2)), 0, 162, 50);
     }
 
-    gfx.frozenScreen.copy(renderer.bmp);
-    cachedBackground = true;
+    gfx.frozen_screen.Copy(renderer.bmp);
+    cached_background = true;
   }
 
-  renderer.bmp.copy(gfx.frozenScreen);
+  renderer.bmp.Copy(gfx.frozen_screen);
 
   if (!focused) return;
 
-  drawRoundedBox(renderer.bmp, 114, 2, 0, 7, common.font.getDims(LS(SelWeap)));
+  DrawRoundedBox(renderer.bmp, 114, 2, 0, 7, common.font.GetDims(LS(SelWeap)));
 
-  common.font.drawText(renderer.bmp, LS(SelWeap), 116, 3, 50);
+  common.font.DrawText(renderer.bmp, LS(SelWeap), 116, 3, 50);
 
   for (std::size_t i = 0; i < menus.size(); ++i) {
-    Menu& weaponMenu = menus[i];
+    Menu& weapon_menu = menus[i];
 
     Viewport& vp = *game.viewports[i];
 
-    Worm& worm = *game.wormByIdx(vp.wormIdx);
+    Worm& worm = *game.WormByIdx(vp.worm_idx);
     WormSettings& ws = *worm.settings;
 
-    int width = common.font.getDims(ws.name);
-    drawRoundedBox(renderer.bmp, weaponMenu.x + 29 - width / 2, weaponMenu.y - 11, 0, 7, width);
-    common.font.drawText(renderer.bmp, ws.name, weaponMenu.x + 31 - width / 2, weaponMenu.y - 10,
-                         Palette::wormSpriteColorBase[worm.index] + 1);
+    int width = common.font.GetDims(ws.name);
+    DrawRoundedBox(renderer.bmp, weapon_menu.x + 29 - width / 2, weapon_menu.y - 11, 0, 7, width);
+    common.font.DrawText(renderer.bmp, ws.name, weapon_menu.x + 31 - width / 2, weapon_menu.y - 10,
+                         Palette::kWormSpriteColorBase[worm.index] + 1);
 
-    if (!isReady[i]) {
-      menus[i].draw(common, gfx.playRenderer, false);
+    if (!is_ready[i]) {
+      menus[i].Draw(common, gfx.play_renderer, false);
     }
   }
 
   // TODO: This just uses the currently activated palette, which might well be wrong.
-  gfx.playRenderer.pal = gfx.playRenderer.origpal;
-  gfx.playRenderer.pal.rotateFrom(gfx.playRenderer.origpal, 168, 174, gfx.menuCycles);
-  gfx.playRenderer.pal.fade(gfx.playRenderer.fadeValue);
+  gfx.play_renderer.pal = gfx.play_renderer.origpal;
+  gfx.play_renderer.pal.RotateFrom(gfx.play_renderer.origpal, 168, 174, gfx.menu_cycles);
+  gfx.play_renderer.pal.Fade(gfx.play_renderer.fade_value);
 }
 
-void WeaponSelection::draw(Renderer& renderer, GameState state, bool useSpectatorViewports) {
-  if (useSpectatorViewports) {
-    drawSpectatorViewports(renderer, state);
+void WeaponSelection::Draw(Renderer& renderer, GameState state, bool use_spectator_viewports) {
+  if (use_spectator_viewports) {
+    DrawSpectatorViewports(renderer, state);
   } else {
-    drawNormalViewports(renderer, state);
+    DrawNormalViewports(renderer, state);
   }
 }
 
-bool WeaponSelection::processFrame() {
+bool WeaponSelection::ProcessFrame() {
   Common& common = *game.common;
 
-  bool allReady = true;
+  bool all_ready = true;
 
   for (std::size_t i = 0; i < menus.size(); ++i) {
-    int weapID = menus[i].selection() - 1;
+    int weap_id = menus[i].Selection() - 1;
 
     Viewport& vp = *game.viewports[i];
-    Worm& worm = *game.wormByIdx(vp.wormIdx);
+    Worm& worm = *game.WormByIdx(vp.worm_idx);
 
     WormSettings& ws = *worm.settings;
 
-    if (!isReady[i]) {
+    if (!is_ready[i]) {
       // Find this player's gamepad (if using one)
-      int gpIdx = -1;
-      if (ws.inputDevice != WormSettingsExtensions::InputKeyboard)
-        gpIdx = gfx.findGamepadForPlayer(vp.wormIdx);
+      int gp_idx = -1;
+      if (ws.input_device != WormSettingsExtensions::kInputKeyboard)
+        gp_idx = gfx.FindGamepadForPlayer(vp.worm_idx);
 
-      if (weapID >= 0 && weapID < Settings::selectableWeapons) {
-        bool left = worm.pressed(Worm::Left);
-        if (!left && gpIdx >= 0 && gfx.joysticks[gpIdx].axisButtonState[1])  // LEFTX negative
+      if (weap_id >= 0 && weap_id < Settings::kSelectableWeapons) {
+        bool left = worm.Pressed(Worm::kLeft);
+        if (!left && gp_idx >= 0 && gfx.joysticks[gp_idx].axis_button_state[1])  // LEFTX negative
           left = true;
 
         if (left) {
-          worm.release(Worm::Left);
+          worm.Release(Worm::kLeft);
 
-          game.soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
+          game.sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
 
           do {
-            --ws.weapons[weapID];
-            if (ws.weapons[weapID] < 1) ws.weapons[weapID] = (uint32_t)common.weapons.size();
-          } while (game.settings->weapTable[common.weapOrder[ws.weapons[weapID] - 1]] != 0);
+            --ws.weapons[weap_id];
+            if (ws.weapons[weap_id] < 1) ws.weapons[weap_id] = (uint32_t)common.weapons.size();
+          } while (game.settings->weap_table[common.weap_order[ws.weapons[weap_id] - 1]] != 0);
 
-          int w = common.weapOrder[ws.weapons[weapID] - 1];
-          worm.weapons[weapID].type = &common.weapons[w];
-          menus[i].selected()->string = common.weapons[w].name;
+          int w = common.weap_order[ws.weapons[weap_id] - 1];
+          worm.weapons[weap_id].type = &common.weapons[w];
+          menus[i].Selected()->string = common.weapons[w].name;
         }
 
-        bool right = worm.pressed(Worm::Right);
-        if (!right && gpIdx >= 0 && gfx.joysticks[gpIdx].axisButtonState[0])  // LEFTX positive
+        bool right = worm.Pressed(Worm::kRight);
+        if (!right && gp_idx >= 0 && gfx.joysticks[gp_idx].axis_button_state[0])  // LEFTX positive
           right = true;
 
         if (right) {
-          worm.release(Worm::Right);
+          worm.Release(Worm::kRight);
 
-          game.soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
+          game.sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
           do {
-            ++ws.weapons[weapID];
-            if (ws.weapons[weapID] > (uint32_t)common.weapons.size()) ws.weapons[weapID] = 1;
-          } while (game.settings->weapTable[common.weapOrder[ws.weapons[weapID] - 1]] != 0);
+            ++ws.weapons[weap_id];
+            if (ws.weapons[weap_id] > (uint32_t)common.weapons.size()) ws.weapons[weap_id] = 1;
+          } while (game.settings->weap_table[common.weap_order[ws.weapons[weap_id] - 1]] != 0);
 
-          int w = common.weapOrder[ws.weapons[weapID] - 1];
-          worm.weapons[weapID].type = &common.weapons[w];
-          menus[i].selected()->string = common.weapons[w].name;
+          int w = common.weap_order[ws.weapons[weap_id] - 1];
+          worm.weapons[weap_id].type = &common.weapons[w];
+          menus[i].Selected()->string = common.weapons[w].name;
         }
       }
 
-      bool up = worm.pressedOnce(Worm::Up);
-      if (!up && gpIdx >= 0 && gfx.joysticks[gpIdx].axisPressed[3])  // LEFTY negative
+      bool up = worm.PressedOnce(Worm::kUp);
+      if (!up && gp_idx >= 0 && gfx.joysticks[gp_idx].axis_pressed[3])  // LEFTY negative
       {
-        gfx.joysticks[gpIdx].axisPressed[3] = false;
+        gfx.joysticks[gp_idx].axis_pressed[3] = false;
         up = true;
       }
       if (up) {
-        game.soundPlayer->play(common.soundHook[SoundMenuMoveDown]);
-        menus[i].movement(-1);
+        game.sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
+        menus[i].Movement(-1);
       }
 
-      bool down = worm.pressedOnce(Worm::Down);
-      if (!down && gpIdx >= 0 && gfx.joysticks[gpIdx].axisPressed[2])  // LEFTY positive
+      bool down = worm.PressedOnce(Worm::kDown);
+      if (!down && gp_idx >= 0 && gfx.joysticks[gp_idx].axis_pressed[2])  // LEFTY positive
       {
-        gfx.joysticks[gpIdx].axisPressed[2] = false;
+        gfx.joysticks[gp_idx].axis_pressed[2] = false;
         down = true;
       }
       if (down) {
-        game.soundPlayer->play(common.soundHook[SoundMenuMoveUp]);
-        menus[i].movement(1);
+        game.sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
+        menus[i].Movement(1);
       }
 
       // Check Fire control OR A button on assigned gamepad
-      bool confirm = worm.pressed(Worm::Fire);
-      if (!confirm && gpIdx >= 0 && gfx.joysticks[gpIdx].btnPressed[SDL_GAMEPAD_BUTTON_SOUTH]) {
-        gfx.joysticks[gpIdx].btnPressed[SDL_GAMEPAD_BUTTON_SOUTH] = false;
+      bool confirm = worm.Pressed(Worm::kFire);
+      if (!confirm && gp_idx >= 0 && gfx.joysticks[gp_idx].btn_pressed[SDL_GAMEPAD_BUTTON_SOUTH]) {
+        gfx.joysticks[gp_idx].btn_pressed[SDL_GAMEPAD_BUTTON_SOUTH] = false;
         confirm = true;
       }
 
       if (confirm) {
-        if (menus[i].selection() == 0) {
-          bool weapUsed[256] = {};
+        if (menus[i].Selection() == 0) {
+          bool weap_used[256] = {};
 
-          bool enoughWeapons = (enabledWeaps >= Settings::selectableWeapons);
+          bool enough_weapons = (enabled_weaps >= Settings::kSelectableWeapons);
 
-          for (int j = 0; j < Settings::selectableWeapons; ++j) {
+          for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
             while (true) {
               ws.weapons[j] = game.rand(1, 41);
 
-              int w = common.weapOrder[ws.weapons[j] - 1];
+              int w = common.weap_order[ws.weapons[j] - 1];
 
-              if ((!enoughWeapons || !weapUsed[w]) && game.settings->weapTable[w] <= 0) break;
+              if ((!enough_weapons || !weap_used[w]) && game.settings->weap_table[w] <= 0) break;
             }
 
-            int w = common.weapOrder[ws.weapons[j] - 1];
+            int w = common.weap_order[ws.weapons[j] - 1];
 
-            weapUsed[w] = true;
+            weap_used[w] = true;
 
             menus[i].items[j + 1].string = common.weapons[w].name;
           }
-        } else if (menus[i].selection() == 6)  // TODO: Unhardcode
+        } else if (menus[i].Selection() == 6)  // TODO: Unhardcode
         {
-          game.soundPlayer->play(common.soundHook[SoundMenuSelect]);
-          isReady[i] = true;
+          game.sound_player->Play(common.sound_hook[SoundMenuSelect]);
+          is_ready[i] = true;
         }
       }
     }
 
-    allReady = allReady && isReady[i];
+    all_ready = all_ready && is_ready[i];
   }
 
-  return allReady;
+  return all_ready;
 }
 
-void WeaponSelection::finalize() {
+void WeaponSelection::Finalize() {
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm& worm = *game.worms[i];
 
-    worm.initWeapons(game);
+    worm.InitWeapons(game);
   }
-  game.releaseControls();
+  game.ReleaseControls();
 
   // TODO: Make sure the weapon selection is transfered back to Gfx to be saved
 }
 
-void WeaponSelection::focus() { focused = true; }
+void WeaponSelection::Focus() { focused = true; }
 
-void WeaponSelection::unfocus() { focused = false; }
+void WeaponSelection::Unfocus() { focused = false; }

--- a/src/game/weapsel.hpp
+++ b/src/game/weapsel.hpp
@@ -9,22 +9,22 @@ struct Game;
 struct WeaponSelection {
   WeaponSelection(Game& game);
 
-  void draw(Renderer& renderer, GameState state, bool useSpectatorViewports);
-  void drawNormalViewports(Renderer& renderer, GameState state);
-  void drawSpectatorViewports(Renderer& renderer, GameState state);
-  bool processFrame();
-  void finalize();
+  void Draw(Renderer& renderer, GameState state, bool use_spectator_viewports);
+  void DrawNormalViewports(Renderer& renderer, GameState state);
+  void DrawSpectatorViewports(Renderer& renderer, GameState state);
+  bool ProcessFrame();
+  void Finalize();
 
-  void focus();
-  void unfocus();
+  void Focus();
+  void Unfocus();
 
   Game& game;
 
-  int enabledWeaps;
-  int fadeValue;
-  std::vector<bool> isReady;
+  int enabled_weaps;
+  int fade_value;
+  std::vector<bool> is_ready;
   std::vector<Menu> menus;
-  bool cachedBackground, cachedSpectatorBackground;
+  bool cached_background, cached_spectator_background;
   bool focused;
 };
 

--- a/src/game/worm.cpp
+++ b/src/game/worm.cpp
@@ -93,37 +93,37 @@ void WormSettings::LoadProfile(FsNode node) {
 
 void Worm::CalculateReactionForce(Game& game, int new_x, int new_y, int dir) {
   static Point const kColPoints[4][7] = {{// DOWN reaction points
-                                         {-1, -4},
-                                         {0, -4},
-                                         {1, -4},
-                                         {0, 0},
-                                         {0, 0},
-                                         {0, 0},
-                                         {0, 0}},
-                                        {// LEFT reaction points
-                                         {1, -3},
-                                         {1, -2},
-                                         {1, -1},
-                                         {1, 0},
-                                         {1, 1},
-                                         {1, 2},
-                                         {1, 3}},
-                                        {// UP reaction points
-                                         {-1, 4},
-                                         {0, 4},
-                                         {1, 4},
-                                         {0, 0},
-                                         {0, 0},
-                                         {0, 0},
-                                         {0, 0}},
-                                        {// RIGHT reaction points
-                                         {-1, -3},
-                                         {-1, -2},
-                                         {-1, -1},
-                                         {-1, 0},
-                                         {-1, 1},
-                                         {-1, 2},
-                                         {-1, 3}}
+                                          {-1, -4},
+                                          {0, -4},
+                                          {1, -4},
+                                          {0, 0},
+                                          {0, 0},
+                                          {0, 0},
+                                          {0, 0}},
+                                         {// LEFT reaction points
+                                          {1, -3},
+                                          {1, -2},
+                                          {1, -1},
+                                          {1, 0},
+                                          {1, 1},
+                                          {1, 2},
+                                          {1, 3}},
+                                         {// UP reaction points
+                                          {-1, 4},
+                                          {0, 4},
+                                          {1, 4},
+                                          {0, 0},
+                                          {0, 0},
+                                          {0, 0},
+                                          {0, 0}},
+                                         {// RIGHT reaction points
+                                          {-1, -3},
+                                          {-1, -2},
+                                          {-1, -1},
+                                          {-1, 0},
+                                          {-1, 1},
+                                          {-1, 2},
+                                          {-1, 3}}
 
   };
 
@@ -319,7 +319,8 @@ void Worm::Process(Game& game) {
           weapons[current_weapon].delay_left <= 0) {
         Fire(game);
       } else if (!Pressed(kFire) || Pressed(kChange) || !weapons[current_weapon].Available()) {
-        if (weapons[current_weapon].type->loop_sound) game.sound_player->Stop(&weapons[current_weapon]);
+        if (weapons[current_weapon].type->loop_sound)
+          game.sound_player->Stop(&weapons[current_weapon]);
       }
 
       ProcessPhysics(game);
@@ -726,8 +727,9 @@ void Worm::DoRespawning(Game& game) {
   int dest_y = Ftoi(pos.y) - 80;
   LimitXy(dest_x, dest_y, game.level.width - 158, game.level.height - 158);
 
-  if (logic_respawn.x < dest_x + 5 && logic_respawn.x > dest_x - 5 && logic_respawn.y < dest_y + 5 &&
-      logic_respawn.y > dest_y - 5 && ready)  // Don't spawn in quicksim
+  if (logic_respawn.x < dest_x + 5 && logic_respawn.x > dest_x - 5 &&
+      logic_respawn.y < dest_y + 5 && logic_respawn.y > dest_y - 5 &&
+      ready)  // Don't spawn in quicksim
   {
     auto ipos = Ftoi(pos);
     DrawDirtEffect(common, game.rand, game.level, 0, ipos.x - 7, ipos.y - 7);

--- a/src/game/worm.cpp
+++ b/src/game/worm.cpp
@@ -17,82 +17,82 @@
 
 #include <SDL3/SDL.h>
 
-void WormSettingsExtensions::initDefaultGamepadControls() {
+void WormSettingsExtensions::InitDefaultGamepadControls() {
   // DPad for movement
-  gamepadControls[Up] = SDL_GAMEPAD_BUTTON_DPAD_UP;
-  gamepadControls[Down] = SDL_GAMEPAD_BUTTON_DPAD_DOWN;
-  gamepadControls[Left] = SDL_GAMEPAD_BUTTON_DPAD_LEFT;
-  gamepadControls[Right] = SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
+  gamepad_controls[kUp] = SDL_GAMEPAD_BUTTON_DPAD_UP;
+  gamepad_controls[kDown] = SDL_GAMEPAD_BUTTON_DPAD_DOWN;
+  gamepad_controls[kLeft] = SDL_GAMEPAD_BUTTON_DPAD_LEFT;
+  gamepad_controls[kRight] = SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
   // A = Jump, Right trigger = Fire, Right shoulder = Change, Left shoulder = Dig
-  gamepadControls[Jump] = SDL_GAMEPAD_BUTTON_SOUTH;
-  gamepadControls[Fire] = gamepadAxisPositive(SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
-  gamepadControls[Change] = SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER;
-  gamepadControls[Dig] = SDL_GAMEPAD_BUTTON_LEFT_SHOULDER;
+  gamepad_controls[kJump] = SDL_GAMEPAD_BUTTON_SOUTH;
+  gamepad_controls[kFire] = GamepadAxisPositive(SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
+  gamepad_controls[kChange] = SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER;
+  gamepad_controls[kDig] = SDL_GAMEPAD_BUTTON_LEFT_SHOULDER;
 }
 
 struct Point {
   int x, y;
 };
 
-uint64_t& WormSettings::updateHash() {
-  std::string tomlData = toToml();
+uint64_t& WormSettings::UpdateHash() {
+  std::string toml_data = ToToml();
 
-  hash = XXH3_64bits(tomlData.data(), tomlData.size());
+  hash = XXH3_64bits(toml_data.data(), toml_data.size());
   return hash;
 }
 
-std::string WormSettings::toToml() const {
+std::string WormSettings::ToToml() const {
   std::ostringstream ss;
   {
     cereal::TomlOutputArchive ar(ss);
-    serializeWormSettingsToml(ar, const_cast<WormSettings&>(*this));
+    SerializeWormSettingsToml(ar, const_cast<WormSettings&>(*this));
   }
   return ss.str();
 }
 
-void WormSettings::fromToml(std::string const& data) {
+void WormSettings::FromToml(std::string const& data) {
   std::istringstream ss(data);
   cereal::TomlInputArchive ar(ss);
-  serializeWormSettingsToml(ar, *this);
+  SerializeWormSettingsToml(ar, *this);
 }
 
-void WormSettings::saveProfile(FsNode node) {
+void WormSettings::SaveProfile(FsNode node) {
   try {
-    auto writer_ptr = node.toWriter();
+    auto writer_ptr = node.ToWriter();
     io::Writer& writer = *writer_ptr;
-    profileNode = node;
+    profile_node = node;
 
-    std::string toml = toToml();
-    writer.put(reinterpret_cast<uint8_t const*>(toml.data()), toml.size());
+    std::string toml = ToToml();
+    writer.Put(reinterpret_cast<uint8_t const*>(toml.data()), toml.size());
   } catch (std::runtime_error& e) {
-    Console::writeWarning(std::string("Error saving profile: ") + e.what());
+    console::WriteWarning(std::string("Error saving profile: ") + e.what());
   }
 }
 
-void WormSettings::loadProfile(FsNode node) {
-  int oldColor = color;
+void WormSettings::LoadProfile(FsNode node) {
+  int old_color = color;
   try {
-    auto reader_ptr = node.toReader();
+    auto reader_ptr = node.ToReader();
     io::Reader& reader = *reader_ptr;
-    profileNode = node;
+    profile_node = node;
 
     std::string content;
     uint8_t buf[4096];
     for (;;) {
-      std::size_t got = reader.try_get(buf, sizeof(buf));
+      std::size_t got = reader.TryGet(buf, sizeof(buf));
       if (got == 0) break;
       content.append(reinterpret_cast<char*>(buf), got);
     }
-    fromToml(content);
+    FromToml(content);
   } catch (std::runtime_error& e) {
-    Console::writeWarning(std::string("Error loading profile: ") + e.what());
+    console::WriteWarning(std::string("Error loading profile: ") + e.what());
   }
 
-  color = oldColor;  // We preserve the color
+  color = old_color;  // We preserve the color
 }
 
-void Worm::calculateReactionForce(Game& game, int newX, int newY, int dir) {
-  static Point const colPoints[4][7] = {{// DOWN reaction points
+void Worm::CalculateReactionForce(Game& game, int new_x, int new_y, int dir) {
+  static Point const kColPoints[4][7] = {{// DOWN reaction points
                                          {-1, -4},
                                          {0, -4},
                                          {1, -4},
@@ -127,33 +127,33 @@ void Worm::calculateReactionForce(Game& game, int newX, int newY, int dir) {
 
   };
 
-  static int const colPointCount[4] = {3, 7, 3, 7};
+  static int const kColPointCount[4] = {3, 7, 3, 7};
 
   reacts[dir] = 0;
 
   // newX should be x + velX at the first call
 
-  for (int i = 0; i < colPointCount[dir]; ++i) {
-    int colX = newX + colPoints[dir][i].x;
-    int colY = newY + colPoints[dir][i].y;
+  for (int i = 0; i < kColPointCount[dir]; ++i) {
+    int col_x = new_x + kColPoints[dir][i].x;
+    int col_y = new_y + kColPoints[dir][i].y;
 
-    if (!game.level.checkedMatWrap(colX, colY).background()) {
+    if (!game.level.CheckedMatWrap(col_x, col_y).Background()) {
       ++reacts[dir];
     }
   }
 }
 
-void Worm::processPhysics(Game& game) {
+void Worm::ProcessPhysics(Game& game) {
   Common& common = *game.common;
 
-  if (reacts[RFUp] > 0) vel.x = (vel.x * LC(WormFricMult)) / LC(WormFricDiv);
+  if (reacts[kRfUp] > 0) vel.x = (vel.x * LC(WormFricMult)) / LC(WormFricDiv);
 
   fixedvec absvel(std::abs(vel.x), std::abs(vel.y));
 
   int32_t rh, rv, mbh, mbv;
 
-  rh = reacts[vel.x >= 0 ? RFLeft : RFRight];
-  rv = reacts[vel.y >= 0 ? RFUp : RFDown];
+  rh = reacts[vel.x >= 0 ? kRfLeft : kRfRight];
+  rv = reacts[vel.y >= 0 ? kRfUp : kRfDown];
   mbh = vel.x > 0 ? LC(MinBounceRight) : -LC(MinBounceLeft);
   mbv = vel.y > 0 ? LC(MinBounceDown) : -LC(MinBounceUp);
 
@@ -161,10 +161,10 @@ void Worm::processPhysics(Game& game) {
       rh)  // TODO: We wouldn't need the vel.x check if we knew that mbh/mbv were always non-zero
   {
     if (absvel.x > mbh) {
-      if (common.H[HFallDamage])
+      if (common.h[HFallDamage])
         health -= LC(FallDamageRight);
       else
-        game.soundPlayer->play(common.soundHook[SoundBump]);
+        game.sound_player->Play(common.sound_hook[SoundBump]);
       vel.x = -vel.x / 3;
     } else
       vel.x = 0;
@@ -172,195 +172,195 @@ void Worm::processPhysics(Game& game) {
 
   if (vel.y && rv) {
     if (absvel.y > mbv) {
-      if (common.H[HFallDamage])
+      if (common.h[HFallDamage])
         health -= LC(FallDamageDown);
       else
-        game.soundPlayer->play(common.soundHook[SoundBump]);
+        game.sound_player->Play(common.sound_hook[SoundBump]);
       vel.y = -vel.y / 3;
     } else
       vel.y = 0;
   }
 
-  if (reacts[RFUp] == 0) {
+  if (reacts[kRfUp] == 0) {
     vel.y += LC(WormGravity);
   }
 
   // No, we can't use rh/rv here, they are out of date
-  if (reacts[vel.x >= 0 ? RFLeft : RFRight] < 2) pos.x += vel.x;
+  if (reacts[vel.x >= 0 ? kRfLeft : kRfRight] < 2) pos.x += vel.x;
 
-  if (reacts[vel.y >= 0 ? RFUp : RFDown] < 2) pos.y += vel.y;
+  if (reacts[vel.y >= 0 ? kRfUp : kRfDown] < 2) pos.y += vel.y;
 }
 
-void Worm::process(Game& game) {
+void Worm::Process(Game& game) {
   Common& common = *game.common;
 
   if (health > settings->health) health = settings->health;
 
-  if ((game.settings->gameMode != Settings::GMKillEmAll &&
-       game.settings->gameMode != Settings::GMScalesOfJustice) ||
+  if ((game.settings->game_mode != Settings::kGmKillEmAll &&
+       game.settings->game_mode != Settings::kGmScalesOfJustice) ||
       lives > 0) {
     if (visible) {
       // Liero.exe: 291C
 
       auto next = pos + vel;
-      auto iNext = ftoi(next);
+      auto i_next = Ftoi(next);
 
       {  // Calculate reaction forces
 
         for (int i = 0; i < 4; i++) {
-          calculateReactionForce(game, iNext.x, iNext.y, i);
+          CalculateReactionForce(game, i_next.x, i_next.y, i);
 
           // Yes, Liero does this in every iteration. Keep it this way.
 
-          if (iNext.x < 4) {
-            reacts[RFRight] += 5;
-          } else if (iNext.x > game.level.width - 5) {
-            reacts[RFLeft] += 5;
+          if (i_next.x < 4) {
+            reacts[kRfRight] += 5;
+          } else if (i_next.x > game.level.width - 5) {
+            reacts[kRfLeft] += 5;
           }
 
-          if (iNext.y < 5) {
-            reacts[RFDown] += 5;
+          if (i_next.y < 5) {
+            reacts[kRfDown] += 5;
           } else {
-            if (common.H[HWormFloat]) {
-              if (iNext.y > LC(WormFloatLevel)) vel.y -= LC(WormFloatPower);
-            } else if (iNext.y > game.level.height - 6) {
-              reacts[RFUp] += 5;
+            if (common.h[HWormFloat]) {
+              if (i_next.y > LC(WormFloatLevel)) vel.y -= LC(WormFloatPower);
+            } else if (i_next.y > game.level.height - 6) {
+              reacts[kRfUp] += 5;
             }
           }
         }
 
-        if (reacts[RFDown] < 2) {
-          if (reacts[RFUp] > 0) {
-            if (reacts[RFLeft] > 0 || reacts[RFRight] > 0) {
+        if (reacts[kRfDown] < 2) {
+          if (reacts[kRfUp] > 0) {
+            if (reacts[kRfLeft] > 0 || reacts[kRfRight] > 0) {
               // Low or none push down,
               // Push up and
               // Push left or right
 
-              pos.y -= itof(1);
+              pos.y -= Itof(1);
               next.y = pos.y + vel.y;
-              iNext.y = ftoi(next.y);
+              i_next.y = Ftoi(next.y);
 
-              calculateReactionForce(game, iNext.x, iNext.y, RFLeft);
-              calculateReactionForce(game, iNext.x, iNext.y, RFRight);
+              CalculateReactionForce(game, i_next.x, i_next.y, kRfLeft);
+              CalculateReactionForce(game, i_next.x, i_next.y, kRfRight);
             }
           }
         }
 
-        if (reacts[RFUp] < 2) {
-          if (reacts[RFDown] > 0) {
-            if (reacts[RFLeft] > 0 || reacts[RFRight] > 0) {
+        if (reacts[kRfUp] < 2) {
+          if (reacts[kRfDown] > 0) {
+            if (reacts[kRfLeft] > 0 || reacts[kRfRight] > 0) {
               // Low or none push up,
               // Push down and
               // Push left or right
 
-              pos.y += itof(1);
+              pos.y += Itof(1);
               next.y = pos.y + vel.y;
-              iNext.y = ftoi(next.y);
+              i_next.y = Ftoi(next.y);
 
-              calculateReactionForce(game, iNext.x, iNext.y, RFLeft);
-              calculateReactionForce(game, iNext.x, iNext.y, RFRight);
+              CalculateReactionForce(game, i_next.x, i_next.y, kRfLeft);
+              CalculateReactionForce(game, i_next.x, i_next.y, kRfRight);
             }
           }
         }
       }
 
-      auto ipos = ftoi(pos);
+      auto ipos = Ftoi(pos);
 
-      auto br = game.bonuses.all();
-      for (Bonus* i; (i = br.next());) {
-        if (ipos.x + 5 > ftoi(i->x) && ipos.x - 5 < ftoi(i->x) && ipos.y + 5 > ftoi(i->y) &&
-            ipos.y - 5 < ftoi(i->y)) {
+      auto br = game.bonuses.All();
+      for (Bonus* i; (i = br.Next());) {
+        if (ipos.x + 5 > Ftoi(i->x) && ipos.x - 5 < Ftoi(i->x) && ipos.y + 5 > Ftoi(i->y) &&
+            ipos.y - 5 < Ftoi(i->y)) {
           if (i->frame == 1) {
             if (health < settings->health) {
-              game.bonuses.free(br);
+              game.bonuses.Free(br);
 
-              game.doHealing(*this, (game.rand(LC(BonusHealthVar)) + LC(BonusMinHealth)) *
+              game.DoHealing(*this, (game.rand(LC(BonusHealthVar)) + LC(BonusMinHealth)) *
                                         settings->health / 100);
             }
           } else if (i->frame == 0) {
             if (game.rand(LC(BonusExplodeRisk)) > 1) {
-              WormWeapon& ww = weapons[currentWeapon];
+              WormWeapon& ww = weapons[current_weapon];
 
-              if (!common.H[HBonusReloadOnly]) {
-                fireCone = 0;
+              if (!common.h[HBonusReloadOnly]) {
+                fire_cone = 0;
 
                 ww.type = &common.weapons[i->weapon];
                 ww.ammo = ww.type->ammo;
               }
 
-              game.soundPlayer->play(common.soundHook[SoundReloaded]);
+              game.sound_player->Play(common.sound_hook[SoundReloaded]);
 
-              game.bonuses.free(br);
+              game.bonuses.Free(br);
 
-              ww.loadingLeft = 0;
+              ww.loading_left = 0;
             } else {
-              int bix = ftoi(i->x);
-              int biy = ftoi(i->y);
-              game.bonuses.free(br);
-              common.sobjectTypes[0].create(game, bix, biy, index, 0);
+              int bix = Ftoi(i->x);
+              int biy = Ftoi(i->y);
+              game.bonuses.Free(br);
+              common.sobject_types[0].Create(game, bix, biy, index, 0);
             }
           }
         }
       }
 
-      processSteerables(game);
+      ProcessSteerables(game);
 
-      if (!movable && !pressed(Left) &&
-          !pressed(Right))  // processSteerables sets movable to false, does this interfer?
+      if (!movable && !Pressed(kLeft) &&
+          !Pressed(kRight))  // processSteerables sets movable to false, does this interfer?
       {
         movable = true;
       }  // 2FB1
 
-      processAiming(game);
-      processTasks(game);
-      processWeapons(game);
+      ProcessAiming(game);
+      ProcessTasks(game);
+      ProcessWeapons(game);
 
-      if (pressed(Fire) && !pressed(Change) && weapons[currentWeapon].available() &&
-          weapons[currentWeapon].delayLeft <= 0) {
-        fire(game);
-      } else if (!pressed(Fire) || pressed(Change) || !weapons[currentWeapon].available()) {
-        if (weapons[currentWeapon].type->loopSound) game.soundPlayer->stop(&weapons[currentWeapon]);
+      if (Pressed(kFire) && !Pressed(kChange) && weapons[current_weapon].Available() &&
+          weapons[current_weapon].delay_left <= 0) {
+        Fire(game);
+      } else if (!Pressed(kFire) || Pressed(kChange) || !weapons[current_weapon].Available()) {
+        if (weapons[current_weapon].type->loop_sound) game.sound_player->Stop(&weapons[current_weapon]);
       }
 
-      processPhysics(game);
-      processSight(game);
+      ProcessPhysics(game);
+      ProcessSight(game);
 
-      if (pressed(Change)) {
-        processWeaponChange(game);
+      if (Pressed(kChange)) {
+        ProcessWeaponChange(game);
       } else {
-        keyChangePressed = false;
-        processMovement(game);
+        key_change_pressed = false;
+        ProcessMovement(game);
       }
 
       if (health < settings->health / 4) {
         if (game.rand(health + 6) == 0) {
           if (game.rand(3) == 0) {
             int snd = 18 + game.rand(3);  // NOTE: MUST be outside the unpredictable branch below
-            if (!game.soundPlayer->isPlaying(this)) {
-              game.soundPlayer->play(snd, this);
+            if (!game.sound_player->IsPlaying(this)) {
+              game.sound_player->Play(snd, this);
             }
           }
 
-          common.nobjectTypes[6].create1(game, vel, pos, 0, index, 0);
+          common.nobject_types[6].Create1(game, vel, pos, 0, index, 0);
         }
       }
 
       if (health <= 0) {
-        leaveShellTimer = 0;
-        makeSightGreen = false;
+        leave_shell_timer = 0;
+        make_sight_green = false;
 
-        Weapon const& w = *weapons[currentWeapon].type;
-        if (w.loopSound) {
-          game.soundPlayer->stop(&weapons[currentWeapon]);
+        Weapon const& w = *weapons[current_weapon].type;
+        if (w.loop_sound) {
+          game.sound_player->Stop(&weapons[current_weapon]);
         }
 
-        int deathSnd = 15 + game.rand(3);
-        game.soundPlayer->play(deathSnd, this);
+        int death_snd = 15 + game.rand(3);
+        game.sound_player->Play(death_snd, this);
 
-        fireCone = 0;
+        fire_cone = 0;
         ninjarope.out = false;
 
-        if (game.settings->gameMode == Settings::GMScalesOfJustice) {
+        if (game.settings->game_mode == Settings::kGmScalesOfJustice) {
           while (health <= 0) {
             health += settings->health;
             --lives;
@@ -369,61 +369,61 @@ void Worm::process(Game& game) {
           --lives;
         }
 
-        int oldLastKilled = game.lastKilledIdx;
+        int old_last_killed = game.last_killed_idx;
         // For GameOfTag, 'it' doesn't change if the killer
         // was not 'it', itself, unknown or there were no 'it'.
-        if (game.settings->gameMode != Settings::GMGameOfTag || game.lastKilledIdx < 0 ||
-            lastKilledByIdx < 0 || lastKilledByIdx == index ||
-            lastKilledByIdx == game.lastKilledIdx) {
-          game.lastKilledIdx = index;
+        if (game.settings->game_mode != Settings::kGmGameOfTag || game.last_killed_idx < 0 ||
+            last_killed_by_idx < 0 || last_killed_by_idx == index ||
+            last_killed_by_idx == game.last_killed_idx) {
+          game.last_killed_idx = index;
         }
-        game.gotChanged = (oldLastKilled != game.lastKilledIdx);
+        game.got_changed = (old_last_killed != game.last_killed_idx);
 
-        if (lastKilledByIdx >= 0 && lastKilledByIdx != index) {
-          ++game.wormByIdx(lastKilledByIdx)->kills;
+        if (last_killed_by_idx >= 0 && last_killed_by_idx != index) {
+          ++game.WormByIdx(last_killed_by_idx)->kills;
         }
 
         visible = false;
-        killedTimer = KilledTimerInitial;
+        killed_timer = kKilledTimerInitial;
 
         int max = 120 * game.settings->blood / 100;
 
         if (max > 1) {
           for (int i = 1; i <= max; ++i) {
-            common.nobjectTypes[6].create2(game, game.rand(128), vel / 3, pos, 0, index, 0);
+            common.nobject_types[6].Create2(game, game.rand(128), vel / 3, pos, 0, index, 0);
           }
         }
 
         for (int i = 7; i <= 105; i += 14) {
-          common.nobjectTypes[index].create2(game, i + game.rand(14), vel / 3, pos, 0, index, 0);
+          common.nobject_types[index].Create2(game, i + game.rand(14), vel / 3, pos, 0, index, 0);
         }
 
-        game.statsRecorder->afterDeath(this);
+        game.stats_recorder->AfterDeath(this);
 
-        release(Fire);
+        Release(kFire);
       }
 
       // Update frame
-      int animFrame = animate ? ((game.cycles & 31) >> 3) : 0;
-      currentFrame = angleFrame() + game.settings->wormAnimTab[animFrame];
+      int anim_frame = animate ? ((game.cycles & 31) >> 3) : 0;
+      current_frame = AngleFrame() + game.settings->kWormAnimTab[anim_frame];
     } else {
       // Worm is dead
-      steerableCount = 0;
+      steerable_count = 0;
 
-      if (pressedOnce(Fire)) ready = true;
+      if (PressedOnce(kFire)) ready = true;
 
-      if (killedTimer > 0) --killedTimer;
+      if (killed_timer > 0) --killed_timer;
 
-      if (killedTimer == 0 && !game.quickSim)  // Don't respawn in quicksim
-        beginRespawn(game);
+      if (killed_timer == 0 && !game.quick_sim)  // Don't respawn in quicksim
+        BeginRespawn(game);
 
-      if (killedTimer < 0) doRespawning(game);
+      if (killed_timer < 0) DoRespawning(game);
     }
   }
 }
 
-int Worm::angleFrame() const {
-  int x = ftoi(aimingAngle) - 12;
+int Worm::AngleFrame() const {
+  int x = Ftoi(aiming_angle) - 12;
 
   if (direction != 0) x -= 49;
 
@@ -440,113 +440,113 @@ int Worm::angleFrame() const {
   return x;
 }
 
-int sqrVectorLength(int x, int y) { return x * x + y * y; }
+int SqrVectorLength(int x, int y) { return x * x + y * y; }
 
-void DumbLieroAI::process(Game& game, Worm& worm) {
+void DumbLieroAI::Process(Game& game, Worm& worm) {
   Common& common = *game.common;
 
   Worm* target = 0;
-  int minLen = 0;
+  int min_len = 0;
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm* w = game.worms[i].get();
     if (w != &worm) {
       int len =
-          sqrVectorLength(ftoi(worm.pos.x) - ftoi(w->pos.x), ftoi(worm.pos.y) - ftoi(w->pos.y));
-      if (!target || len < minLen)  // First or closer worm
+          SqrVectorLength(Ftoi(worm.pos.x) - Ftoi(w->pos.x), Ftoi(worm.pos.y) - Ftoi(w->pos.y));
+      if (!target || len < min_len)  // First or closer worm
       {
         target = w;
-        minLen = len;
+        min_len = len;
       }
     }
   }
 
-  int maxDist;
+  int max_dist;
 
-  WormWeapon& ww = worm.weapons[worm.currentWeapon];
+  WormWeapon& ww = worm.weapons[worm.current_weapon];
   Weapon const& w = *ww.type;
 
-  if (w.timeToExplo > 0 && w.timeToExplo < 500) {
-    maxDist = (w.timeToExplo - w.timeToExploV / 2) * w.speed / 130;
+  if (w.time_to_explo > 0 && w.time_to_explo < 500) {
+    max_dist = (w.time_to_explo - w.time_to_explo_v / 2) * w.speed / 130;
   } else {
-    maxDist = w.speed - w.gravity / 10;
+    max_dist = w.speed - w.gravity / 10;
   }  // 4D43
 
-  if (maxDist < 90) maxDist = 90;
+  if (max_dist < 90) max_dist = 90;
 
   fixedvec delta = target->pos - worm.pos;
-  auto idelta = ftoi(delta);
+  auto idelta = Ftoi(delta);
 
-  int realDist = vectorLength(idelta.x, idelta.y);
+  int real_dist = VectorLength(idelta.x, idelta.y);
 
-  if (realDist < maxDist || !worm.visible) {
+  if (real_dist < max_dist || !worm.visible) {
     // The other worm is close enough
-    bool fire = worm.pressed(Worm::Fire);
-    if (rand(common.aiParams.k[fire][WormSettings::Fire]) == 0) {
-      worm.setControlState(Worm::Fire, !fire);
+    bool fire = worm.Pressed(Worm::kFire);
+    if (rand(common.ai_params.k[fire][WormSettings::kFire]) == 0) {
+      worm.SetControlState(Worm::kFire, !fire);
     }  // 4DE7
   } else if (worm.visible) {
-    worm.release(Worm::Fire);
+    worm.Release(Worm::kFire);
   }  // 4DFA
 
   // In Liero this is a loop with two iterations, that's better maybe
-  bool jump = worm.pressed(Worm::Jump);
-  if (rand(common.aiParams.k[jump][WormSettings::Jump]) == 0) {
-    worm.toggleControlState(Worm::Jump);
+  bool jump = worm.Pressed(Worm::kJump);
+  if (rand(common.ai_params.k[jump][WormSettings::kJump]) == 0) {
+    worm.ToggleControlState(Worm::kJump);
   }
 
-  bool change = worm.pressed(Worm::Change);
-  if (rand(common.aiParams.k[change][WormSettings::Change]) == 0) {
-    worm.toggleControlState(Worm::Change);
+  bool change = worm.Pressed(Worm::kChange);
+  if (rand(common.ai_params.k[change][WormSettings::kChange]) == 0) {
+    worm.ToggleControlState(Worm::kChange);
   }
 
   // l_4E6B:
   //  Moves up
 
   // l_4EE5:
-  if (realDist > 0) {
-    delta /= realDist;
+  if (real_dist > 0) {
+    delta /= real_dist;
   } else {
-    delta.zero();
+    delta.Zero();
   }  // 4F2F
 
   int dir = 1;
 
   for (; dir < 128; ++dir) {
-    if (std::abs(cossinTable[dir].x - delta.x) < 0xC00 &&
-        std::abs(cossinTable[dir].y - delta.y) < 0xC00)  // The original had 0xC000, which is wrong
+    if (std::abs(cossin_table[dir].x - delta.x) < 0xC00 &&
+        std::abs(cossin_table[dir].y - delta.y) < 0xC00)  // The original had 0xC000, which is wrong
       break;
   }  // 4F93
 
-  fixed adeltaX = std::abs(delta.x);
-  fixed adeltaY = std::abs(delta.y);
+  fixed adelta_x = std::abs(delta.x);
+  fixed adelta_y = std::abs(delta.y);
 
   if (dir >= 128) {
     if (delta.x > 0) {
       if (delta.y < 0) {
-        if (adeltaY > adeltaX)
+        if (adelta_y > adelta_x)
           dir = 64 + rand(16);
-        else if (adeltaX > adeltaY)
+        else if (adelta_x > adelta_y)
           dir = 80 + rand(16);
         else
           dir = 80;
       } else  // deltaY >= 0
       {
-        if (adeltaX > adeltaY)
+        if (adelta_x > adelta_y)
           dir = 96 + rand(16);
         else
           dir = 116;
       }
     } else {
       if (delta.y < 0) {
-        if (adeltaY > adeltaX)
+        if (adelta_y > adelta_x)
           dir = 48 + rand(16);
-        else if (adeltaX > adeltaY)
+        else if (adelta_x > adelta_y)
           dir = 32 + rand(16);
         else
           dir = 48;  // This was 56, but that seems wrong
       } else         // deltaX <= 0 && deltaY >= 0
       {
-        if (adeltaX > adeltaY)
+        if (adelta_x > adelta_y)
           dir = 12 + rand(16);
         else
           dir = 12;
@@ -581,230 +581,230 @@ void DumbLieroAI::process(Game& game, Worm& worm) {
      } // 51C6
   */
 
-  change = worm.pressed(Worm::Change);
+  change = worm.Pressed(Worm::kChange);
 
   if (change) {
-    if (rand(common.aiParams.k[worm.pressed(Worm::Left)][WormSettings::Left]) == 0) {
-      worm.toggleControlState(Worm::Left);
+    if (rand(common.ai_params.k[worm.Pressed(Worm::kLeft)][WormSettings::kLeft]) == 0) {
+      worm.ToggleControlState(Worm::kLeft);
     }
 
-    if (rand(common.aiParams.k[worm.pressed(Worm::Right)][WormSettings::Right]) == 0) {
-      worm.toggleControlState(Worm::Right);
+    if (rand(common.ai_params.k[worm.Pressed(Worm::kRight)][WormSettings::kRight]) == 0) {
+      worm.ToggleControlState(Worm::kRight);
     }
 
     if (worm.ninjarope.out && worm.ninjarope.attached) {
       // l_525F:
-      bool up = worm.pressed(Worm::Up);
+      bool up = worm.Pressed(Worm::kUp);
 
-      if (rand(common.aiParams.k[up][WormSettings::Up]) == 0) {
-        worm.toggleControlState(Worm::Up);
+      if (rand(common.ai_params.k[up][WormSettings::kUp]) == 0) {
+        worm.ToggleControlState(Worm::kUp);
       }
 
-      bool down = worm.pressed(Worm::Down);
-      if (rand(common.aiParams.k[down][WormSettings::Down]) == 0) {
-        worm.toggleControlState(Worm::Down);
+      bool down = worm.Pressed(Worm::kDown);
+      if (rand(common.ai_params.k[down][WormSettings::kDown]) == 0) {
+        worm.ToggleControlState(Worm::kDown);
       }
     } else {
       // l_52D2:
-      worm.release(Worm::Up);
-      worm.release(Worm::Down);
+      worm.Release(Worm::kUp);
+      worm.Release(Worm::kDown);
     }  // 52F8
   }  // if(change)
   else {
-    if (realDist > maxDist) {
-      worm.setControlState(Worm::Right, (delta.x > 0));
-      worm.setControlState(Worm::Left, (delta.x <= 0));
+    if (real_dist > max_dist) {
+      worm.SetControlState(Worm::kRight, (delta.x > 0));
+      worm.SetControlState(Worm::kLeft, (delta.x <= 0));
     }  // 5347
     else {
-      worm.release(Worm::Right);
-      worm.release(Worm::Left);
+      worm.Release(Worm::kRight);
+      worm.Release(Worm::kLeft);
     }
 
     if (worm.direction != 0) {
-      if (dir < 64) worm.press(Worm::Left);
+      if (dir < 64) worm.Press(Worm::kLeft);
       // 5369
-      worm.setControlState(Worm::Up, (dir + 1 < ftoi(worm.aimingAngle)));
+      worm.SetControlState(Worm::kUp, (dir + 1 < Ftoi(worm.aiming_angle)));
       // 5379
-      worm.setControlState(Worm::Down, (dir - 1 > ftoi(worm.aimingAngle)));
+      worm.SetControlState(Worm::kDown, (dir - 1 > Ftoi(worm.aiming_angle)));
     } else {
-      if (dir > 64) worm.press(Worm::Right);
+      if (dir > 64) worm.Press(Worm::kRight);
       // 53C6
-      worm.setControlState(Worm::Up, (dir - 1 > ftoi(worm.aimingAngle)));
+      worm.SetControlState(Worm::kUp, (dir - 1 > Ftoi(worm.aiming_angle)));
       // 53E8
-      worm.setControlState(Worm::Down, (dir + 1 < ftoi(worm.aimingAngle)));
+      worm.SetControlState(Worm::kDown, (dir + 1 < Ftoi(worm.aiming_angle)));
       // 540A
     }
 
-    if (worm.pressed(Worm::Left) && worm.reacts[Worm::RFRight]) {
-      if (worm.reacts[Worm::RFDown] > 0)
-        worm.press(Worm::Right);
+    if (worm.Pressed(Worm::kLeft) && worm.reacts[Worm::kRfRight]) {
+      if (worm.reacts[Worm::kRfDown] > 0)
+        worm.Press(Worm::kRight);
       else
-        worm.press(Worm::Jump);
+        worm.Press(Worm::kJump);
     }  // 5454
 
-    if (worm.pressed(Worm::Right) && worm.reacts[Worm::RFLeft]) {
-      if (worm.reacts[Worm::RFDown] > 0)
-        worm.press(Worm::Left);
+    if (worm.Pressed(Worm::kRight) && worm.reacts[Worm::kRfLeft]) {
+      if (worm.reacts[Worm::kRfDown] > 0)
+        worm.Press(Worm::kLeft);
       else
-        worm.press(Worm::Jump);
+        worm.Press(Worm::kJump);
     }  // 549E
   }
 }
 
-void Worm::initWeapons(Game& game) {
+void Worm::InitWeapons(Game& game) {
   Common& common = *game.common;
-  currentWeapon = 0;  // It was 1 in OpenLiero A1
+  current_weapon = 0;  // It was 1 in OpenLiero A1
 
-  for (int j = 0; j < Settings::selectableWeapons; ++j) {
+  for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
     WormWeapon& ww = weapons[j];
-    ww.type = &common.weapons[common.weapOrder[settings->weapons[j] - 1]];
+    ww.type = &common.weapons[common.weap_order[settings->weapons[j] - 1]];
     ww.ammo = ww.type->ammo;
-    ww.delayLeft = 0;
-    ww.loadingLeft = 0;
+    ww.delay_left = 0;
+    ww.loading_left = 0;
   }
 }
 
-void Worm::beginRespawn(Game& game) {
+void Worm::BeginRespawn(Game& game) {
   Common& common = *game.common;
 
-  auto temp = ftoi(pos);
+  auto temp = Ftoi(pos);
 
-  logicRespawn = temp - IVec2(80, 80);
+  logic_respawn = temp - IVec2(80, 80);
 
   auto enemy = temp;
 
   if (game.worms.size() == 2) {
-    enemy = ftoi(game.worms[index ^ 1]->pos);
+    enemy = Ftoi(game.worms[index ^ 1]->pos);
   }
 
   int trials = 0;
   do {
-    pos.x = itof(LC(WormSpawnRectX) + game.rand(LC(WormSpawnRectW)));
-    pos.y = itof(LC(WormSpawnRectY) + game.rand(LC(WormSpawnRectH)));
+    pos.x = Itof(LC(WormSpawnRectX) + game.rand(LC(WormSpawnRectW)));
+    pos.y = Itof(LC(WormSpawnRectY) + game.rand(LC(WormSpawnRectH)));
 
     // The original didn't have + 4 in both, which seems
     // to be done in the exe and makes sense.
-    while (ftoi(pos.y) + 4 < game.level.height &&
-           game.level.mat(ftoi(pos.x), ftoi(pos.y) + 4).background()) {
-      pos.y += itof(1);
+    while (Ftoi(pos.y) + 4 < game.level.height &&
+           game.level.Mat(Ftoi(pos.x), Ftoi(pos.y) + 4).Background()) {
+      pos.y += Itof(1);
     }
 
     if (++trials >= 50000) break;
-  } while (!checkRespawnPosition(game, enemy.x, enemy.y, temp.x, temp.y, ftoi(pos.x), ftoi(pos.y)));
+  } while (!CheckRespawnPosition(game, enemy.x, enemy.y, temp.x, temp.y, Ftoi(pos.x), Ftoi(pos.y)));
 
-  killedTimer = -1;
+  killed_timer = -1;
 }
 
-void limitXY(int& x, int& y, int maxX, int maxY) {
+void LimitXy(int& x, int& y, int max_x, int max_y) {
   if (x < 0)
     x = 0;
-  else if (x > maxX)
-    x = maxX;
+  else if (x > max_x)
+    x = max_x;
 
   if (y < 0) y = 0;
-  if (y > maxY) y = maxY;
+  if (y > max_y) y = max_y;
 }
 
-void Worm::doRespawning(Game& game) {
+void Worm::DoRespawning(Game& game) {
   Common& common = *game.common;
 
   for (int c = 0; c < 4; c++) {
-    if (logicRespawn.x < ftoi(pos.x) - 80)
-      ++logicRespawn.x;
-    else if (logicRespawn.x > ftoi(pos.x) - 80)
-      --logicRespawn.x;
+    if (logic_respawn.x < Ftoi(pos.x) - 80)
+      ++logic_respawn.x;
+    else if (logic_respawn.x > Ftoi(pos.x) - 80)
+      --logic_respawn.x;
 
-    if (logicRespawn.y < ftoi(pos.y) - 80)
-      ++logicRespawn.y;
-    else if (logicRespawn.y > ftoi(pos.y) - 80)
-      --logicRespawn.y;
+    if (logic_respawn.y < Ftoi(pos.y) - 80)
+      ++logic_respawn.y;
+    else if (logic_respawn.y > Ftoi(pos.y) - 80)
+      --logic_respawn.y;
   }
 
-  limitXY(logicRespawn.x, logicRespawn.y, game.level.width - 158, game.level.height - 158);
+  LimitXy(logic_respawn.x, logic_respawn.y, game.level.width - 158, game.level.height - 158);
 
-  int destX = ftoi(pos.x) - 80;
-  int destY = ftoi(pos.y) - 80;
-  limitXY(destX, destY, game.level.width - 158, game.level.height - 158);
+  int dest_x = Ftoi(pos.x) - 80;
+  int dest_y = Ftoi(pos.y) - 80;
+  LimitXy(dest_x, dest_y, game.level.width - 158, game.level.height - 158);
 
-  if (logicRespawn.x < destX + 5 && logicRespawn.x > destX - 5 && logicRespawn.y < destY + 5 &&
-      logicRespawn.y > destY - 5 && ready)  // Don't spawn in quicksim
+  if (logic_respawn.x < dest_x + 5 && logic_respawn.x > dest_x - 5 && logic_respawn.y < dest_y + 5 &&
+      logic_respawn.y > dest_y - 5 && ready)  // Don't spawn in quicksim
   {
-    auto ipos = ftoi(pos);
-    drawDirtEffect(common, game.rand, game.level, 0, ipos.x - 7, ipos.y - 7);
+    auto ipos = Ftoi(pos);
+    DrawDirtEffect(common, game.rand, game.level, 0, ipos.x - 7, ipos.y - 7);
     if (game.settings->shadow)
-      correctShadow(common, game.level, Rect(ipos.x - 10, ipos.y - 10, ipos.x + 11, ipos.y + 11));
+      CorrectShadow(common, game.level, Rect(ipos.x - 10, ipos.y - 10, ipos.x + 11, ipos.y + 11));
 
     ready = false;
-    game.soundPlayer->play(common.soundHook[SoundAlive]);
+    game.sound_player->Play(common.sound_hook[SoundAlive]);
 
     visible = true;
-    fireCone = 0;
-    vel.zero();
-    if (game.settings->gameMode != Settings::GMScalesOfJustice) health = settings->health;
+    fire_cone = 0;
+    vel.Zero();
+    if (game.settings->game_mode != Settings::kGmScalesOfJustice) health = settings->health;
 
     // NOTE: This was done at death before, but doing it here seems to make more sense
     if (game.rand() & 1) {
-      aimingAngle = itof(32);
+      aiming_angle = Itof(32);
       direction = 0;
     } else {
-      aimingAngle = itof(96);
+      aiming_angle = Itof(96);
       direction = 1;
     }
 
-    game.statsRecorder->afterSpawn(this);
+    game.stats_recorder->AfterSpawn(this);
   }
 }
 
-void Worm::processWeapons(Game& game) {
+void Worm::ProcessWeapons(Game& game) {
   Common& common = *game.common;
 
-  for (int i = 0; i < Settings::selectableWeapons; ++i) {
-    if (weapons[i].delayLeft >= 0) --weapons[i].delayLeft;
+  for (int i = 0; i < Settings::kSelectableWeapons; ++i) {
+    if (weapons[i].delay_left >= 0) --weapons[i].delay_left;
   }
 
-  WormWeapon& ww = weapons[currentWeapon];
+  WormWeapon& ww = weapons[current_weapon];
   Weapon const& w = *ww.type;
 
   if (ww.ammo <= 0) {
-    int computedLoadingTime = w.computedLoadingTime(*game.settings);
-    ww.loadingLeft = computedLoadingTime;
+    int computed_loading_time = w.ComputedLoadingTime(*game.settings);
+    ww.loading_left = computed_loading_time;
     ww.ammo = w.ammo;
   }
 
-  if (ww.loadingLeft > 0)  // NOTE: computedLoadingTime is never 0, so this works
+  if (ww.loading_left > 0)  // NOTE: computedLoadingTime is never 0, so this works
   {
-    --ww.loadingLeft;
-    if (ww.loadingLeft <= 0 && w.playReloadSound) {
-      game.soundPlayer->play(common.soundHook[SoundReloaded]);
+    --ww.loading_left;
+    if (ww.loading_left <= 0 && w.play_reload_sound) {
+      game.sound_player->Play(common.sound_hook[SoundReloaded]);
     }
   }
 
-  if (fireCone > 0) {
-    --fireCone;
+  if (fire_cone > 0) {
+    --fire_cone;
   }
 
-  if (leaveShellTimer > 0) {
-    if (--leaveShellTimer <= 0) {
-      auto velY = -int(game.rand(20000));
-      auto velX = game.rand(16000) - 8000;
-      common.nobjectTypes[7].create1(game, fixedvec(velX, velY), pos, 0, index, 0);
+  if (leave_shell_timer > 0) {
+    if (--leave_shell_timer <= 0) {
+      auto vel_y = -int(game.rand(20000));
+      auto vel_x = game.rand(16000) - 8000;
+      common.nobject_types[7].Create1(game, fixedvec(vel_x, vel_y), pos, 0, index, 0);
     }
   }
 }
 
-void Worm::processMovement(Game& game) {
+void Worm::ProcessMovement(Game& game) {
   Common& common = *game.common;
 
   if (movable) {
-    bool left = pressed(Left);
-    bool right = pressed(Right);
+    bool left = Pressed(kLeft);
+    bool right = Pressed(kRight);
 
     if (left && !right) {
       if (vel.x > LC(MaxVelLeft)) vel.x -= LC(WalkVelLeft);
 
       if (direction != 0) {
-        aimingSpeed = 0;
-        if (aimingAngle >= itof(64)) aimingAngle = itof(128) - aimingAngle;
+        aiming_speed = 0;
+        if (aiming_angle >= Itof(64)) aiming_angle = Itof(128) - aiming_angle;
         direction = 0;
       }
 
@@ -815,8 +815,8 @@ void Worm::processMovement(Game& game) {
       if (vel.x < LC(MaxVelRight)) vel.x += LC(WalkVelRight);
 
       if (direction != 1) {
-        aimingSpeed = 0;
-        if (aimingAngle <= itof(64)) aimingAngle = itof(128) - aimingAngle;
+        aiming_speed = 0;
+        if (aiming_angle <= Itof(64)) aiming_angle = Itof(128) - aiming_angle;
         direction = 1;
       }
 
@@ -824,12 +824,12 @@ void Worm::processMovement(Game& game) {
     }
 
     if (left && right) {
-      if (ableToDig) {
-        ableToDig = false;
+      if (able_to_dig) {
+        able_to_dig = false;
 
-        fixedvec dir(cossinTable[ftoi(aimingAngle)]);
+        fixedvec dir(cossin_table[Ftoi(aiming_angle)]);
 
-        auto digPos = dir * 2 + pos;
+        auto dig_pos = dir * 2 + pos;
 
         /* TODO
         long iDigx = ftoi(fTempx) - 4;
@@ -861,28 +861,28 @@ void Worm::processMovement(Game& game) {
         lev(iDigx, iDigy), 2, BYTE(w)); } // 419A } // 41A9 } // 41BB
 */
 
-        digPos.x -= itof(7);
-        digPos.y -= itof(7);
+        dig_pos.x -= Itof(7);
+        dig_pos.y -= Itof(7);
 
-        auto idigPos = ftoi(digPos);
-        drawDirtEffect(common, game.rand, game.level, 7, idigPos.x, idigPos.y);
+        auto idig_pos = Ftoi(dig_pos);
+        DrawDirtEffect(common, game.rand, game.level, 7, idig_pos.x, idig_pos.y);
         if (game.settings->shadow)
-          correctShadow(common, game.level,
-                        Rect(idigPos.x - 3, idigPos.y - 3, idigPos.x + 18, idigPos.y + 18));
+          CorrectShadow(common, game.level,
+                        Rect(idig_pos.x - 3, idig_pos.y - 3, idig_pos.x + 18, idig_pos.y + 18));
 
-        digPos += dir * 2;
+        dig_pos += dir * 2;
 
         // l_43EB:
-        idigPos = ftoi(digPos);
-        drawDirtEffect(common, game.rand, game.level, 7, idigPos.x, idigPos.y);
+        idig_pos = Ftoi(dig_pos);
+        DrawDirtEffect(common, game.rand, game.level, 7, idig_pos.x, idig_pos.y);
         if (game.settings->shadow)
-          correctShadow(common, game.level,
-                        Rect(idigPos.x - 3, idigPos.y - 3, idigPos.x + 18, idigPos.y + 18));
+          CorrectShadow(common, game.level,
+                        Rect(idig_pos.x - 3, idig_pos.y - 3, idig_pos.x + 18, idig_pos.y + 18));
 
         // NOTE! Maybe the shadow corrections can be joined into one? Mmm?
       }  // 4552
     } else {
-      ableToDig = true;
+      able_to_dig = true;
     }
 
     if (!left && !right) {
@@ -891,256 +891,256 @@ void Worm::processMovement(Game& game) {
   }
 }
 
-void Worm::processTasks(Game& game) {
+void Worm::ProcessTasks(Game& game) {
   Common& common = *game.common;
 
-  if (pressed(Change)) {
+  if (Pressed(kChange)) {
     if (ninjarope.out) {
-      if (pressed(Up)) ninjarope.length -= LC(NRPullVel);
-      if (pressed(Down)) ninjarope.length += LC(NRReleaseVel);
+      if (Pressed(kUp)) ninjarope.length -= LC(NRPullVel);
+      if (Pressed(kDown)) ninjarope.length += LC(NRReleaseVel);
 
       if (ninjarope.length < LC(NRMinLength)) ninjarope.length = LC(NRMinLength);
       if (ninjarope.length > LC(NRMaxLength)) ninjarope.length = LC(NRMaxLength);
     }
 
-    if (pressedOnce(Jump)) {
+    if (PressedOnce(kJump)) {
       ninjarope.out = true;
       ninjarope.attached = false;
 
-      game.soundPlayer->play(common.soundHook[SoundNinjaropeThrow]);
+      game.sound_player->Play(common.sound_hook[SoundNinjaropeThrow]);
 
       ninjarope.pos = pos;
-      ninjarope.vel = fixedvec(cossinTable[ftoi(aimingAngle)].x << LC(NRThrowVelX),
-                               cossinTable[ftoi(aimingAngle)].y << LC(NRThrowVelY));
+      ninjarope.vel = fixedvec(cossin_table[Ftoi(aiming_angle)].x << LC(NRThrowVelX),
+                               cossin_table[Ftoi(aiming_angle)].y << LC(NRThrowVelY));
 
       ninjarope.length = LC(NRInitialLength);
     }
   } else {
     // Jump = remove ninjarope, jump
-    if (pressed(Jump)) {
+    if (Pressed(kJump)) {
       ninjarope.out = false;
       ninjarope.attached = false;
 
-      if ((reacts[RFUp] > 0 || common.H[HAirJump]) && (ableToJump || common.H[HMultiJump])) {
+      if ((reacts[kRfUp] > 0 || common.h[HAirJump]) && (able_to_jump || common.h[HMultiJump])) {
         vel.y -= LC(JumpForce);
-        ableToJump = false;
+        able_to_jump = false;
       }
     } else
-      ableToJump = true;
+      able_to_jump = true;
   }
 }
 
-void Worm::processAiming(Game& game) {
+void Worm::ProcessAiming(Game& game) {
   Common& common = *game.common;
 
-  bool up = pressed(Up);
-  bool down = pressed(Down);
+  bool up = Pressed(kUp);
+  bool down = Pressed(kDown);
 
-  if (aimingSpeed != 0) {
-    aimingAngle += aimingSpeed;
+  if (aiming_speed != 0) {
+    aiming_angle += aiming_speed;
 
     if (!up && !down) {
-      aimingSpeed = (aimingSpeed * LC(AimFricMult)) / LC(AimFricDiv);
+      aiming_speed = (aiming_speed * LC(AimFricMult)) / LC(AimFricDiv);
     }
 
     if (direction == 1) {
-      if (ftoi(aimingAngle) > LC(AimMaxRight)) {
-        aimingSpeed = 0;
-        aimingAngle = itof(LC(AimMaxRight));
+      if (Ftoi(aiming_angle) > LC(AimMaxRight)) {
+        aiming_speed = 0;
+        aiming_angle = Itof(LC(AimMaxRight));
       }
-      if (ftoi(aimingAngle) < LC(AimMinRight)) {
-        aimingSpeed = 0;
-        aimingAngle = itof(LC(AimMinRight));
+      if (Ftoi(aiming_angle) < LC(AimMinRight)) {
+        aiming_speed = 0;
+        aiming_angle = Itof(LC(AimMinRight));
       }
     } else {
-      if (ftoi(aimingAngle) < LC(AimMaxLeft)) {
-        aimingSpeed = 0;
-        aimingAngle = itof(LC(AimMaxLeft));
+      if (Ftoi(aiming_angle) < LC(AimMaxLeft)) {
+        aiming_speed = 0;
+        aiming_angle = Itof(LC(AimMaxLeft));
       }
-      if (ftoi(aimingAngle) > LC(AimMinLeft)) {
-        aimingSpeed = 0;
-        aimingAngle = itof(LC(AimMinLeft));
+      if (Ftoi(aiming_angle) > LC(AimMinLeft)) {
+        aiming_speed = 0;
+        aiming_angle = Itof(LC(AimMinLeft));
       }
     }
   }
 
-  if (movable && (!ninjarope.out || !pressed(Change))) {
+  if (movable && (!ninjarope.out || !Pressed(kChange))) {
     if (up) {
       if (direction == 0) {
-        if (aimingSpeed < LC(MaxAimVelLeft)) aimingSpeed += LC(AimAccLeft);
+        if (aiming_speed < LC(MaxAimVelLeft)) aiming_speed += LC(AimAccLeft);
       } else {
-        if (aimingSpeed > LC(MaxAimVelRight)) aimingSpeed -= LC(AimAccRight);
+        if (aiming_speed > LC(MaxAimVelRight)) aiming_speed -= LC(AimAccRight);
       }
     }
 
     if (down) {
       if (direction == 1) {
-        if (aimingSpeed < LC(MaxAimVelLeft)) aimingSpeed += LC(AimAccLeft);
+        if (aiming_speed < LC(MaxAimVelLeft)) aiming_speed += LC(AimAccLeft);
       } else {
-        if (aimingSpeed > LC(MaxAimVelRight)) aimingSpeed -= LC(AimAccRight);
+        if (aiming_speed > LC(MaxAimVelRight)) aiming_speed -= LC(AimAccRight);
       }
     }
   }
 }
 
-void Worm::processWeaponChange(Game& game) {
-  if (!keyChangePressed) {
-    release(Left);
-    release(Right);
+void Worm::ProcessWeaponChange(Game& game) {
+  if (!key_change_pressed) {
+    Release(kLeft);
+    Release(kRight);
 
-    keyChangePressed = true;
+    key_change_pressed = true;
   }
 
-  fireCone = 0;
+  fire_cone = 0;
   animate = false;
 
-  if (weapons[currentWeapon].type->loopSound) {
-    game.soundPlayer->stop(&weapons[currentWeapon]);
+  if (weapons[current_weapon].type->loop_sound) {
+    game.sound_player->Stop(&weapons[current_weapon]);
   }
 
-  if (weapons[currentWeapon].available() || game.settings->loadChange) {
-    if (pressedOnce(Left)) {
-      if (--currentWeapon < 0) currentWeapon = Settings::selectableWeapons - 1;
+  if (weapons[current_weapon].Available() || game.settings->load_change) {
+    if (PressedOnce(kLeft)) {
+      if (--current_weapon < 0) current_weapon = Settings::kSelectableWeapons - 1;
 
-      hotspotX = ftoi(pos.x);
-      hotspotY = ftoi(pos.y);
+      hotspot_x = Ftoi(pos.x);
+      hotspot_y = Ftoi(pos.y);
     }
 
-    if (pressedOnce(Right)) {
-      if (++currentWeapon >= Settings::selectableWeapons) currentWeapon = 0;
+    if (PressedOnce(kRight)) {
+      if (++current_weapon >= Settings::kSelectableWeapons) current_weapon = 0;
 
-      hotspotX = ftoi(pos.x);
-      hotspotY = ftoi(pos.y);
+      hotspot_x = Ftoi(pos.x);
+      hotspot_y = Ftoi(pos.y);
     }
   }
 }
 
-void Worm::fire(Game& game) {
+void Worm::Fire(Game& game) {
   Common& common = *game.common;
-  WormWeapon& ww = weapons[currentWeapon];
+  WormWeapon& ww = weapons[current_weapon];
   Weapon const& w = *ww.type;
 
   --ww.ammo;
-  ww.delayLeft = w.delay;
+  ww.delay_left = w.delay;
 
-  fireCone = w.fireCone;
+  fire_cone = w.fire_cone;
 
-  fixedvec firing(cossinTable[ftoi(aimingAngle)] * (w.detectDistance + 5) + pos -
-                  fixedvec(0, itof(1)));
+  fixedvec firing(cossin_table[Ftoi(aiming_angle)] * (w.detect_distance + 5) + pos -
+                  fixedvec(0, Itof(1)));
 
-  if (w.leaveShells > 0) {
-    if (game.rand(w.leaveShells) == 0) {
-      leaveShellTimer = w.leaveShellDelay;
+  if (w.leave_shells > 0) {
+    if (game.rand(w.leave_shells) == 0) {
+      leave_shell_timer = w.leave_shell_delay;
     }
   }
 
-  if (w.loopSound) {
-    if (!game.soundPlayer->isPlaying(&weapons[currentWeapon])) {
-      game.soundPlayer->play(w.launchSound, &weapons[currentWeapon], -1);
+  if (w.loop_sound) {
+    if (!game.sound_player->IsPlaying(&weapons[current_weapon])) {
+      game.sound_player->Play(w.launch_sound, &weapons[current_weapon], -1);
     }
   } else {
-    game.soundPlayer->play(w.launchSound);
+    game.sound_player->Play(w.launch_sound);
   }
 
   int speed = w.speed;
-  fixedvec firingVel;
+  fixedvec firing_vel;
   int parts = w.parts;
 
-  if (w.affectByWorm) {
+  if (w.affect_by_worm) {
     if (speed < 100) speed = 100;
 
-    firingVel = vel * 100 / speed;
+    firing_vel = vel * 100 / speed;
   }
 
   for (int i = 0; i < parts; ++i) {
-    w.fire(game, ftoi(aimingAngle), firingVel, speed, firing, index, &ww);
+    w.Fire(game, Ftoi(aiming_angle), firing_vel, speed, firing, index, &ww);
   }
 
   int recoil = w.recoil;
 
-  if (common.H[HSignedRecoil] && recoil >= 128) recoil -= 256;
+  if (common.h[HSignedRecoil] && recoil >= 128) recoil -= 256;
 
-  vel -= cossinTable[ftoi(aimingAngle)] * recoil / 100;
+  vel -= cossin_table[Ftoi(aiming_angle)] * recoil / 100;
 }
 
-bool checkForWormHit(Game& game, int x, int y, int dist, Worm* ownWorm) {
+bool CheckForWormHit(Game& game, int x, int y, int dist, Worm* own_worm) {
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm& w = *game.worms[i];
 
-    if (&w != ownWorm) {
-      return checkForSpecWormHit(game, x, y, dist, w);
+    if (&w != own_worm) {
+      return CheckForSpecWormHit(game, x, y, dist, w);
     }
   }
 
   return false;
 }
 
-bool checkForSpecWormHit(Game& game, int x, int y, int dist, Worm& w) {
+bool CheckForSpecWormHit(Game& game, int x, int y, int dist, Worm& w) {
   Common& common = *game.common;
 
   if (!w.visible) return false;
 
-  PalIdx* wormSprite = common.wormSprite(w.currentFrame, w.direction, 0);
+  PalIdx* worm_sprite = common.WormSprite(w.current_frame, w.direction, 0);
 
-  int deltaX = x - ftoi(w.pos.x) + 7;
-  int deltaY = y - ftoi(w.pos.y) + 5;
+  int delta_x = x - Ftoi(w.pos.x) + 7;
+  int delta_y = y - Ftoi(w.pos.y) + 5;
 
-  Rect r(deltaX - dist, deltaY - dist, deltaX + dist + 1, deltaY + dist + 1);
+  Rect r(delta_x - dist, delta_y - dist, delta_x + dist + 1, delta_y + dist + 1);
 
-  r.intersect(Rect(0, 0, 16, 16));
+  r.Intersect(Rect(0, 0, 16, 16));
 
   for (int cy = r.y1; cy < r.y2; ++cy)
     for (int cx = r.x1; cx < r.x2; ++cx) {
       assert(cy * 16 + cx < 16 * 16);
-      if (common.materials[wormSprite[cy * 16 + cx]].worm()) return true;
+      if (common.materials[worm_sprite[cy * 16 + cx]].Worm()) return true;
     }
 
   return false;
 }
 
-void Worm::processSight(Game& game) {
+void Worm::ProcessSight(Game& game) {
   Common& common = *game.common;
 
-  WormWeapon& ww = weapons[currentWeapon];
+  WormWeapon& ww = weapons[current_weapon];
   Weapon const& w = *ww.type;
 
-  if (ww.available() && (w.laserSight || ww.type - &common.weapons[0] == LC(LaserWeapon) - 1)) {
-    fixedvec dir = cossinTable[ftoi(aimingAngle)];
-    fixedvec temp = fixedvec(pos.x + dir.x * 6, pos.y + dir.y * 6 - itof(1));
+  if (ww.Available() && (w.laser_sight || ww.type - &common.weapons[0] == LC(LaserWeapon) - 1)) {
+    fixedvec dir = cossin_table[Ftoi(aiming_angle)];
+    fixedvec temp = fixedvec(pos.x + dir.x * 6, pos.y + dir.y * 6 - Itof(1));
 
     do {
       temp += dir;
-      makeSightGreen = checkForWormHit(game, ftoi(temp.x), ftoi(temp.y), 0, this);
-    } while (temp.x >= 0 && temp.y >= 0 && temp.x < itof(game.level.width) &&
-             temp.y < itof(game.level.height) && game.level.mat(ftoi(temp)).background() &&
-             !makeSightGreen);
+      make_sight_green = CheckForWormHit(game, Ftoi(temp.x), Ftoi(temp.y), 0, this);
+    } while (temp.x >= 0 && temp.y >= 0 && temp.x < Itof(game.level.width) &&
+             temp.y < Itof(game.level.height) && game.level.Mat(Ftoi(temp)).Background() &&
+             !make_sight_green);
 
-    hotspotX = ftoi(temp.x);
-    hotspotY = ftoi(temp.y);
+    hotspot_x = Ftoi(temp.x);
+    hotspot_y = Ftoi(temp.y);
   } else
-    makeSightGreen = false;
+    make_sight_green = false;
 }
 
-void Worm::processSteerables(Game& game) {
-  steerableCount = 0;
-  steerableSumX = 0;
-  steerableSumY = 0;
+void Worm::ProcessSteerables(Game& game) {
+  steerable_count = 0;
+  steerable_sum_x = 0;
+  steerable_sum_y = 0;
 
-  WormWeapon& ww = weapons[currentWeapon];
-  if (ww.type->shotType == Weapon::STSteerable) {
-    auto wr = game.wobjects.all();
-    for (WObject* i; (i = wr.next());) {
-      if (i->type == ww.type && i->ownerIdx == index) {
-        if (pressed(Left)) i->curFrame -= (game.cycles & 1) + 1;
+  WormWeapon& ww = weapons[current_weapon];
+  if (ww.type->shot_type == Weapon::kStSteerable) {
+    auto wr = game.wobjects.All();
+    for (WObject* i; (i = wr.Next());) {
+      if (i->type == ww.type && i->owner_idx == index) {
+        if (Pressed(kLeft)) i->cur_frame -= (game.cycles & 1) + 1;
 
-        if (pressed(Right)) i->curFrame += (game.cycles & 1) + 1;
+        if (Pressed(kRight)) i->cur_frame += (game.cycles & 1) + 1;
 
-        i->curFrame &= 127;  // Wrap
+        i->cur_frame &= 127;  // Wrap
         movable = false;
 
-        steerableSumX += ftoi(i->pos.x);
-        steerableSumY += ftoi(i->pos.y);
-        ++steerableCount;
+        steerable_sum_x += Ftoi(i->pos.x);
+        steerable_sum_y += Ftoi(i->pos.y);
+        ++steerable_count;
       }
     }
   }

--- a/src/game/worm.hpp
+++ b/src/game/worm.hpp
@@ -42,7 +42,18 @@ struct WormWeapon {
 };
 
 struct WormSettingsExtensions {
-  enum Control { kUp, kDown, kLeft, kRight, kFire, kChange, kJump, kDig, kMaxControl = kDig, kMaxControlEx };
+  enum Control {
+    kUp,
+    kDown,
+    kLeft,
+    kRight,
+    kFire,
+    kChange,
+    kJump,
+    kDig,
+    kMaxControl = kDig,
+    kMaxControlEx
+  };
 
   // Input device: 0 = keyboard, 1 = gamepad 0, 2 = gamepad 1, etc.
   static int const kInputKeyboard = 0;
@@ -112,7 +123,8 @@ struct Renderer;
 struct WormAI {
   virtual void Process(Game& game, Worm& worm) = 0;
 
-  virtual void DrawDebug(Game& game, Worm const& worm, Renderer& renderer, int offs_x, int offs_y) {}
+  virtual void DrawDebug(Game& game, Worm const& worm, Renderer& renderer, int offs_x, int offs_y) {
+  }
 };
 
 struct DumbLieroAI : WormAI {
@@ -228,7 +240,9 @@ struct Worm {
 
   void SetControlState(Control control, bool state) { control_states.Set(control, state); }
 
-  void ToggleControlState(Control control) { control_states.Set(control, !control_states[control]); }
+  void ToggleControlState(Control control) {
+    control_states.Set(control, !control_states[control]);
+  }
 
   int MinimapColor() const { return 129 + index * 4; }
 
@@ -259,16 +273,16 @@ struct Worm {
   bool key_change_pressed;
   bool movable;
 
-  bool animate;         // Should the worm be animated?
-  bool visible;         // Is the worm visible?
-  bool ready;           // Is the worm ready to play?
-  bool flag;            // Does the worm have a flag?
+  bool animate;           // Should the worm be animated?
+  bool visible;           // Is the worm visible?
+  bool ready;             // Is the worm ready to play?
+  bool flag;              // Does the worm have a flag?
   bool make_sight_green;  // Changes the sight color
-  int health;           // Health left
-  int lives;            // lives left
-  int kills;            // Kills made
+  int health;             // Health left
+  int lives;              // lives left
+  int kills;              // Kills made
 
-  int timer;        // Timer for GOT
+  int timer;         // Timer for GOT
   int killed_timer;  // Time until worm respawns
   static constexpr int kKilledTimerInitial = 150;
   int current_frame;
@@ -277,10 +291,10 @@ struct Worm {
 
   Ninjarope ninjarope;
 
-  int current_weapon;    // The selected weapon
+  int current_weapon;      // The selected weapon
   int last_killed_by_idx;  // What worm that last killed this worm
-  int fire_cone;         // How much is left of the firecone
-  int leave_shell_timer;  // Time until next shell drop
+  int fire_cone;           // How much is left of the firecone
+  int leave_shell_timer;   // Time until next shell drop
 
   std::shared_ptr<WormSettings> settings;  // !CLONING
   int index;                               // 0 or 1
@@ -301,7 +315,7 @@ struct Worm {
 
   // Data for LocalController
   ControlState clean_control_states;  // This contains the real state of real and
-                                    // extended controls
+                                      // extended controls
 };
 
 bool CheckForWormHit(Game& game, int x, int y, int dist, Worm* own_worm);

--- a/src/game/worm.hpp
+++ b/src/game/worm.hpp
@@ -24,55 +24,55 @@ struct Ninjarope {
   Worm* anchor;       // If non-zero, the worm the ninjarope is attached to
   fixedvec pos, vel;  // Ninjarope props
   // Not needed as far as I can tell: fixed forceX, forceY;
-  int length, curLen;
+  int length, cur_len;
 
-  void process(Worm& owner, Game& game);
+  void Process(Worm& owner, Game& game);
 };
 
 struct WormWeapon {
-  WormWeapon() : ammo(0), delayLeft(0), loadingLeft(0) {}
+  WormWeapon() : ammo(0), delay_left(0), loading_left(0) {}
 
-  bool available() const { return loadingLeft == 0; }
+  bool Available() const { return loading_left == 0; }
 
   // int id;
   Weapon const* type;
   int ammo;
-  int delayLeft;
-  int loadingLeft;
+  int delay_left;
+  int loading_left;
 };
 
 struct WormSettingsExtensions {
-  enum Control { Up, Down, Left, Right, Fire, Change, Jump, Dig, MaxControl = Dig, MaxControlEx };
+  enum Control { kUp, kDown, kLeft, kRight, kFire, kChange, kJump, kDig, kMaxControl = kDig, kMaxControlEx };
 
   // Input device: 0 = keyboard, 1 = gamepad 0, 2 = gamepad 1, etc.
-  static int const InputKeyboard = 0;
+  static int const kInputKeyboard = 0;
 
   WormSettingsExtensions() {
-    std::memset(controlsEx, 0, sizeof(controlsEx));
-    std::memset(gamepadControls, 0, sizeof(gamepadControls));
-    inputDevice = InputKeyboard;
-    initDefaultGamepadControls();
+    std::memset(controls_ex, 0, sizeof(controls_ex));
+    std::memset(gamepad_controls, 0, sizeof(gamepad_controls));
+    input_device = kInputKeyboard;
+    InitDefaultGamepadControls();
   }
 
-  void initDefaultGamepadControls();
+  void InitDefaultGamepadControls();
 
-  uint32_t controlsEx[MaxControlEx];
+  uint32_t controls_ex[kMaxControlEx];
 
   // Gamepad binding: stores SDL_GamepadButton or encoded axis for each control
   // Encoding: 0-99 = SDL_GamepadButton, 100+axis*2 = axis positive, 101+axis*2 = axis negative
-  static uint32_t const GamepadAxisBase = 100;
-  static uint32_t gamepadAxisPositive(int axis) { return GamepadAxisBase + axis * 2; }
-  static uint32_t gamepadAxisNegative(int axis) { return GamepadAxisBase + axis * 2 + 1; }
-  static bool isGamepadAxis(uint32_t v) { return v >= GamepadAxisBase; }
+  static uint32_t const kGamepadAxisBase = 100;
+  static uint32_t GamepadAxisPositive(int axis) { return kGamepadAxisBase + axis * 2; }
+  static uint32_t GamepadAxisNegative(int axis) { return kGamepadAxisBase + axis * 2 + 1; }
+  static bool IsGamepadAxis(uint32_t v) { return v >= kGamepadAxisBase; }
 
-  uint32_t gamepadControls[MaxControlEx];
-  uint32_t inputDevice;
-  std::string gamepadName;    // Human-readable name (e.g., "Xbox Wireless Controller")
-  std::string gamepadSerial;  // Hardware serial for disambiguating identical controllers
+  uint32_t gamepad_controls[kMaxControlEx];
+  uint32_t input_device;
+  std::string gamepad_name;    // Human-readable name (e.g., "Xbox Wireless Controller")
+  std::string gamepad_serial;  // Hardware serial for disambiguating identical controllers
 };
 
 struct WormSettings : WormSettingsExtensions {
-  WormSettings() : health(100), controller(0), randomName(true), color(0) {
+  WormSettings() : health(100), controller(0), random_name(true), color(0) {
     rgb[0] = 26;
     rgb[1] = 26;
     rgb[2] = 62;
@@ -83,25 +83,25 @@ struct WormSettings : WormSettingsExtensions {
     std::memset(controls, 0, sizeof(controls));
   }
 
-  uint64_t& updateHash();
+  uint64_t& UpdateHash();
 
-  void saveProfile(FsNode node);
-  void loadProfile(FsNode node);
-  std::string toToml() const;
-  void fromToml(std::string const& data);
+  void SaveProfile(FsNode node);
+  void LoadProfile(FsNode node);
+  std::string ToToml() const;
+  void FromToml(std::string const& data);
 
   int health;
   uint32_t controller;  // CPU / Human
-  uint32_t controls[MaxControl];
+  uint32_t controls[kMaxControl];
   uint32_t weapons[NUM_WEAPONS];  // TODO: Adjustable
   std::string name;
   int rgb[3];
-  bool randomName;
+  bool random_name;
 
   int color;
 
   // std::string profilePath;
-  FsNode profileNode;
+  FsNode profile_node;
 
   uint64_t hash;
 };
@@ -110,29 +110,29 @@ struct Viewport;
 struct Renderer;
 
 struct WormAI {
-  virtual void process(Game& game, Worm& worm) = 0;
+  virtual void Process(Game& game, Worm& worm) = 0;
 
-  virtual void drawDebug(Game& game, Worm const& worm, Renderer& renderer, int offsX, int offsY) {}
+  virtual void DrawDebug(Game& game, Worm const& worm, Renderer& renderer, int offs_x, int offs_y) {}
 };
 
 struct DumbLieroAI : WormAI {
-  void process(Game& game, Worm& worm);
+  void Process(Game& game, Worm& worm);
 
   Rand rand;
 };
 
 struct Worm {
-  enum { RFDown, RFLeft, RFUp, RFRight };
+  enum { kRfDown, kRfLeft, kRfUp, kRfRight };
 
   enum Control {
-    Up = WormSettings::Up,
-    Down = WormSettings::Down,
-    Left = WormSettings::Left,
-    Right = WormSettings::Right,
-    Fire = WormSettings::Fire,
-    Change = WormSettings::Change,
-    Jump = WormSettings::Jump,
-    MaxControl
+    kUp = WormSettings::kUp,
+    kDown = WormSettings::kDown,
+    kLeft = WormSettings::kLeft,
+    kRight = WormSettings::kRight,
+    kFire = WormSettings::kFire,
+    kChange = WormSettings::kChange,
+    kJump = WormSettings::kJump,
+    kMaxControl
   };
 
   struct ControlState {
@@ -140,24 +140,24 @@ struct Worm {
 
     bool operator==(ControlState const& b) const { return istate == b.istate; }
 
-    uint32_t pack() const {
+    uint32_t Pack() const {
       return istate;  // & ((1 << MaxControl)-1);
     }
 
-    void unpack(uint32_t state) { istate = state & 0x7f; }
+    void Unpack(uint32_t state) { istate = state & 0x7f; }
 
     bool operator!=(ControlState const& b) const { return !operator==(b); }
 
     bool operator[](std::size_t n) const { return ((istate >> n) & 1) != 0; }
 
-    void set(std::size_t n, bool v) {
+    void Set(std::size_t n, bool v) {
       if (v)
         istate |= 1 << n;
       else
         istate &= ~(uint32_t(1u) << n);
     }
 
-    void toggle(std::size_t n) { istate ^= 1 << n; }
+    void Toggle(std::size_t n) { istate ^= 1 << n; }
 
     uint32_t istate;
   };
@@ -165,14 +165,14 @@ struct Worm {
   Worm()
       : pos(),
         vel(),
-        hotspotX(0),
-        hotspotY(0),
-        aimingAngle(0),
-        aimingSpeed(0),
-        ableToJump(false),
-        ableToDig(false)  // The previous state of some keys
+        hotspot_x(0),
+        hotspot_y(0),
+        aiming_angle(0),
+        aiming_speed(0),
+        able_to_jump(false),
+        able_to_dig(false)  // The previous state of some keys
         ,
-        keyChangePressed(false),
+        key_change_pressed(false),
         movable(false),
         animate(false)  // Should the worm be animated?
         ,
@@ -182,7 +182,7 @@ struct Worm {
         ,
         flag(false)  // Has the worm a flag?
         ,
-        makeSightGreen(false)  // Changes the sight color
+        make_sight_green(false)  // Changes the sight color
         ,
         health(0)  // Health left
         ,
@@ -192,95 +192,95 @@ struct Worm {
         ,
         timer(0)  // Timer for GOT
         ,
-        killedTimer(0)  // Time until worm respawns
+        killed_timer(0)  // Time until worm respawns
         ,
-        currentFrame(0),
+        current_frame(0),
         flags(0)  // How many flags does this worm have?
         ,
-        currentWeapon(0),
-        lastKilledByIdx(-1),
-        fireCone(0),
-        leaveShellTimer(0),
+        current_weapon(0),
+        last_killed_by_idx(-1),
+        fire_cone(0),
+        leave_shell_timer(0),
         index(0),
         direction(0),
-        steerableCount(0),
-        statsX(0) {
-    makeSightGreen = false;
+        steerable_count(0),
+        stats_x(0) {
+    make_sight_green = false;
 
     ready = true;
     movable = true;
 
     visible = false;
-    killedTimer = KilledTimerInitial;
+    killed_timer = kKilledTimerInitial;
   }
 
-  bool pressed(Control control) const { return controlStates[control]; }
+  bool Pressed(Control control) const { return control_states[control]; }
 
-  bool pressedOnce(Control control) {
-    bool state = controlStates[control];
-    controlStates.set(control, false);
+  bool PressedOnce(Control control) {
+    bool state = control_states[control];
+    control_states.Set(control, false);
     return state;
   }
 
-  void release(Control control) { controlStates.set(control, false); }
+  void Release(Control control) { control_states.Set(control, false); }
 
-  void press(Control control) { controlStates.set(control, true); }
+  void Press(Control control) { control_states.Set(control, true); }
 
-  void setControlState(Control control, bool state) { controlStates.set(control, state); }
+  void SetControlState(Control control, bool state) { control_states.Set(control, state); }
 
-  void toggleControlState(Control control) { controlStates.set(control, !controlStates[control]); }
+  void ToggleControlState(Control control) { control_states.Set(control, !control_states[control]); }
 
-  int minimapColor() const { return 129 + index * 4; }
+  int MinimapColor() const { return 129 + index * 4; }
 
-  void beginRespawn(Game& game);
-  void doRespawning(Game& game);
-  void process(Game& game);
-  void processWeapons(Game& game);
-  void processPhysics(Game& game);
-  void processMovement(Game& game);
-  void processTasks(Game& game);
-  void processAiming(Game& game);
-  void processWeaponChange(Game& game);
-  void processSteerables(Game& game);
-  void fire(Game& game);
-  void processSight(Game& game);
-  void calculateReactionForce(Game& game, int newX, int newY, int dir);
-  void initWeapons(Game& game);
-  int angleFrame() const;
+  void BeginRespawn(Game& game);
+  void DoRespawning(Game& game);
+  void Process(Game& game);
+  void ProcessWeapons(Game& game);
+  void ProcessPhysics(Game& game);
+  void ProcessMovement(Game& game);
+  void ProcessTasks(Game& game);
+  void ProcessAiming(Game& game);
+  void ProcessWeaponChange(Game& game);
+  void ProcessSteerables(Game& game);
+  void Fire(Game& game);
+  void ProcessSight(Game& game);
+  void CalculateReactionForce(Game& game, int new_x, int new_y, int dir);
+  void InitWeapons(Game& game);
+  int AngleFrame() const;
 
   fixedvec pos, vel;
 
-  IVec2 logicRespawn;
+  IVec2 logic_respawn;
 
-  int hotspotX, hotspotY;  // Hotspots for laser, laser sight, etc.
-  fixed aimingAngle, aimingSpeed;
+  int hotspot_x, hotspot_y;  // Hotspots for laser, laser sight, etc.
+  fixed aiming_angle, aiming_speed;
 
-  bool ableToJump, ableToDig;  // The previous state of some keys
-  bool keyChangePressed;
+  bool able_to_jump, able_to_dig;  // The previous state of some keys
+  bool key_change_pressed;
   bool movable;
 
   bool animate;         // Should the worm be animated?
   bool visible;         // Is the worm visible?
   bool ready;           // Is the worm ready to play?
   bool flag;            // Does the worm have a flag?
-  bool makeSightGreen;  // Changes the sight color
+  bool make_sight_green;  // Changes the sight color
   int health;           // Health left
   int lives;            // lives left
   int kills;            // Kills made
 
   int timer;        // Timer for GOT
-  int killedTimer;  // Time until worm respawns
-  static constexpr int KilledTimerInitial = 150;
-  int currentFrame;
+  int killed_timer;  // Time until worm respawns
+  static constexpr int kKilledTimerInitial = 150;
+  int current_frame;
 
   int flags;  // How many flags does this worm have?
 
   Ninjarope ninjarope;
 
-  int currentWeapon;    // The selected weapon
-  int lastKilledByIdx;  // What worm that last killed this worm
-  int fireCone;         // How much is left of the firecone
-  int leaveShellTimer;  // Time until next shell drop
+  int current_weapon;    // The selected weapon
+  int last_killed_by_idx;  // What worm that last killed this worm
+  int fire_cone;         // How much is left of the firecone
+  int leave_shell_timer;  // Time until next shell drop
 
   std::shared_ptr<WormSettings> settings;  // !CLONING
   int index;                               // 0 or 1
@@ -290,20 +290,20 @@ struct Worm {
   int reacts[4];
   WormWeapon weapons[NUM_WEAPONS];
   int direction;
-  ControlState controlStates;
-  ControlState prevControlStates;
+  ControlState control_states;
+  ControlState prev_control_states;
 
   // Temporary state for steerables
-  int steerableSumX, steerableSumY, steerableCount;
+  int steerable_sum_x, steerable_sum_y, steerable_count;
 
   // which X coordinate to display stats at for this worm
-  int statsX;
+  int stats_x;
 
   // Data for LocalController
-  ControlState cleanControlStates;  // This contains the real state of real and
+  ControlState clean_control_states;  // This contains the real state of real and
                                     // extended controls
 };
 
-bool checkForWormHit(Game& game, int x, int y, int dist, Worm* ownWorm);
-bool checkForSpecWormHit(Game& game, int x, int y, int dist, Worm& w);
-int sqrVectorLength(int x, int y);
+bool CheckForWormHit(Game& game, int x, int y, int dist, Worm* own_worm);
+bool CheckForSpecWormHit(Game& game, int x, int y, int dist, Worm& w);
+int SqrVectorLength(int x, int y);

--- a/src/tc_tool/common_exereader.cpp
+++ b/src/tc_tool/common_exereader.cpp
@@ -7,12 +7,12 @@
 #include "game/rand.hpp"
 #include "game/reader.hpp"
 
-int CSint32desc[][3] = {{CNRInitialLength, 0x32D7, 0x32DD},
+int c_sint32desc[][3] = {{CNRInitialLength, 0x32D7, 0x32DD},
                         {CNRAttachLength, 0xA679, 0xA67F},
 
                         {0, -1, -1}};
 
-int CSint24desc[][3] = {{CMinBounceUp, 0x3B7D, 0x3B74},
+int c_sint24desc[][3] = {{CMinBounceUp, 0x3B7D, 0x3B74},
                         {CMinBounceDown, 0x3B00, 0x3AF7},
                         {CMinBounceLeft, 0x3A83, 0x3A7A},
                         {CMinBounceRight, 0x3A06, 0x39FD},
@@ -38,11 +38,11 @@ int CSint24desc[][3] = {{CMinBounceUp, 0x3B7D, 0x3B74},
 
                         {0, -1, -1}};
 
-int CUint16desc[][2] = {{CBloodLimit, 0xE686},
+int c_uint16desc[][2] = {{CBloodLimit, 0xE686},
 
                         {0, -1}};
 
-int CSint16desc[][2] = {
+int c_sint16desc[][2] = {
     {CWormFricMult, 0x39BD},
     {CWormFricDiv, 0x39C7},
     {CWormMinSpawnDistLast, 0x242E},
@@ -81,7 +81,7 @@ int CSint16desc[][2] = {
 
     {0, -1}};
 
-int CUint8desc[][2] = {{CAimMaxRight, 0x3030},
+int c_uint8desc[][2] = {{CAimMaxRight, 0x3030},
                        {CAimMinRight, 0x304A},
                        {CAimMaxLeft, 0x3066},
                        {CAimMinLeft, 0x3080},
@@ -99,7 +99,7 @@ int CUint8desc[][2] = {{CAimMaxRight, 0x3030},
 
                        {0, -1}};
 
-int CSint8desc[][2] = {{CNRPullVel, 0x31D0},
+int c_sint8desc[][2] = {{CNRPullVel, 0x31D0},
                        {CNRReleaseVel, 0x31F0},
 
                        // FallDamage hack
@@ -113,7 +113,7 @@ int CSint8desc[][2] = {{CNRPullVel, 0x31D0},
 
                        {0, -1}};
 
-int Sstringdesc[][2] = {{SInitSound, 0x177F},
+int sstringdesc[][2] = {{SInitSound, 0x177F},
                         {SLoadingSounds, 0x18F2},
 
                         {SInit_BaseIO, 0x17DD},
@@ -169,69 +169,69 @@ struct HackDesc {
   int (*indicators)[2];
 };
 
-int hFallDamageInd[][2] = {{0x3A0A, 0x26},
+int h_fall_damage_ind[][2] = {{0x3A0A, 0x26},
                            {0x3A87, 0x26},
                            {0x3B04, 0x26},
                            {0x3B81, 0x26},
 
                            {-1, 0}};
 
-int hBonusReloadOnlyInd[][2] = {
+int h_bonus_reload_only_ind[][2] = {
     {0x2DB1, 0xEB},  // We check one byte only, because ProMode has a silly jump destination
 
     {-1, 0}};
 
-int hBonusSpawnRectInd[][2] = {
+int h_bonus_spawn_rect_ind[][2] = {
     {0x2318, 0x05},  // These are the first bytes of the add instructions that offset the spawn
     {0x2323, 0x05},
 
     {-1, 0}};
 
-int hBonusOnlyHealthInd[][2] = {{0x228B, 0xB0},
+int h_bonus_only_health_ind[][2] = {{0x228B, 0xB0},
                                 {0x228C, 0x02},
 
                                 {-1, 0}};
 
-int hBonusOnlyWeaponInd[][2] = {{0x228B, 0xB0},
+int h_bonus_only_weapon_ind[][2] = {{0x228B, 0xB0},
                                 {0x228C, 0x01},
 
                                 {-1, 0}};
 
-int hBonusDisableInd[][2] = {{0xBED3, 0xEB},
+int h_bonus_disable_ind[][2] = {{0xBED3, 0xEB},
 
                              {-1, 0}};
 
-int hWormFloatInd[][2] = {{0x29D7, 0x26},  // 0x26 is the first byte of the sub instruction
+int h_worm_float_ind[][2] = {{0x29D7, 0x26},  // 0x26 is the first byte of the sub instruction
                           {0x29DA, 0x34},  // 0x34 is the offset to part of velY of the worm
 
                           {-1, 0}};
 
-int hRemExpInd[][2] = {
+int h_rem_exp_ind[][2] = {
     // Start of the mov instruction that zeroes the timeout counter
     {0x8fc9, 0x26},
     {0x8fca, 0xc7},
     {-1, 0}};
 
-int hSignedRecoilInd[][2] = {{0x38AC, 0x98}, {0x38EC, 0x98}, {-1, 0}};
+int h_signed_recoil_ind[][2] = {{0x38AC, 0x98}, {0x38EC, 0x98}, {-1, 0}};
 
-int hAirJumpInd[][2] = {{0x3313, 0xEB}, {0x3314, 0x06}, {-1, 0}};
+int h_air_jump_ind[][2] = {{0x3313, 0xEB}, {0x3314, 0x06}, {-1, 0}};
 
-int hMultiJumpInd[][2] = {{0x331B, 0xEB}, {0x331C, 0x06}, {-1, 0}};
+int h_multi_jump_ind[][2] = {{0x331B, 0xEB}, {0x331C, 0x06}, {-1, 0}};
 
-HackDesc Hhackdesc[] = {{HFallDamage, hFallDamageInd},
-                        {HBonusReloadOnly, hBonusReloadOnlyInd},
-                        {HBonusSpawnRect, hBonusSpawnRectInd},
-                        {HWormFloat, hWormFloatInd},
-                        {HBonusOnlyHealth, hBonusOnlyHealthInd},
-                        {HBonusOnlyWeapon, hBonusOnlyWeaponInd},
-                        {HBonusDisable, hBonusDisableInd},
-                        {HRemExp, hRemExpInd},
-                        {HSignedRecoil, hSignedRecoilInd},
-                        {HAirJump, hAirJumpInd},
-                        {HMultiJump, hMultiJumpInd},
+HackDesc hhackdesc[] = {{HFallDamage, h_fall_damage_ind},
+                        {HBonusReloadOnly, h_bonus_reload_only_ind},
+                        {HBonusSpawnRect, h_bonus_spawn_rect_ind},
+                        {HWormFloat, h_worm_float_ind},
+                        {HBonusOnlyHealth, h_bonus_only_health_ind},
+                        {HBonusOnlyWeapon, h_bonus_only_weapon_ind},
+                        {HBonusDisable, h_bonus_disable_ind},
+                        {HRemExp, h_rem_exp_ind},
+                        {HSignedRecoil, h_signed_recoil_ind},
+                        {HAirJump, h_air_jump_ind},
+                        {HMultiJump, h_multi_jump_ind},
                         {0, 0}};
 
-char const* sobjectNames[14] = {"Large explosion",
+char const* sobject_names[14] = {"Large explosion",
                                 "Medium explosion",
                                 "Small explosion",
                                 "Hellraider smoke",
@@ -246,7 +246,7 @@ char const* sobjectNames[14] = {"Large explosion",
                                 "Medium explosion, bigger",
                                 "Unknown"};
 
-char const* nobjectNames[24] = {"Worm 1 parts",
+char const* nobject_names[24] = {"Worm 1 parts",
                                 "Worm 2 parts",
                                 "Particle, disappearing",
                                 "Particle, small damage",
@@ -271,7 +271,7 @@ char const* nobjectNames[24] = {"Worm 1 parts",
                                 "Grasshopper 6",
                                 "Grasshopper 7"};
 
-std::string toId(std::string const& name) {
+std::string ToId(std::string const& name) {
   std::string ret;
   for (char c : name) {
     if ((uint8_t)c >= 128 || !std::isalnum((uint8_t)c))
@@ -282,107 +282,107 @@ std::string toId(std::string const& name) {
   return ret;
 }
 
-inline std::string readPascalString(ReaderFile& f) {
-  unsigned char length = f.get();
+inline std::string ReadPascalString(ReaderFile& f) {
+  unsigned char length = f.Get();
 
   char txt[256];
-  f.get(reinterpret_cast<uint8_t*>(txt), length);
+  f.Get(reinterpret_cast<uint8_t*>(txt), length);
   return std::string(txt, length);
 }
 
-inline std::string readPascalString(ReaderFile& f, unsigned char fieldLen) {
+inline std::string ReadPascalString(ReaderFile& f, unsigned char field_len) {
   char txt[256];
-  f.get(reinterpret_cast<uint8_t*>(txt), fieldLen);
+  f.Get(reinterpret_cast<uint8_t*>(txt), field_len);
 
   unsigned char length = static_cast<unsigned char>(txt[0]);
   return std::string(txt + 1, length);
 }
 
-inline std::string readPascalStringAt(ReaderFile& f, size_t location) {
-  f.seekg(location);
-  return readPascalString(f);
+inline std::string ReadPascalStringAt(ReaderFile& f, size_t location) {
+  f.Seekg(location);
+  return ReadPascalString(f);
 }
 
-void loadConstants(Common& common, ReaderFile& exe) {
-  for (int i = 0; CSint32desc[i][1] >= 0; ++i) {
-    exe.seekg(CSint32desc[i][1]);
-    int32_t a = (int32_t)io::read_uint16_le(exe);
-    exe.seekg(CSint32desc[i][2]);
-    int32_t b = (int16_t)io::read_uint16_le(exe);
-    common.C[CSint32desc[i][0]] = a + (b << 16);
+void LoadConstants(Common& common, ReaderFile& exe) {
+  for (int i = 0; c_sint32desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_sint32desc[i][1]);
+    int32_t a = (int32_t)io::ReadUint16Le(exe);
+    exe.Seekg(c_sint32desc[i][2]);
+    int32_t b = (int16_t)io::ReadUint16Le(exe);
+    common.c[c_sint32desc[i][0]] = a + (b << 16);
   }
 
-  for (int i = 0; CSint24desc[i][1] >= 0; ++i) {
-    exe.seekg(CSint24desc[i][1]);
-    int32_t a = (int32_t)io::read_uint16_le(exe);
-    exe.seekg(CSint24desc[i][2]);
-    int32_t b = (int8_t)exe.get();
-    common.C[CSint24desc[i][0]] = a + (b << 16);
+  for (int i = 0; c_sint24desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_sint24desc[i][1]);
+    int32_t a = (int32_t)io::ReadUint16Le(exe);
+    exe.Seekg(c_sint24desc[i][2]);
+    int32_t b = (int8_t)exe.Get();
+    common.c[c_sint24desc[i][0]] = a + (b << 16);
   }
 
-  for (int i = 0; CSint16desc[i][1] >= 0; ++i) {
-    exe.seekg(CSint16desc[i][1]);
-    common.C[CSint16desc[i][0]] = (int16_t)io::read_uint16_le(exe);
+  for (int i = 0; c_sint16desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_sint16desc[i][1]);
+    common.c[c_sint16desc[i][0]] = (int16_t)io::ReadUint16Le(exe);
   }
 
-  for (int i = 0; CUint16desc[i][1] >= 0; ++i) {
-    exe.seekg(CUint16desc[i][1]);
-    common.C[CUint16desc[i][0]] = io::read_uint16_le(exe);
+  for (int i = 0; c_uint16desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_uint16desc[i][1]);
+    common.c[c_uint16desc[i][0]] = io::ReadUint16Le(exe);
   }
 
-  for (int i = 0; CSint8desc[i][1] >= 0; ++i) {
-    exe.seekg(CSint8desc[i][1]);
-    common.C[CSint8desc[i][0]] = (int8_t)exe.get();
+  for (int i = 0; c_sint8desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_sint8desc[i][1]);
+    common.c[c_sint8desc[i][0]] = (int8_t)exe.Get();
   }
 
-  for (int i = 0; CUint8desc[i][1] >= 0; ++i) {
-    exe.seekg(CUint8desc[i][1]);
-    common.C[CUint8desc[i][0]] = exe.get();
+  for (int i = 0; c_uint8desc[i][1] >= 0; ++i) {
+    exe.Seekg(c_uint8desc[i][1]);
+    common.c[c_uint8desc[i][0]] = exe.Get();
   }
 
-  for (int i = 0; Sstringdesc[i][1] >= 0; ++i) {
+  for (int i = 0; sstringdesc[i][1] >= 0; ++i) {
     // Strings in the EXE are CP437 (DOS Liero); tc.cfg stores UTF-8.
-    common.S[Sstringdesc[i][0]] =
-        cp437::cp437BytesToUtf8(readPascalStringAt(exe, Sstringdesc[i][1]));
+    common.s[sstringdesc[i][0]] =
+        cp437::Cp437BytesToUtf8(ReadPascalStringAt(exe, sstringdesc[i][1]));
   }
 
-  for (int i = 0; Hhackdesc[i].indicators; ++i) {
-    int (*ind)[2] = Hhackdesc[i].indicators;
+  for (int i = 0; hhackdesc[i].indicators; ++i) {
+    int (*ind)[2] = hhackdesc[i].indicators;
     bool active = true;
     for (; (*ind)[0] >= 0; ++ind) {
-      exe.seekg((*ind)[0]);
-      int b = exe.get();
+      exe.Seekg((*ind)[0]);
+      int b = exe.Get();
       if (b != (*ind)[1]) {
         active = false;
         break;
       }
     }
 
-    common.H[Hhackdesc[i].which] = active;
+    common.h[hhackdesc[i].which] = active;
   }
 }
 
-void loadPalette(Common& common, ReaderFile& exe) {
-  exe.seekg(132774);
+void LoadPalette(Common& common, ReaderFile& exe) {
+  exe.Seekg(132774);
 
   for (int i = 0; i < 256; ++i) {
     unsigned char rgb[3];
-    exe.get(reinterpret_cast<uint8_t*>(rgb), 3);
+    exe.Get(reinterpret_cast<uint8_t*>(rgb), 3);
 
     common.exepal.entries[i].r = rgb[0] & 63;
     common.exepal.entries[i].g = rgb[1] & 63;
     common.exepal.entries[i].b = rgb[2] & 63;
   }
 
-  exe.seekg(0x1AF0C);
+  exe.Seekg(0x1AF0C);
   for (int i = 0; i < 4; ++i) {
-    common.colorAnim[i].from = exe.get();
-    common.colorAnim[i].to = exe.get();
+    common.color_anim[i].from = exe.Get();
+    common.color_anim[i].to = exe.Get();
   }
 }
 
-void loadMaterials(Common& common, ReaderFile& exe) {
-  exe.seekg(0x01C2E0);
+void LoadMaterials(Common& common, ReaderFile& exe) {
+  exe.Seekg(0x01C2E0);
 
   for (int i = 0; i < 256; ++i) {
     common.materials[i].flags = 0;
@@ -391,7 +391,7 @@ void loadMaterials(Common& common, ReaderFile& exe) {
   unsigned char bits[32];
 
   for (int i = 0; i < 5; ++i) {
-    exe.get(reinterpret_cast<uint8_t*>(bits), 32);
+    exe.Get(reinterpret_cast<uint8_t*>(bits), 32);
 
     for (int j = 0; j < 256; ++j) {
       int bit = ((bits[j >> 3] >> (j & 7)) & 1);
@@ -399,9 +399,9 @@ void loadMaterials(Common& common, ReaderFile& exe) {
     }
   }
 
-  exe.seekg(0x01AEA8);
+  exe.Seekg(0x01AEA8);
 
-  exe.get(reinterpret_cast<uint8_t*>(bits), 32);
+  exe.Get(reinterpret_cast<uint8_t*>(bits), 32);
 
   for (int j = 0; j < 256; ++j) {
     int bit = ((bits[j >> 3] >> (j & 7)) & 1);
@@ -410,208 +410,208 @@ void loadMaterials(Common& common, ReaderFile& exe) {
 }
 
 struct Read32 {
-  static inline int32_t run(ReaderFile& f) { return (int32_t)io::read_uint32_le(f); }
+  static inline int32_t Run(ReaderFile& f) { return (int32_t)io::ReadUint32Le(f); }
 };
 
 struct Read16 {
-  static inline int32_t run(ReaderFile& f) { return (int32_t)(int16_t)io::read_uint16_le(f); }
+  static inline int32_t Run(ReaderFile& f) { return (int32_t)(int16_t)io::ReadUint16Le(f); }
 };
 
 struct Read8 {
-  static inline int32_t run(ReaderFile& f) { return f.get(); }
+  static inline int32_t Run(ReaderFile& f) { return f.Get(); }
 };
 
 struct ReadBool {
-  static inline bool run(ReaderFile& f) { return f.get() != 0; }
+  static inline bool Run(ReaderFile& f) { return f.Get() != 0; }
 };
 
 template <typename T>
 struct Dec {
-  static inline int32_t run(ReaderFile& f) { return T::run(f) - 1; }
+  static inline int32_t Run(ReaderFile& f) { return T::Run(f) - 1; }
 };
 
 template <typename Reader, typename T, int N, typename U>
-inline void readMembers(ReaderFile& f, T (&arr)[N], U(T::* mem)) {
+inline void ReadMembers(ReaderFile& f, T (&arr)[N], U(T::* mem)) {
   for (int i = 0; i < N; ++i) {
-    (arr[i].*mem) = Reader::run(f);
+    (arr[i].*mem) = Reader::Run(f);
   }
 }
 
 template <typename Reader, typename T, typename U>
-inline void readMembers(ReaderFile& f, std::vector<T>& arr, U(T::* mem)) {
+inline void ReadMembers(ReaderFile& f, std::vector<T>& arr, U(T::* mem)) {
   for (int i = 0; i < arr.size(); ++i) {
-    (arr[i].*mem) = Reader::run(f);
+    (arr[i].*mem) = Reader::Run(f);
   }
 }
 
-void loadWeapons(Common& common, ReaderFile& exe) {
-  exe.seekg(112806);
+void LoadWeapons(Common& common, ReaderFile& exe) {
+  exe.Seekg(112806);
 
-  readMembers<Read8>(exe, common.weapons, &Weapon::detectDistance);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::affectByWorm);
-  readMembers<Read8>(exe, common.weapons, &Weapon::blowAway);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::detect_distance);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::affect_by_worm);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::blow_away);
 
-  exe.seekg(112966);
-  readMembers<Read16>(exe, common.weapons, &Weapon::gravity);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::shadow);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::laserSight);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::launchSound);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::loopSound);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::exploSound);
-  readMembers<Read16>(exe, common.weapons, &Weapon::speed);
-  readMembers<Read16>(exe, common.weapons, &Weapon::addSpeed);
-  readMembers<Read16>(exe, common.weapons, &Weapon::distribution);
-  readMembers<Read8>(exe, common.weapons, &Weapon::parts);
-  readMembers<Read8>(exe, common.weapons, &Weapon::recoil);
-  readMembers<Read16>(exe, common.weapons, &Weapon::multSpeed);
-  readMembers<Read16>(exe, common.weapons, &Weapon::delay);
-  readMembers<Read16>(exe, common.weapons, &Weapon::loadingTime);
-  readMembers<Read8>(exe, common.weapons, &Weapon::ammo);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::createOnExp);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::dirtEffect);
-  readMembers<Read8>(exe, common.weapons, &Weapon::leaveShells);
-  readMembers<Read8>(exe, common.weapons, &Weapon::leaveShellDelay);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::playReloadSound);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::wormExplode);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::explGround);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::wormCollide);
-  readMembers<Read8>(exe, common.weapons, &Weapon::fireCone);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::collideWithObjects);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::affectByExplosions);
-  readMembers<Read8>(exe, common.weapons, &Weapon::bounce);
-  readMembers<Read16>(exe, common.weapons, &Weapon::timeToExplo);
-  readMembers<Read16>(exe, common.weapons, &Weapon::timeToExploV);
-  readMembers<Read8>(exe, common.weapons, &Weapon::hitDamage);
-  readMembers<Read8>(exe, common.weapons, &Weapon::bloodOnHit);
-  readMembers<Read16>(exe, common.weapons, &Weapon::startFrame);
-  readMembers<Read8>(exe, common.weapons, &Weapon::numFrames);
-  readMembers<ReadBool>(exe, common.weapons, &Weapon::loopAnim);
-  readMembers<Read8>(exe, common.weapons, &Weapon::shotType);
-  readMembers<Read8>(exe, common.weapons, &Weapon::colorBullets);
-  readMembers<Read8>(exe, common.weapons, &Weapon::splinterAmount);
-  readMembers<Read8>(exe, common.weapons, &Weapon::splinterColour);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::splinterType);
-  readMembers<Read8>(exe, common.weapons, &Weapon::splinterScatter);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::objTrailType);
-  readMembers<Read8>(exe, common.weapons, &Weapon::objTrailDelay);
-  readMembers<Read8>(exe, common.weapons, &Weapon::partTrailType);
-  readMembers<Dec<Read8> >(exe, common.weapons, &Weapon::partTrailObj);
-  readMembers<Read8>(exe, common.weapons, &Weapon::partTrailDelay);
+  exe.Seekg(112966);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::gravity);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::shadow);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::laser_sight);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::launch_sound);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::loop_sound);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::explo_sound);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::speed);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::add_speed);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::distribution);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::parts);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::recoil);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::mult_speed);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::delay);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::loading_time);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::ammo);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::create_on_exp);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::dirt_effect);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::leave_shells);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::leave_shell_delay);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::play_reload_sound);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::worm_explode);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::expl_ground);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::worm_collide);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::fire_cone);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::collide_with_objects);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::affect_by_explosions);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::bounce);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::time_to_explo);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::time_to_explo_v);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::hit_damage);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::blood_on_hit);
+  ReadMembers<Read16>(exe, common.weapons, &Weapon::start_frame);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::num_frames);
+  ReadMembers<ReadBool>(exe, common.weapons, &Weapon::loop_anim);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::shot_type);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::color_bullets);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::splinter_amount);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::splinter_colour);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::splinter_type);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::splinter_scatter);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::obj_trail_type);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::obj_trail_delay);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::part_trail_type);
+  ReadMembers<Dec<Read8> >(exe, common.weapons, &Weapon::part_trail_obj);
+  ReadMembers<Read8>(exe, common.weapons, &Weapon::part_trail_delay);
 
-  exe.seekg(0x1B676);
+  exe.Seekg(0x1B676);
   for (int i = 0; i < 40; ++i) {
     // Read CP437 bytes from the EXE; derive idStr from those (toId() lowercases
     // ASCII and replaces everything else with '_', so single-byte input keeps
     // the id length predictable), then transcode the displayable name to UTF-8.
-    std::string raw = readPascalString(exe, 14);
-    common.weapons[i].idStr = toId(raw);
-    common.weapons[i].name = cp437::cp437BytesToUtf8(raw);
+    std::string raw = ReadPascalString(exe, 14);
+    common.weapons[i].id_str = ToId(raw);
+    common.weapons[i].name = cp437::Cp437BytesToUtf8(raw);
     common.weapons[i].id = i;
-    common.weapons[i].chainExplosion = i == 34;
+    common.weapons[i].chain_explosion = i == 34;
   }
 
   // Special objects
-  exe.seekg(115218);
-  readMembers<Dec<Read8> >(exe, common.sobjectTypes, &SObjectType::startSound);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::numSounds);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::animDelay);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::startFrame);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::numFrames);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::detectRange);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::damage);
-  readMembers<Read32>(exe, common.sobjectTypes,
-                      &SObjectType::blowAway);  // blowAway has 13 slots, not 14. The last value
+  exe.Seekg(115218);
+  ReadMembers<Dec<Read8> >(exe, common.sobject_types, &SObjectType::start_sound);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::num_sounds);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::anim_delay);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::start_frame);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::num_frames);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::detect_range);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::damage);
+  ReadMembers<Read32>(exe, common.sobject_types,
+                      &SObjectType::blow_away);  // blowAway has 13 slots, not 14. The last value
                                                 // will overlap with shadow.
 
-  exe.seekg(115368);
-  readMembers<ReadBool>(exe, common.sobjectTypes, &SObjectType::shadow);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::shake);
-  readMembers<Read8>(exe, common.sobjectTypes, &SObjectType::flash);
-  readMembers<Dec<Read8> >(exe, common.sobjectTypes, &SObjectType::dirtEffect);
+  exe.Seekg(115368);
+  ReadMembers<ReadBool>(exe, common.sobject_types, &SObjectType::shadow);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::shake);
+  ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::flash);
+  ReadMembers<Dec<Read8> >(exe, common.sobject_types, &SObjectType::dirt_effect);
 
   for (int i = 0; i < 14; ++i)  // TODO: Unhardcode
   {
-    common.sobjectTypes[i].id = i;
+    common.sobject_types[i].id = i;
   }
 
-  exe.seekg(111430);
+  exe.Seekg(111430);
 
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::detectDistance);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::gravity);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::speed);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::speedV);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::distribution);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::blowAway);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::bounce);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::hitDamage);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::wormExplode);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::explGround);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::wormDestroy);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::bloodOnHit);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::startFrame);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::numFrames);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::drawOnMap);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::colorBullets);
-  readMembers<Dec<Read8> >(exe, common.nobjectTypes, &NObjectType::createOnExp);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::affectByExplosions);
-  readMembers<Dec<Read8> >(exe, common.nobjectTypes, &NObjectType::dirtEffect);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::splinterAmount);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::splinterColour);
-  readMembers<Dec<Read8> >(exe, common.nobjectTypes, &NObjectType::splinterType);
-  readMembers<ReadBool>(exe, common.nobjectTypes, &NObjectType::bloodTrail);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::bloodTrailDelay);
-  readMembers<Dec<Read8> >(exe, common.nobjectTypes, &NObjectType::leaveObj);
-  readMembers<Read8>(exe, common.nobjectTypes, &NObjectType::leaveObjDelay);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::timeToExplo);
-  readMembers<Read16>(exe, common.nobjectTypes, &NObjectType::timeToExploV);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::detect_distance);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::gravity);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::speed);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::speed_v);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::distribution);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::blow_away);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::bounce);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::hit_damage);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::worm_explode);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::expl_ground);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::worm_destroy);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::blood_on_hit);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::start_frame);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::num_frames);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::draw_on_map);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::color_bullets);
+  ReadMembers<Dec<Read8> >(exe, common.nobject_types, &NObjectType::create_on_exp);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::affect_by_explosions);
+  ReadMembers<Dec<Read8> >(exe, common.nobject_types, &NObjectType::dirt_effect);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::splinter_amount);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::splinter_colour);
+  ReadMembers<Dec<Read8> >(exe, common.nobject_types, &NObjectType::splinter_type);
+  ReadMembers<ReadBool>(exe, common.nobject_types, &NObjectType::blood_trail);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::blood_trail_delay);
+  ReadMembers<Dec<Read8> >(exe, common.nobject_types, &NObjectType::leave_obj);
+  ReadMembers<Read8>(exe, common.nobject_types, &NObjectType::leave_obj_delay);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::time_to_explo);
+  ReadMembers<Read16>(exe, common.nobject_types, &NObjectType::time_to_explo_v);
 
   for (int i = 0; i < 24; ++i)  // TODO: Unhardcode
   {
-    common.nobjectTypes[i].id = i;
+    common.nobject_types[i].id = i;
   }
 }
 
-void loadTextures(Common& common, ReaderFile& exe) {
-  exe.seekg(0x1C208);
-  readMembers<ReadBool>(exe, common.textures, &Texture::nDrawBack);
-  exe.seekg(0x1C1EA);
-  readMembers<Read8>(exe, common.textures, &Texture::mFrame);
-  exe.seekg(0x1C1F4);
-  readMembers<Read8>(exe, common.textures, &Texture::sFrame);
-  exe.seekg(0x1C1FE);
-  readMembers<Read8>(exe, common.textures, &Texture::rFrame);
+void LoadTextures(Common& common, ReaderFile& exe) {
+  exe.Seekg(0x1C208);
+  ReadMembers<ReadBool>(exe, common.textures, &Texture::n_draw_back);
+  exe.Seekg(0x1C1EA);
+  ReadMembers<Read8>(exe, common.textures, &Texture::m_frame);
+  exe.Seekg(0x1C1F4);
+  ReadMembers<Read8>(exe, common.textures, &Texture::s_frame);
+  exe.Seekg(0x1C1FE);
+  ReadMembers<Read8>(exe, common.textures, &Texture::r_frame);
 }
 
-void loadOthers(Common& common, ReaderFile& exe) {
-  exe.seekg(0x1C1E2);
+void LoadOthers(Common& common, ReaderFile& exe) {
+  exe.Seekg(0x1C1E2);
 
   for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j) common.bonusRandTimer[j][i] = io::read_uint16_le(exe);
+    for (int j = 0; j < 2; ++j) common.bonus_rand_timer[j][i] = io::ReadUint16Le(exe);
 
-  exe.seekg(0x1AEEE + 2);
+  exe.Seekg(0x1AEEE + 2);
 
   for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 7; ++j) common.aiParams.k[i][j] = io::read_uint16_le(exe);
+    for (int j = 0; j < 7; ++j) common.ai_params.k[i][j] = io::ReadUint16Le(exe);
 
-  exe.seekg(0x1C1E0);
+  exe.Seekg(0x1C1E0);
 
-  for (int i = 0; i < 2; ++i) common.bonusSObjects[i] = exe.get() - 1;
+  for (int i = 0; i < 2; ++i) common.bonus_s_objects[i] = exe.Get() - 1;
 }
 
-void loadSprites(SpriteSet& ss, ReaderFile& f, int width, int height, int count) {
+void LoadSprites(SpriteSet& ss, ReaderFile& f, int width, int height, int count) {
   assert(width == height);  // We only support rectangular sprites right now
 
   ss.width = width;
   ss.height = height;
-  ss.spriteSize = width * height;
+  ss.sprite_size = width * height;
   ss.count = count;
 
-  int amount = ss.spriteSize * count;
+  int amount = ss.sprite_size * count;
   ss.data.resize(amount);
 
   std::vector<uint8_t> temp(amount);
 
-  f.get(&temp[0], amount);
+  f.Get(&temp[0], amount);
 
   PalIdx* dest = &ss.data[0];
   uint8_t* src = &temp[0];
@@ -625,102 +625,102 @@ void loadSprites(SpriteSet& ss, ReaderFile& f, int width, int height, int count)
       src += height;
     }
 
-    dest += ss.spriteSize;
+    dest += ss.sprite_size;
   }
 }
 
-void cropSprites(SpriteSet& sprites, int first, int count, int minX, int minY, int width,
+void CropSprites(SpriteSet& sprites, int first, int count, int min_x, int min_y, int width,
                  int height) {
   // Crop sprites by clearing pixels outside the desired area.
 
-  int maxX = minX + width - 1;
-  int maxY = minY + height - 1;
+  int max_x = min_x + width - 1;
+  int max_y = min_y + height - 1;
 
   for (int i = first; i < first + count; i++) {
     Sprite sprite = sprites[i];
 
     for (int y = 0; y < sprite.height; y++) {
       for (int x = 0; x < sprite.width; x++) {
-        if (x < minX || x > maxX || y < minY || y > maxY) sprite.mem[y * sprite.width + x] = 0;
+        if (x < min_x || x > max_x || y < min_y || y > max_y) sprite.mem[y * sprite.width + x] = 0;
       }
     }
   }
 }
 
-void loadGfx(Common& common, ReaderFile& exe, ReaderFile& gfx) {
-  exe.seekg(0x1C1DE);
-  common.bonusFrames[0] = exe.get();
-  common.bonusFrames[1] = exe.get();
+void LoadGfx(Common& common, ReaderFile& exe, ReaderFile& gfx) {
+  exe.Seekg(0x1C1DE);
+  common.bonus_frames[0] = exe.Get();
+  common.bonus_frames[1] = exe.Get();
 
-  gfx.seekg(10);  // Skip some header
+  gfx.Seekg(10);  // Skip some header
 
-  loadSprites(common.largeSprites, gfx, 16, 16, 110);
-  gfx.skip(4);  // Extra stuff
+  LoadSprites(common.large_sprites, gfx, 16, 16, 110);
+  gfx.Skip(4);  // Extra stuff
 
-  loadSprites(common.smallSprites, gfx, 7, 7, 130);
-  gfx.skip(4);  // Extra stuff
+  LoadSprites(common.small_sprites, gfx, 7, 7, 130);
+  gfx.Skip(4);  // Extra stuff
 
-  loadSprites(common.textSprites, gfx, 4, 4, 26);
+  LoadSprites(common.text_sprites, gfx, 4, 4, 26);
 
   // The original would only render 10x9 pixels of the worm sprites.
   // Cropping the worm sprites here to match the original behavior.
-  cropSprites(common.largeSprites, 16, 21, 2, 0, 10, 9);
+  CropSprites(common.large_sprites, 16, 21, 2, 0, 10, 9);
 
   Rand rand;
 
   for (int y = 0; y < 16; ++y)
     for (int x = 0; x < 16; ++x) {
       int idx = y * 16 + x;
-      common.largeSprites.spritePtr(73)[idx] = rand(4) + 160;
-      common.largeSprites.spritePtr(74)[idx] = rand(4) + 160;
+      common.large_sprites.SpritePtr(73)[idx] = rand(4) + 160;
+      common.large_sprites.SpritePtr(74)[idx] = rand(4) + 160;
 
-      common.largeSprites.spritePtr(87)[idx] = rand(4) + 12;
-      common.largeSprites.spritePtr(88)[idx] = rand(4) + 12;
+      common.large_sprites.SpritePtr(87)[idx] = rand(4) + 12;
+      common.large_sprites.SpritePtr(88)[idx] = rand(4) + 12;
 
-      common.largeSprites.spritePtr(82)[idx] = rand(4) + 94;
-      common.largeSprites.spritePtr(83)[idx] = rand(4) + 94;
+      common.large_sprites.SpritePtr(82)[idx] = rand(4) + 94;
+      common.large_sprites.SpritePtr(83)[idx] = rand(4) + 94;
     }
 }
 
-void loadSfx(std::vector<SfxSample>& sounds, ReaderFile& snd) {
-  int count = io::read_uint16_le(snd);
+void LoadSfx(std::vector<SfxSample>& sounds, ReaderFile& snd) {
+  int count = io::ReadUint16Le(snd);
 
   sounds.clear();
 
   for (int i = 0; i < count; ++i) {
     uint8_t name[9];
     name[8] = 0;
-    snd.get(name, 8);
+    snd.Get(name, 8);
 
-    int offset = io::read_uint32_le(snd);
-    int length = io::read_uint32_le(snd);
+    int offset = io::ReadUint32Le(snd);
+    int length = io::ReadUint32Le(snd);
 
-    auto oldPos = snd.tellg();
+    auto old_pos = snd.Tellg();
 
-    SfxSample sample(toId(reinterpret_cast<char const*>(name)), length);
+    SfxSample sample(ToId(reinterpret_cast<char const*>(name)), length);
 
     if (length > 0) {
-      snd.seekg(offset);
-      snd.get(&sample.originalData[0], length);
+      snd.Seekg(offset);
+      snd.Get(&sample.original_data[0], length);
 
-      sample.createSound();
+      sample.CreateSound();
     }
 
-    snd.seekg(oldPos);
+    snd.Seekg(old_pos);
 
     sounds.push_back(std::move(sample));
   }
 }
 
-void loadFont(Font& font, ReaderFile& exe) {
+void LoadFont(Font& font, ReaderFile& exe) {
   font.chars.resize(250);
 
-  std::size_t const FontSize = 250 * 8 * 8 + 1;
-  std::vector<unsigned char> temp(FontSize);
+  std::size_t const kFontSize = 250 * 8 * 8 + 1;
+  std::vector<unsigned char> temp(kFontSize);
 
-  exe.seekg(0x1C825);
+  exe.Seekg(0x1C825);
 
-  exe.get(reinterpret_cast<uint8_t*>(&temp[0]), FontSize);
+  exe.Get(reinterpret_cast<uint8_t*>(&temp[0]), kFontSize);
 
   for (int i = 0; i < 250; ++i) {
     unsigned char* ptr = &temp[i * 64 + 1];
@@ -735,41 +735,41 @@ void loadFont(Font& font, ReaderFile& exe) {
   }
 }
 
-void loadFromExe(Common& common, ReaderFile& exe, ReaderFile& gfx, ReaderFile& snd) {
+void LoadFromExe(Common& common, ReaderFile& exe, ReaderFile& gfx, ReaderFile& snd) {
   common.weapons.resize(40);
-  common.nobjectTypes.resize(24);
-  common.sobjectTypes.resize(14);
+  common.nobject_types.resize(24);
+  common.sobject_types.resize(14);
 
   for (int i = 0; i < 14; ++i) {
-    common.sobjectTypes[i].idStr = toId(sobjectNames[i]);
+    common.sobject_types[i].id_str = ToId(sobject_names[i]);
   }
 
   for (int i = 0; i < 24; ++i) {
-    common.nobjectTypes[i].idStr = toId(nobjectNames[i]);
+    common.nobject_types[i].id_str = ToId(nobject_names[i]);
   }
 
-  loadConstants(common, exe);
-  loadFont(common.font, exe);
-  loadPalette(common, exe);
-  loadMaterials(common, exe);
-  loadWeapons(common, exe);
-  loadTextures(common, exe);
-  loadOthers(common, exe);
+  LoadConstants(common, exe);
+  LoadFont(common.font, exe);
+  LoadPalette(common, exe);
+  LoadMaterials(common, exe);
+  LoadWeapons(common, exe);
+  LoadTextures(common, exe);
+  LoadOthers(common, exe);
 
-  loadGfx(common, exe, gfx);
-  loadSfx(common.sounds, snd);
+  LoadGfx(common, exe, gfx);
+  LoadSfx(common.sounds, snd);
 
   // Resolve the engine's named sound hooks against the loaded sound
   // table so saveTcConfig emits a populated [sounds] section. Without
   // this, a freshly extracted TC has every hook at -1 and the engine's
   // menu / round-begin / bump / reload sounds are silent (issue #44).
   static struct {
-    SOUND_DEF_T hook;
+    SoundDefT hook;
     char const* name;
-  } const hookNames[] = {
+  } const kHookNames[] = {
       {SoundMenuMoveUp, "moveup"}, {SoundMenuMoveDown, "movedown"}, {SoundMenuSelect, "select"},
       {SoundBump, "bump"},         {SoundBegin, "begin"},           {SoundReloaded, "reloaded"},
       {SoundAlive, "alive"},       {SoundNinjaropeThrow, "throw"},
   };
-  for (auto const& m : hookNames) common.soundHook[m.hook] = common.soundIndex(m.name);
+  for (auto const& m : kHookNames) common.sound_hook[m.hook] = common.SoundIndex(m.name);
 }

--- a/src/tc_tool/common_exereader.cpp
+++ b/src/tc_tool/common_exereader.cpp
@@ -8,39 +8,39 @@
 #include "game/reader.hpp"
 
 int c_sint32desc[][3] = {{CNRInitialLength, 0x32D7, 0x32DD},
-                        {CNRAttachLength, 0xA679, 0xA67F},
+                         {CNRAttachLength, 0xA679, 0xA67F},
 
-                        {0, -1, -1}};
+                         {0, -1, -1}};
 
 int c_sint24desc[][3] = {{CMinBounceUp, 0x3B7D, 0x3B74},
-                        {CMinBounceDown, 0x3B00, 0x3AF7},
-                        {CMinBounceLeft, 0x3A83, 0x3A7A},
-                        {CMinBounceRight, 0x3A06, 0x39FD},
-                        {CWormGravity, 0x3BDE, 0x3BD7},
-                        {CWalkVelLeft, 0x3F97, 0x3F9D},
-                        {CMaxVelLeft, 0x3F8C, 0x3F83},
-                        {CWalkVelRight, 0x4018, 0x401E},
-                        {CMaxVelRight, 0x400D, 0x4004},
-                        {CJumpForce, 0x3327, 0x332D},
-                        {CMaxAimVelLeft, 0x30F2, 0x30E9},
-                        {CAimAccLeft, 0x30FD, 0x3103},
-                        {CMaxAimVelRight, 0x311A, 0x3111},
-                        {CAimAccRight, 0x3125, 0x312B},
-                        {CNinjaropeGravity, 0xA895, 0xA89B},
-                        {CNRMinLength, 0x3206, 0x31FD},
-                        {CNRMaxLength, 0x3229, 0x3220},
+                         {CMinBounceDown, 0x3B00, 0x3AF7},
+                         {CMinBounceLeft, 0x3A83, 0x3A7A},
+                         {CMinBounceRight, 0x3A06, 0x39FD},
+                         {CWormGravity, 0x3BDE, 0x3BD7},
+                         {CWalkVelLeft, 0x3F97, 0x3F9D},
+                         {CMaxVelLeft, 0x3F8C, 0x3F83},
+                         {CWalkVelRight, 0x4018, 0x401E},
+                         {CMaxVelRight, 0x400D, 0x4004},
+                         {CJumpForce, 0x3327, 0x332D},
+                         {CMaxAimVelLeft, 0x30F2, 0x30E9},
+                         {CAimAccLeft, 0x30FD, 0x3103},
+                         {CMaxAimVelRight, 0x311A, 0x3111},
+                         {CAimAccRight, 0x3125, 0x312B},
+                         {CNinjaropeGravity, 0xA895, 0xA89B},
+                         {CNRMinLength, 0x3206, 0x31FD},
+                         {CNRMaxLength, 0x3229, 0x3220},
 
-                        {CBonusGravity, 0x72C3, 0x72C9},
-                        {CBObjGravity, 0x744A, 0x7450},
+                         {CBonusGravity, 0x72C3, 0x72C9},
+                         {CBObjGravity, 0x744A, 0x7450},
 
-                        // WormFloat hack
-                        {CWormFloatPower, 0x29DB, 0x29E1},
+                         // WormFloat hack
+                         {CWormFloatPower, 0x29DB, 0x29E1},
 
-                        {0, -1, -1}};
+                         {0, -1, -1}};
 
 int c_uint16desc[][2] = {{CBloodLimit, 0xE686},
 
-                        {0, -1}};
+                         {0, -1}};
 
 int c_sint16desc[][2] = {
     {CWormFricMult, 0x39BD},
@@ -82,36 +82,36 @@ int c_sint16desc[][2] = {
     {0, -1}};
 
 int c_uint8desc[][2] = {{CAimMaxRight, 0x3030},
-                       {CAimMinRight, 0x304A},
-                       {CAimMaxLeft, 0x3066},
-                       {CAimMinLeft, 0x3080},
-                       {CNRColourBegin, 0x10FD2},
-                       {CNRColourEnd, 0x11069},
-                       {CBonusExplodeRisk, 0x2DB2},
-                       {CBonusHealthVar, 0x2D56},
-                       {CBonusMinHealth, 0x2D5D},
-                       {CLaserWeapon, 0x7255},
+                        {CAimMinRight, 0x304A},
+                        {CAimMaxLeft, 0x3066},
+                        {CAimMinLeft, 0x3080},
+                        {CNRColourBegin, 0x10FD2},
+                        {CNRColourEnd, 0x11069},
+                        {CBonusExplodeRisk, 0x2DB2},
+                        {CBonusHealthVar, 0x2D56},
+                        {CBonusMinHealth, 0x2D5D},
+                        {CLaserWeapon, 0x7255},
 
-                       {CFirstBloodColour, 0x2388},
-                       {CNumBloodColours, 0x2381},
+                        {CFirstBloodColour, 0x2388},
+                        {CNumBloodColours, 0x2381},
 
-                       {CRemExpObject, 0x8F8B},
+                        {CRemExpObject, 0x8F8B},
 
-                       {0, -1}};
+                        {0, -1}};
 
 int c_sint8desc[][2] = {{CNRPullVel, 0x31D0},
-                       {CNRReleaseVel, 0x31F0},
+                        {CNRReleaseVel, 0x31F0},
 
-                       // FallDamage hack
-                       {CFallDamageRight, 0x3A0E},
-                       {CFallDamageLeft, 0x3A8B},
-                       {CFallDamageDown, 0x3B08},
-                       {CFallDamageUp, 0x3B85},
+                        // FallDamage hack
+                        {CFallDamageRight, 0x3A0E},
+                        {CFallDamageLeft, 0x3A8B},
+                        {CFallDamageDown, 0x3B08},
+                        {CFallDamageUp, 0x3B85},
 
-                       {CBloodStepUp, 0xE67B},
-                       {CBloodStepDown, 0xE68E},
+                        {CBloodStepUp, 0xE67B},
+                        {CBloodStepDown, 0xE68E},
 
-                       {0, -1}};
+                        {0, -1}};
 
 int sstringdesc[][2] = {{SInitSound, 0x177F},
                         {SLoadingSounds, 0x18F2},
@@ -170,11 +170,11 @@ struct HackDesc {
 };
 
 int h_fall_damage_ind[][2] = {{0x3A0A, 0x26},
-                           {0x3A87, 0x26},
-                           {0x3B04, 0x26},
-                           {0x3B81, 0x26},
+                              {0x3A87, 0x26},
+                              {0x3B04, 0x26},
+                              {0x3B81, 0x26},
 
-                           {-1, 0}};
+                              {-1, 0}};
 
 int h_bonus_reload_only_ind[][2] = {
     {0x2DB1, 0xEB},  // We check one byte only, because ProMode has a silly jump destination
@@ -188,23 +188,23 @@ int h_bonus_spawn_rect_ind[][2] = {
     {-1, 0}};
 
 int h_bonus_only_health_ind[][2] = {{0x228B, 0xB0},
-                                {0x228C, 0x02},
+                                    {0x228C, 0x02},
 
-                                {-1, 0}};
+                                    {-1, 0}};
 
 int h_bonus_only_weapon_ind[][2] = {{0x228B, 0xB0},
-                                {0x228C, 0x01},
+                                    {0x228C, 0x01},
 
-                                {-1, 0}};
+                                    {-1, 0}};
 
 int h_bonus_disable_ind[][2] = {{0xBED3, 0xEB},
 
-                             {-1, 0}};
+                                {-1, 0}};
 
 int h_worm_float_ind[][2] = {{0x29D7, 0x26},  // 0x26 is the first byte of the sub instruction
-                          {0x29DA, 0x34},  // 0x34 is the offset to part of velY of the worm
+                             {0x29DA, 0x34},  // 0x34 is the offset to part of velY of the worm
 
-                          {-1, 0}};
+                             {-1, 0}};
 
 int h_rem_exp_ind[][2] = {
     // Start of the mov instruction that zeroes the timeout counter
@@ -232,44 +232,44 @@ HackDesc hhackdesc[] = {{HFallDamage, h_fall_damage_ind},
                         {0, 0}};
 
 char const* sobject_names[14] = {"Large explosion",
-                                "Medium explosion",
-                                "Small explosion",
-                                "Hellraider smoke",
-                                "Zimm flash",
-                                "Nuke smoke",
-                                "Flashing pixel",
-                                "Teleport flash",
-                                "Small explosion, silent",
-                                "Very small explosion, silent",
-                                "Medium explosion, smaller",
-                                "Large explosion, smaller",
-                                "Medium explosion, bigger",
-                                "Unknown"};
+                                 "Medium explosion",
+                                 "Small explosion",
+                                 "Hellraider smoke",
+                                 "Zimm flash",
+                                 "Nuke smoke",
+                                 "Flashing pixel",
+                                 "Teleport flash",
+                                 "Small explosion, silent",
+                                 "Very small explosion, silent",
+                                 "Medium explosion, smaller",
+                                 "Large explosion, smaller",
+                                 "Medium explosion, bigger",
+                                 "Unknown"};
 
 char const* nobject_names[24] = {"Worm 1 parts",
-                                "Worm 2 parts",
-                                "Particle, disappearing",
-                                "Particle, small damage",
-                                "Particle, medium damage",
-                                "Particle, larger damage",
-                                "Blood",
-                                "Shells",
-                                "Clusterbomb bombs",
-                                "Large nukes",
-                                "Hellraider bullets",
-                                "Small nukes",
-                                "Napalm fireballs",
-                                "Dirt",
-                                "Chiquitabomb bombs",
-                                "Grasshopper 1",
-                                "Grasshopper 2",
-                                "Grasshopper 3",
-                                "Grasshopper 4",
-                                "Grasshopper 5",
-                                "Flag 1",
-                                "Flag 2",
-                                "Grasshopper 6",
-                                "Grasshopper 7"};
+                                 "Worm 2 parts",
+                                 "Particle, disappearing",
+                                 "Particle, small damage",
+                                 "Particle, medium damage",
+                                 "Particle, larger damage",
+                                 "Blood",
+                                 "Shells",
+                                 "Clusterbomb bombs",
+                                 "Large nukes",
+                                 "Hellraider bullets",
+                                 "Small nukes",
+                                 "Napalm fireballs",
+                                 "Dirt",
+                                 "Chiquitabomb bombs",
+                                 "Grasshopper 1",
+                                 "Grasshopper 2",
+                                 "Grasshopper 3",
+                                 "Grasshopper 4",
+                                 "Grasshopper 5",
+                                 "Flag 1",
+                                 "Flag 2",
+                                 "Grasshopper 6",
+                                 "Grasshopper 7"};
 
 std::string ToId(std::string const& name) {
   std::string ret;
@@ -521,7 +521,7 @@ void LoadWeapons(Common& common, ReaderFile& exe) {
   ReadMembers<Read8>(exe, common.sobject_types, &SObjectType::damage);
   ReadMembers<Read32>(exe, common.sobject_types,
                       &SObjectType::blow_away);  // blowAway has 13 slots, not 14. The last value
-                                                // will overlap with shadow.
+                                                 // will overlap with shadow.
 
   exe.Seekg(115368);
   ReadMembers<ReadBool>(exe, common.sobject_types, &SObjectType::shadow);

--- a/src/tc_tool/common_exereader.hpp
+++ b/src/tc_tool/common_exereader.hpp
@@ -4,5 +4,5 @@
 
 struct ReaderFile;
 
-void loadFromExe(Common& common, ReaderFile& exe, ReaderFile& gfx, ReaderFile& snd);
-void loadSfx(std::vector<SfxSample>& sounds, ReaderFile& snd);
+void LoadFromExe(Common& common, ReaderFile& exe, ReaderFile& gfx, ReaderFile& snd);
+void LoadSfx(std::vector<SfxSample>& sounds, ReaderFile& snd);

--- a/src/tc_tool/common_writer.cpp
+++ b/src/tc_tool/common_writer.cpp
@@ -139,7 +139,7 @@ void CommonSave(Common& common, std::string const& path) {
 
     std::ostringstream ss;
     SaveNObjectConfig(common, w, ss);
-    io::FileWriter n_writer(JoinPath(dir, w.idStr + ".cfg").c_str(), "wb");
+    io::FileWriter n_writer(JoinPath(dir, w.id_str + ".cfg").c_str(), "wb");
     auto str = ss.str();
     for (char c : str) n_writer.Put(c);
   }
@@ -150,7 +150,7 @@ void CommonSave(Common& common, std::string const& path) {
 
     std::ostringstream ss;
     SaveSObjectConfig(common, w, ss);
-    io::FileWriter s_writer(JoinPath(dir, w.idStr + ".cfg").c_str(), "wb");
+    io::FileWriter s_writer(JoinPath(dir, w.id_str + ".cfg").c_str(), "wb");
     auto str = ss.str();
     for (char c : str) s_writer.Put(c);
   }

--- a/src/tc_tool/common_writer.cpp
+++ b/src/tc_tool/common_writer.cpp
@@ -6,107 +6,107 @@
 #include <fstream>
 #include <sstream>
 
-void writeSpriteTga(io::Writer& w, int imageWidth, int imageHeight, uint8_t* data, Palette& pal) {
-  w.put(0);
-  w.put(1);
-  w.put(1);
+void WriteSpriteTga(io::Writer& w, int image_width, int image_height, uint8_t* data, Palette& pal) {
+  w.Put(0);
+  w.Put(1);
+  w.Put(1);
 
   // Palette spec
-  io::write_uint16_le(w, 0);
-  io::write_uint16_le(w, 256);
-  w.put(24);
+  io::WriteUint16Le(w, 0);
+  io::WriteUint16Le(w, 256);
+  w.Put(24);
 
-  io::write_uint16_le(w, 0);
-  io::write_uint16_le(w, 0);
-  io::write_uint16_le(w, imageWidth);
-  io::write_uint16_le(w, imageHeight);
-  w.put(8);  // Bits per pixel
-  w.put(0);  // Descriptor
+  io::WriteUint16Le(w, 0);
+  io::WriteUint16Le(w, 0);
+  io::WriteUint16Le(w, image_width);
+  io::WriteUint16Le(w, image_height);
+  w.Put(8);  // Bits per pixel
+  w.Put(0);  // Descriptor
 
   for (auto const& entry : pal.entries) {
-    w.put(entry.b << 2);
-    w.put(entry.g << 2);
-    w.put(entry.r << 2);
+    w.Put(entry.b << 2);
+    w.Put(entry.g << 2);
+    w.Put(entry.r << 2);
   }
 
   // Bottom to top
-  for (std::size_t y = (std::size_t)imageHeight; y-- > 0;) {
-    auto const* src = &data[y * imageWidth];
-    w.put((uint8_t const*)src, imageWidth);
+  for (std::size_t y = (std::size_t)image_height; y-- > 0;) {
+    auto const* src = &data[y * image_width];
+    w.Put((uint8_t const*)src, image_width);
   }
 }
 
-void writeSpriteTga(io::Writer& w, SpriteSet& ss, Palette& pal) {
-  writeSpriteTga(w, ss.width, ss.count * ss.height, &ss.data[0], pal);
+void WriteSpriteTga(io::Writer& w, SpriteSet& ss, Palette& pal) {
+  WriteSpriteTga(w, ss.width, ss.count * ss.height, &ss.data[0], pal);
 }
 
-void commonSave(Common& common, std::string const& path) {
-  auto cfgPath = joinPath(path, "tc.cfg");
-  create_directories(cfgPath);
+void CommonSave(Common& common, std::string const& path) {
+  auto cfg_path = JoinPath(path, "tc.cfg");
+  CreateDirectories(cfg_path);
 
   {
     std::ostringstream ss;
-    saveTcConfig(common, ss);
-    io::FileWriter textWriter(cfgPath.c_str(), "wb");
+    SaveTcConfig(common, ss);
+    io::FileWriter text_writer(cfg_path.c_str(), "wb");
     auto str = ss.str();
-    for (char c : str) textWriter.put(c);
+    for (char c : str) text_writer.Put(c);
   }
 
   for (auto& s : common.sounds) {
-    std::string dir(joinPath(path, "sounds/"));
-    create_directories(dir);
+    std::string dir(JoinPath(path, "sounds/"));
+    CreateDirectories(dir);
 
-    io::FileWriter w(joinPath(dir, s.name + ".wav").c_str(), "wb");
+    io::FileWriter w(JoinPath(dir, s.name + ".wav").c_str(), "wb");
 
-    auto roundedSize = (s.originalData.size() + 1) & ~1;
+    auto rounded_size = (s.original_data.size() + 1) & ~1;
 
-    w.put((uint8_t const*)"RIFF", 4);
-    io::write_uint32_le(w, (uint32_t)roundedSize - 8);
-    w.put((uint8_t const*)"WAVE", 4);
+    w.Put((uint8_t const*)"RIFF", 4);
+    io::WriteUint32Le(w, (uint32_t)rounded_size - 8);
+    w.Put((uint8_t const*)"WAVE", 4);
 
-    w.put((uint8_t const*)"fmt ", 4);
-    io::write_uint32_le(w, 16);     // PCM header size
-    io::write_uint16_le(w, 1);      // PCM
-    io::write_uint16_le(w, 1);      // Mono
-    io::write_uint32_le(w, 22050);  // Sample rate
-    io::write_uint32_le(w, 22050 * 1 * 1);
-    io::write_uint16_le(w, 1 * 1);
-    io::write_uint16_le(w, 8);
+    w.Put((uint8_t const*)"fmt ", 4);
+    io::WriteUint32Le(w, 16);     // PCM header size
+    io::WriteUint16Le(w, 1);      // PCM
+    io::WriteUint16Le(w, 1);      // Mono
+    io::WriteUint32Le(w, 22050);  // Sample rate
+    io::WriteUint32Le(w, 22050 * 1 * 1);
+    io::WriteUint16Le(w, 1 * 1);
+    io::WriteUint16Le(w, 8);
 
-    w.put((uint8_t const*)"data", 4);
-    io::write_uint32_le(w, (uint32_t)s.originalData.size() * 1 * 1);  // Data size
+    w.Put((uint8_t const*)"data", 4);
+    io::WriteUint32Le(w, (uint32_t)s.original_data.size() * 1 * 1);  // Data size
 
-    auto curSize = s.originalData.size();
+    auto cur_size = s.original_data.size();
 
-    for (auto& z : s.originalData) w.put(z + 128);
+    for (auto& z : s.original_data) w.Put(z + 128);
 
-    while (curSize < roundedSize) {
-      w.put(0);  // Padding
-      ++curSize;
+    while (cur_size < rounded_size) {
+      w.Put(0);  // Padding
+      ++cur_size;
     }
   }
 
   {
-    std::string dir(joinPath(path, "sprites/"));
-    create_directories(dir);
+    std::string dir(JoinPath(path, "sprites/"));
+    CreateDirectories(dir);
 
     {
-      io::FileWriter w(joinPath(dir, "small.tga").c_str(), "wb");
-      writeSpriteTga(w, common.smallSprites, common.exepal);
+      io::FileWriter w(JoinPath(dir, "small.tga").c_str(), "wb");
+      WriteSpriteTga(w, common.small_sprites, common.exepal);
     }
 
     {
-      io::FileWriter w(joinPath(dir, "large.tga").c_str(), "wb");
-      writeSpriteTga(w, common.largeSprites, common.exepal);
+      io::FileWriter w(JoinPath(dir, "large.tga").c_str(), "wb");
+      WriteSpriteTga(w, common.large_sprites, common.exepal);
     }
 
     {
-      io::FileWriter w(joinPath(dir, "text.tga").c_str(), "wb");
-      writeSpriteTga(w, common.textSprites, common.exepal);
+      io::FileWriter w(JoinPath(dir, "text.tga").c_str(), "wb");
+      WriteSpriteTga(w, common.text_sprites, common.exepal);
     }
 
     {
-      io::FileWriter w(joinPath(dir, "font.tga").c_str(), "wb");
+      io::FileWriter w(JoinPath(dir, "font.tga").c_str(), "wb");
 
       std::vector<uint8_t> data(common.font.chars.size() * 7 * 8, 10);
       for (std::size_t i = 0; i < common.font.chars.size(); ++i) {
@@ -118,40 +118,40 @@ void commonSave(Common& common, std::string const& path) {
             dest[y * 7 + x] = ch.data[y * 7 + x] ? 50 : 0;
           }
       }
-      writeSpriteTga(w, 7, (int)common.font.chars.size() * 8, &data[0], common.exepal);
+      WriteSpriteTga(w, 7, (int)common.font.chars.size() * 8, &data[0], common.exepal);
     }
   }
 
   for (auto& w : common.weapons) {
-    std::string dir(joinPath(path, "weapons/"));
-    create_directories(dir);
+    std::string dir(JoinPath(path, "weapons/"));
+    CreateDirectories(dir);
 
     std::ostringstream ss;
-    saveWeaponConfig(common, w, ss);
-    io::FileWriter wWriter(joinPath(dir, w.idStr + ".cfg").c_str(), "wb");
+    SaveWeaponConfig(common, w, ss);
+    io::FileWriter w_writer(JoinPath(dir, w.id_str + ".cfg").c_str(), "wb");
     auto str = ss.str();
-    for (char c : str) wWriter.put(c);
+    for (char c : str) w_writer.Put(c);
   }
 
-  for (auto& w : common.nobjectTypes) {
-    std::string dir(joinPath(path, "nobjects/"));
-    create_directories(dir);
+  for (auto& w : common.nobject_types) {
+    std::string dir(JoinPath(path, "nobjects/"));
+    CreateDirectories(dir);
 
     std::ostringstream ss;
-    saveNObjectConfig(common, w, ss);
-    io::FileWriter nWriter(joinPath(dir, w.idStr + ".cfg").c_str(), "wb");
+    SaveNObjectConfig(common, w, ss);
+    io::FileWriter n_writer(JoinPath(dir, w.idStr + ".cfg").c_str(), "wb");
     auto str = ss.str();
-    for (char c : str) nWriter.put(c);
+    for (char c : str) n_writer.Put(c);
   }
 
-  for (auto& w : common.sobjectTypes) {
-    std::string dir(joinPath(path, "sobjects/"));
-    create_directories(dir);
+  for (auto& w : common.sobject_types) {
+    std::string dir(JoinPath(path, "sobjects/"));
+    CreateDirectories(dir);
 
     std::ostringstream ss;
-    saveSObjectConfig(common, w, ss);
-    io::FileWriter sWriter(joinPath(dir, w.idStr + ".cfg").c_str(), "wb");
+    SaveSObjectConfig(common, w, ss);
+    io::FileWriter s_writer(JoinPath(dir, w.idStr + ".cfg").c_str(), "wb");
     auto str = ss.str();
-    for (char c : str) sWriter.put(c);
+    for (char c : str) s_writer.Put(c);
   }
 }

--- a/src/tc_tool/common_writer.hpp
+++ b/src/tc_tool/common_writer.hpp
@@ -4,4 +4,4 @@
 
 struct Common;
 
-void commonSave(Common& common, std::string const& path);
+void CommonSave(Common& common, std::string const& path);

--- a/src/tc_tool/tc_tool_main.cpp
+++ b/src/tc_tool/tc_tool_main.cpp
@@ -10,63 +10,63 @@
 int main(int argc, char* argv[]) {
   // Pre-strip --tc-name <value> before passing to paths::resolve so its
   // value isn't mistaken for a positional argument.
-  std::string tcName;
-  std::vector<std::string> argStorage;
-  std::vector<char*> argPtrs;
-  argStorage.reserve(argc);
-  argStorage.emplace_back(argv[0]);
+  std::string tc_name;
+  std::vector<std::string> arg_storage;
+  std::vector<char*> arg_ptrs;
+  arg_storage.reserve(argc);
+  arg_storage.emplace_back(argv[0]);
   for (int i = 1; i < argc; ++i) {
     if (std::strcmp(argv[i], "--tc-name") == 0 && i + 1 < argc) {
-      tcName = argv[++i];
+      tc_name = argv[++i];
     } else {
-      argStorage.emplace_back(argv[i]);
+      arg_storage.emplace_back(argv[i]);
     }
   }
-  for (auto& s : argStorage) argPtrs.push_back(s.data());
-  argPtrs.push_back(nullptr);
+  for (auto& s : arg_storage) arg_ptrs.push_back(s.data());
+  arg_ptrs.push_back(nullptr);
 
-  auto r = paths::resolve(static_cast<int>(argStorage.size()), argPtrs.data());
+  auto r = paths::Resolve(static_cast<int>(arg_storage.size()), arg_ptrs.data());
 
   // First positional is the path to the legacy Liero install directory.
-  if (r.positionalArgs.empty()) {
+  if (r.positional_args.empty()) {
     printf("tctool <path-to-tc>\n");
     return 0;
   }
-  std::string const& exePath = r.positionalArgs[0];
+  std::string const& exe_path = r.positional_args[0];
 
   Common common;
 
-  FsNode path(exePath);
+  FsNode path(exe_path);
 
   bool found = false;
 
-  for (auto const& name : path.iter()) {
-    if (toUpperCase(name.name).find(".EXE") != std::string::npos) {
-      auto exeReader_ptr = (path / name.name).toReader();
-      io::Reader& exeReader = *exeReader_ptr;
-      ReaderFile exe(exeReader);
+  for (auto const& name : path.Iter()) {
+    if (ToUpperCase(name.name).find(".EXE") != std::string::npos) {
+      auto exe_reader_ptr = (path / name.name).ToReader();
+      io::Reader& exe_reader = *exe_reader_ptr;
+      ReaderFile exe(exe_reader);
 
-      if (exe.len() >= 135000 && exe.len() <= 137000) {
+      if (exe.Len() >= 135000 && exe.Len() <= 137000) {
         printf("Converting %s...\n", name.name.c_str());
 
         // TODO: Some TCs change the name of the .SND or .CHR for some reason.
         // We could read that name from the exe to make them work.
-        auto gfxReader_ptr = (path / "LIERO.CHR").toReader();
-        io::Reader& gfxReader = *gfxReader_ptr;
-        ReaderFile gfx(gfxReader);
-        auto sndReader_ptr = (path / "LIERO.SND").toReader();
-        io::Reader& sndReader = *sndReader_ptr;
-        ReaderFile snd(sndReader);
+        auto gfx_reader_ptr = (path / "LIERO.CHR").ToReader();
+        io::Reader& gfx_reader = *gfx_reader_ptr;
+        ReaderFile gfx(gfx_reader);
+        auto snd_reader_ptr = (path / "LIERO.SND").ToReader();
+        io::Reader& snd_reader = *snd_reader_ptr;
+        ReaderFile snd(snd_reader);
 
-        loadFromExe(common, exe, gfx, snd);
+        LoadFromExe(common, exe, gfx, snd);
 
-        if (tcName.empty()) tcName = getLeaf(exePath);
+        if (tc_name.empty()) tc_name = GetLeaf(exe_path);
 
-        FsNode outNode = r.userConfigNode / "TC" / tcName;
+        FsNode out_node = r.user_config_node / "TC" / tc_name;
 
-        printf("Writing to %s...\n", outNode.fullPath().c_str());
+        printf("Writing to %s...\n", out_node.FullPath().c_str());
 
-        commonSave(common, outNode.fullPath());
+        CommonSave(common, out_node.FullPath());
 
         found = true;
         break;
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
   }
 
   if (!found) {
-    printf("Could not find a suitable LIERO.EXE in %s\n", exePath.c_str());
+    printf("Could not find a suitable LIERO.EXE in %s\n", exe_path.c_str());
   }
 
   return 0;

--- a/src/tests/jitter_transport.hpp
+++ b/src/tests/jitter_transport.hpp
@@ -18,116 +18,116 @@ namespace rollback_test {
 struct JitterTransport {
   struct Params {
     uint32_t seed = 0xC0FFEE;
-    int minDelayFrames = 0;
-    int maxDelayFrames = 0;
-    double lossProbability = 0.0;
-    double duplicateProbability = 0.0;
+    int min_delay_frames = 0;
+    int max_delay_frames = 0;
+    double loss_probability = 0.0;
+    double duplicate_probability = 0.0;
   };
 
   static constexpr std::size_t kMaxBatch = rollback::kMaxRollback + 1;
 
   struct InFlight {
-    int deliverAtFrame;
+    int deliver_at_frame;
     uint8_t generation;
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, kMaxBatch> inputs;
-    uint32_t localFrame;
+    uint32_t local_frame;
   };
 
   // The on-wire generation byte travels through the transport so the
   // receive side can exercise the controller's stale-generation drop.
   // Tests that don't care about phase transitions just pass 0.
-  using Deliver = std::function<void(uint8_t generation, uint32_t baseFrame, uint8_t count,
-                                     uint8_t const* inputs, uint32_t localFrame)>;
+  using Deliver = std::function<void(uint8_t generation, uint32_t base_frame, uint8_t count,
+                                     uint8_t const* inputs, uint32_t local_frame)>;
 
   Params params;
   std::mt19937 rng;
-  std::vector<InFlight> aToB;
-  std::vector<InFlight> bToA;
-  int currentFrame = 0;
+  std::vector<InFlight> a_to_b;
+  std::vector<InFlight> b_to_a;
+  int current_frame = 0;
 
-  uint64_t packetsSent = 0;
-  uint64_t packetsDropped = 0;
-  uint64_t packetsDuplicated = 0;
+  uint64_t packets_sent = 0;
+  uint64_t packets_dropped = 0;
+  uint64_t packets_duplicated = 0;
 
   explicit JitterTransport(Params p) : params(p), rng(p.seed) {}
 
-  int randomDelay() {
-    int lo = params.minDelayFrames;
-    int hi = params.maxDelayFrames;
+  int RandomDelay() {
+    int lo = params.min_delay_frames;
+    int hi = params.max_delay_frames;
     if (hi <= lo) return lo;
     std::uniform_int_distribution<int> d(lo, hi);
     return d(rng);
   }
 
-  bool roll(double p) {
+  bool Roll(double p) {
     if (p <= 0.0) return false;
     std::uniform_real_distribution<double> d(0.0, 1.0);
     return d(rng) < p;
   }
 
-  void sendAToB(uint8_t generation, uint32_t baseFrame, uint8_t count, uint8_t const* inputs,
-                uint32_t localFrame) {
-    enqueue(aToB, generation, baseFrame, count, inputs, localFrame);
+  void SendAToB(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t const* inputs,
+                uint32_t local_frame) {
+    Enqueue(a_to_b, generation, base_frame, count, inputs, local_frame);
   }
-  void sendBToA(uint8_t generation, uint32_t baseFrame, uint8_t count, uint8_t const* inputs,
-                uint32_t localFrame) {
-    enqueue(bToA, generation, baseFrame, count, inputs, localFrame);
+  void SendBToA(uint8_t generation, uint32_t base_frame, uint8_t count, uint8_t const* inputs,
+                uint32_t local_frame) {
+    Enqueue(b_to_a, generation, base_frame, count, inputs, local_frame);
   }
 
   // Drain anything whose deliverAtFrame has elapsed, then advance the
   // clock. Within a queue, packets scan in send order — an earlier-sent
   // packet may carry a later deliverAtFrame than a packet queued after
   // it, exactly modelling jittery out-of-order delivery.
-  void tick(Deliver const& deliverA, Deliver const& deliverB) {
-    drainDue(aToB, deliverB);
-    drainDue(bToA, deliverA);
-    ++currentFrame;
+  void Tick(Deliver const& deliver_a, Deliver const& deliver_b) {
+    DrainDue(a_to_b, deliver_b);
+    DrainDue(b_to_a, deliver_a);
+    ++current_frame;
   }
 
   // Force-deliver every in-flight packet. Used at the end of a test to
   // converge both peers regardless of how late tail packets were.
-  void flush(Deliver const& deliverA, Deliver const& deliverB) {
-    for (auto const& p : aToB)
-      deliverB(p.generation, p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    for (auto const& p : bToA)
-      deliverA(p.generation, p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    aToB.clear();
-    bToA.clear();
+  void Flush(Deliver const& deliver_a, Deliver const& deliver_b) {
+    for (auto const& p : a_to_b)
+      deliver_b(p.generation, p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    for (auto const& p : b_to_a)
+      deliver_a(p.generation, p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    a_to_b.clear();
+    b_to_a.clear();
   }
 
-  bool empty() const { return aToB.empty() && bToA.empty(); }
+  bool Empty() const { return a_to_b.empty() && b_to_a.empty(); }
 
  private:
-  void enqueue(std::vector<InFlight>& q, uint8_t generation, uint32_t baseFrame, uint8_t count,
-               uint8_t const* inputs, uint32_t localFrame) {
-    ++packetsSent;
-    if (roll(params.lossProbability)) {
-      ++packetsDropped;
+  void Enqueue(std::vector<InFlight>& q, uint8_t generation, uint32_t base_frame, uint8_t count,
+               uint8_t const* inputs, uint32_t local_frame) {
+    ++packets_sent;
+    if (Roll(params.loss_probability)) {
+      ++packets_dropped;
       return;
     }
     InFlight p{};
-    p.deliverAtFrame = currentFrame + randomDelay();
+    p.deliver_at_frame = current_frame + RandomDelay();
     p.generation = generation;
-    p.baseFrame = baseFrame;
+    p.base_frame = base_frame;
     p.count = count;
     for (uint8_t i = 0; i < count; ++i) p.inputs[i] = inputs[i];
-    p.localFrame = localFrame;
+    p.local_frame = local_frame;
     q.push_back(p);
-    if (roll(params.duplicateProbability)) {
-      ++packetsDuplicated;
+    if (Roll(params.duplicate_probability)) {
+      ++packets_duplicated;
       InFlight d = p;
-      d.deliverAtFrame = currentFrame + randomDelay();
+      d.deliver_at_frame = current_frame + RandomDelay();
       q.push_back(d);
     }
   }
 
-  void drainDue(std::vector<InFlight>& q, Deliver const& deliver) {
+  void DrainDue(std::vector<InFlight>& q, Deliver const& deliver) {
     auto it = q.begin();
     while (it != q.end()) {
-      if (it->deliverAtFrame <= currentFrame) {
-        deliver(it->generation, it->baseFrame, it->count, it->inputs.data(), it->localFrame);
+      if (it->deliver_at_frame <= current_frame) {
+        deliver(it->generation, it->base_frame, it->count, it->inputs.data(), it->local_frame);
         it = q.erase(it);
       } else {
         ++it;

--- a/src/tests/test_cereal_types.cpp
+++ b/src/tests/test_cereal_types.cpp
@@ -15,7 +15,7 @@
 namespace {
 
 template <typename T>
-T roundtripBinary(T const& src) {
+T RoundtripBinary(T const& src) {
   std::stringstream ss;
   {
     cereal::PortableBinaryOutputArchive ar(ss);
@@ -30,7 +30,7 @@ T roundtripBinary(T const& src) {
 }
 
 template <typename T>
-T roundtripToml(T const& src) {
+T RoundtripToml(T const& src) {
   std::stringstream ss;
   {
     cereal::TomlOutputArchive ar(ss);
@@ -48,28 +48,28 @@ T roundtripToml(T const& src) {
 
 TEST_CASE("cereal_types: BasicVec<int,2> binary round-trip", "[cereal_types]") {
   IVec2 src{-12345, 6789};
-  IVec2 dst = roundtripBinary(src);
+  IVec2 dst = RoundtripBinary(src);
   CHECK(dst.x == src.x);
   CHECK(dst.y == src.y);
 }
 
 TEST_CASE("cereal_types: BasicVec<int,2> toml round-trip", "[cereal_types]") {
   IVec2 src{-12345, 6789};
-  IVec2 dst = roundtripToml(src);
+  IVec2 dst = RoundtripToml(src);
   CHECK(dst.x == src.x);
   CHECK(dst.y == src.y);
 }
 
 TEST_CASE("cereal_types: BasicVec<float,2> binary round-trip", "[cereal_types]") {
   FVec2 src{1.5f, -2.25f};
-  FVec2 dst = roundtripBinary(src);
+  FVec2 dst = RoundtripBinary(src);
   CHECK(dst.x == src.x);
   CHECK(dst.y == src.y);
 }
 
 TEST_CASE("cereal_types: BasicRect<int> binary round-trip", "[cereal_types]") {
   Rect src{1, 2, 100, 200};
-  Rect dst = roundtripBinary(src);
+  Rect dst = RoundtripBinary(src);
   CHECK(dst.x1 == 1);
   CHECK(dst.y1 == 2);
   CHECK(dst.x2 == 100);
@@ -78,7 +78,7 @@ TEST_CASE("cereal_types: BasicRect<int> binary round-trip", "[cereal_types]") {
 
 TEST_CASE("cereal_types: BasicRect<int> toml round-trip", "[cereal_types]") {
   Rect src{1, 2, 100, 200};
-  Rect dst = roundtripToml(src);
+  Rect dst = RoundtripToml(src);
   CHECK(dst.x1 == 1);
   CHECK(dst.y1 == 2);
   CHECK(dst.x2 == 100);
@@ -88,8 +88,8 @@ TEST_CASE("cereal_types: BasicRect<int> toml round-trip", "[cereal_types]") {
 TEST_CASE("cereal_types: ControlState round-trip", "[cereal_types]") {
   Worm::ControlState src;
   src.istate = 0x5a;
-  Worm::ControlState bin = roundtripBinary(src);
-  Worm::ControlState toml = roundtripToml(src);
+  Worm::ControlState bin = RoundtripBinary(src);
+  Worm::ControlState toml = RoundtripToml(src);
   CHECK(bin.istate == src.istate);
   CHECK(toml.istate == src.istate);
 }
@@ -101,11 +101,11 @@ TEST_CASE("cereal_types: Ninjarope round-trip excludes anchor", "[cereal_types]"
   src.pos = fixedvec{1234, -5678};
   src.vel = fixedvec{-1, 2};
   src.length = 700;
-  src.curLen = 350;
+  src.cur_len = 350;
   // anchor is intentionally not serialized; verify dst.anchor stays default.
   src.anchor = reinterpret_cast<Worm*>(0xdeadbeef);
 
-  Ninjarope bin = roundtripBinary(src);
+  Ninjarope bin = RoundtripBinary(src);
   CHECK(bin.out == true);
   CHECK(bin.attached == true);
   CHECK(bin.pos.x == 1234);
@@ -113,7 +113,7 @@ TEST_CASE("cereal_types: Ninjarope round-trip excludes anchor", "[cereal_types]"
   CHECK(bin.vel.x == -1);
   CHECK(bin.vel.y == 2);
   CHECK(bin.length == 700);
-  CHECK(bin.curLen == 350);
+  CHECK(bin.cur_len == 350);
   CHECK(bin.anchor == nullptr);
 }
 
@@ -122,19 +122,19 @@ TEST_CASE("cereal_types: Viewport round-trip", "[cereal_types]") {
   src.x = 100;
   src.y = -50;
   src.shake = 7;
-  src.maxX = 320;
-  src.maxY = 200;
-  src.centerX = 160;
-  src.centerY = 100;
-  src.wormIdx = 1;
-  src.bannerY = -8;
+  src.max_x = 320;
+  src.max_y = 200;
+  src.center_x = 160;
+  src.center_y = 100;
+  src.worm_idx = 1;
+  src.banner_y = -8;
   src.rect = Rect{10, 20, 30, 40};
 
-  Viewport bin = roundtripBinary(src);
+  Viewport bin = RoundtripBinary(src);
   CHECK(bin.x == 100);
   CHECK(bin.y == -50);
   CHECK(bin.shake == 7);
-  CHECK(bin.wormIdx == 1);
+  CHECK(bin.worm_idx == 1);
   CHECK(bin.rect.x1 == 10);
   CHECK(bin.rect.y2 == 40);
 }
@@ -143,39 +143,39 @@ TEST_CASE("cereal_types: Worm round-trip excludes context fields", "[cereal_type
   Worm src;
   src.pos = fixedvec{1 << 16, 2 << 16};
   src.vel = fixedvec{-3, 4};
-  src.logicRespawn = IVec2{50, 60};
+  src.logic_respawn = IVec2{50, 60};
   src.health = 75;
   src.lives = 3;
   src.kills = 11;
-  src.aimingAngle = 90 << 16;
-  src.lastKilledByIdx = 2;
-  src.currentWeapon = 3;
+  src.aiming_angle = 90 << 16;
+  src.last_killed_by_idx = 2;
+  src.current_weapon = 3;
   src.direction = 1;
-  src.controlStates.istate = 0x42;
+  src.control_states.istate = 0x42;
   src.weapons[0].ammo = 99;
-  src.weapons[2].delayLeft = 17;
+  src.weapons[2].delay_left = 17;
   src.reacts[1] = 5;
   src.ninjarope.out = true;
   src.ninjarope.length = 500;
 
-  Worm bin = roundtripBinary(src);
+  Worm bin = RoundtripBinary(src);
   CHECK(bin.pos.x == src.pos.x);
   CHECK(bin.pos.y == src.pos.y);
-  CHECK(bin.logicRespawn.x == 50);
+  CHECK(bin.logic_respawn.x == 50);
   CHECK(bin.health == 75);
   CHECK(bin.lives == 3);
-  CHECK(bin.aimingAngle == 90 << 16);
-  CHECK(bin.lastKilledByIdx == 2);
-  CHECK(bin.currentWeapon == 3);
+  CHECK(bin.aiming_angle == 90 << 16);
+  CHECK(bin.last_killed_by_idx == 2);
+  CHECK(bin.current_weapon == 3);
   CHECK(bin.direction == 1);
-  CHECK(bin.controlStates.istate == 0x42);
+  CHECK(bin.control_states.istate == 0x42);
   CHECK(bin.weapons[0].ammo == 99);
-  CHECK(bin.weapons[2].delayLeft == 17);
+  CHECK(bin.weapons[2].delay_left == 17);
   CHECK(bin.reacts[1] == 5);
   CHECK(bin.ninjarope.out == true);
   CHECK(bin.ninjarope.length == 500);
 
-  Worm toml = roundtripToml(src);
+  Worm toml = RoundtripToml(src);
   CHECK(toml.pos.x == src.pos.x);
   CHECK(toml.health == 75);
   CHECK(toml.weapons[0].ammo == 99);
@@ -187,63 +187,63 @@ TEST_CASE("cereal_types: WormSettings round-trip", "[cereal_types]") {
   src.health = 150;
   src.controller = 1;
   src.name = "Hero";
-  src.randomName = false;
+  src.random_name = false;
   src.color = 3;
   src.rgb[0] = 10;
   src.rgb[1] = 20;
   src.rgb[2] = 30;
   src.weapons[0] = 5;
   src.weapons[4] = 7;
-  src.controls[WormSettings::Up] = 100u;
+  src.controls[WormSettings::kUp] = 100u;
 
-  WormSettings bin = roundtripBinary(src);
+  WormSettings bin = RoundtripBinary(src);
   CHECK(bin.health == 150);
   CHECK(bin.controller == 1);
   CHECK(bin.name == "Hero");
-  CHECK(bin.randomName == false);
+  CHECK(bin.random_name == false);
   CHECK(bin.color == 3);
   CHECK(bin.rgb[0] == 10);
   CHECK(bin.rgb[2] == 30);
   CHECK(bin.weapons[0] == 5);
   CHECK(bin.weapons[4] == 7);
-  CHECK(bin.controls[WormSettings::Up] == 100u);
+  CHECK(bin.controls[WormSettings::kUp] == 100u);
 
-  WormSettings toml = roundtripToml(src);
+  WormSettings toml = RoundtripToml(src);
   CHECK(toml.name == "Hero");
   CHECK(toml.weapons[4] == 7);
 }
 
 TEST_CASE("cereal_types: Settings round-trip with shared worm settings", "[cereal_types]") {
   Settings src;
-  src.maxBonuses = 12;
+  src.max_bonuses = 12;
   src.lives = 5;
   src.shadow = true;
   src.tc = "openliero";
-  src.weapTable[0] = 2;
-  src.weapTable[39] = 1;
-  for (int i = 0; i < Settings::NumWormSettings; ++i) {
-    src.wormSettings[i] = std::make_shared<WormSettings>();
-    src.wormSettings[i]->health = 100 + i;
-    src.wormSettings[i]->name = "worm" + std::to_string(i);
+  src.weap_table[0] = 2;
+  src.weap_table[39] = 1;
+  for (int i = 0; i < Settings::kNumWormSettings; ++i) {
+    src.worm_settings[i] = std::make_shared<WormSettings>();
+    src.worm_settings[i]->health = 100 + i;
+    src.worm_settings[i]->name = "worm" + std::to_string(i);
   }
 
-  Settings bin = roundtripBinary(src);
-  CHECK(bin.maxBonuses == 12);
+  Settings bin = RoundtripBinary(src);
+  CHECK(bin.max_bonuses == 12);
   CHECK(bin.lives == 5);
   CHECK(bin.shadow == true);
   CHECK(bin.tc == "openliero");
-  CHECK(bin.weapTable[0] == 2);
-  CHECK(bin.weapTable[39] == 1);
-  for (int i = 0; i < Settings::NumWormSettings; ++i) {
-    REQUIRE(bin.wormSettings[i] != nullptr);
-    CHECK(bin.wormSettings[i]->health == 100 + i);
-    CHECK(bin.wormSettings[i]->name == "worm" + std::to_string(i));
+  CHECK(bin.weap_table[0] == 2);
+  CHECK(bin.weap_table[39] == 1);
+  for (int i = 0; i < Settings::kNumWormSettings; ++i) {
+    REQUIRE(bin.worm_settings[i] != nullptr);
+    CHECK(bin.worm_settings[i]->health == 100 + i);
+    CHECK(bin.worm_settings[i]->name == "worm" + std::to_string(i));
   }
 }
 
 TEST_CASE("cereal_types: Color round-trip", "[cereal_types]") {
   Color src{10, 20, 30, 0};
-  Color bin = roundtripBinary(src);
+  Color bin = RoundtripBinary(src);
   CHECK(bin.r == 10);
   CHECK(bin.g == 20);
   CHECK(bin.b == 30);
@@ -256,7 +256,7 @@ TEST_CASE("cereal_types: Palette round-trip", "[cereal_types]") {
     src.entries[i].g = static_cast<uint8_t>(255 - i);
     src.entries[i].b = static_cast<uint8_t>(i ^ 0x55);
   }
-  Palette bin = roundtripBinary(src);
+  Palette bin = RoundtripBinary(src);
   for (int i = 0; i < 256; ++i) {
     CHECK(static_cast<int>(bin.entries[i].r) == i);
     CHECK(static_cast<int>(bin.entries[i].g) == 255 - i);
@@ -296,7 +296,7 @@ TEST_CASE("cereal_types: Level round-trip preserves data and palette", "[cereal_
 TEST_CASE("cereal_types: Rand round-trip preserves stream", "[cereal_types]") {
   Rand src(0xC0FFEEu);
   for (int i = 0; i < 10; ++i) src();
-  Rand bin = roundtripBinary(src);
+  Rand bin = RoundtripBinary(src);
   CHECK(bin == src);
   CHECK(bin() == src());
 }
@@ -304,18 +304,18 @@ TEST_CASE("cereal_types: Rand round-trip preserves stream", "[cereal_types]") {
 TEST_CASE("cereal_types: WormWeapon round-trip excludes type pointer", "[cereal_types]") {
   WormWeapon src;
   src.ammo = 17;
-  src.delayLeft = 23;
-  src.loadingLeft = 41;
+  src.delay_left = 23;
+  src.loading_left = 41;
 
   // WormWeapon's default ctor leaves `type` uninitialized; this test
   // only checks the fields cereal serialize() touches.
-  WormWeapon bin = roundtripBinary(src);
+  WormWeapon bin = RoundtripBinary(src);
   CHECK(bin.ammo == 17);
-  CHECK(bin.delayLeft == 23);
-  CHECK(bin.loadingLeft == 41);
+  CHECK(bin.delay_left == 23);
+  CHECK(bin.loading_left == 41);
 
-  WormWeapon toml = roundtripToml(src);
+  WormWeapon toml = RoundtripToml(src);
   CHECK(toml.ammo == 17);
-  CHECK(toml.delayLeft == 23);
-  CHECK(toml.loadingLeft == 41);
+  CHECK(toml.delay_left == 23);
+  CHECK(toml.loading_left == 41);
 }

--- a/src/tests/test_cp437.cpp
+++ b/src/tests/test_cp437.cpp
@@ -4,38 +4,38 @@
 
 TEST_CASE("cp437: ASCII round-trips unchanged") {
   for (uint8_t b = 0; b < 0x80; ++b) {
-    REQUIRE(cp437::byteToUnicode(b) == b);
-    REQUIRE(cp437::unicodeToByte(b) == b);
+    REQUIRE(cp437::ByteToUnicode(b) == b);
+    REQUIRE(cp437::UnicodeToByte(b) == b);
   }
 }
 
 TEST_CASE("cp437: known high-half mappings") {
   // The bug that motivated this module: CP437 0x84 is 'ä' (U+00E4),
   // not the U+0084 control character that the legacy tc.cfg stored.
-  REQUIRE(cp437::byteToUnicode(0x84) == U'ä');
-  REQUIRE(cp437::unicodeToByte(U'ä') == 0x84);
+  REQUIRE(cp437::ByteToUnicode(0x84) == U'ä');
+  REQUIRE(cp437::UnicodeToByte(U'ä') == 0x84);
 
-  REQUIRE(cp437::byteToUnicode(0x8F) == U'Å');
-  REQUIRE(cp437::unicodeToByte(U'Å') == 0x8F);
-  REQUIRE(cp437::byteToUnicode(0x99) == U'Ö');
-  REQUIRE(cp437::byteToUnicode(0xAB) == U'½');
+  REQUIRE(cp437::ByteToUnicode(0x8F) == U'Å');
+  REQUIRE(cp437::UnicodeToByte(U'Å') == 0x8F);
+  REQUIRE(cp437::ByteToUnicode(0x99) == U'Ö');
+  REQUIRE(cp437::ByteToUnicode(0xAB) == U'½');
 }
 
 TEST_CASE("cp437: unmapped codepoint returns -1") {
-  REQUIRE(cp437::unicodeToByte(0x1F600) == -1);  // emoji
-  REQUIRE(cp437::unicodeToByte(0x0084) == -1);   // C1 control char
+  REQUIRE(cp437::UnicodeToByte(0x1F600) == -1);  // emoji
+  REQUIRE(cp437::UnicodeToByte(0x0084) == -1);   // C1 control char
 }
 
 TEST_CASE("cp437: bytes -> UTF-8 -> codepoint round-trip") {
   std::string raw;
   for (int b = 0; b < 256; ++b) raw.push_back(static_cast<char>(b));
 
-  std::string utf8 = cp437::cp437BytesToUtf8(raw);
+  std::string utf8 = cp437::Cp437BytesToUtf8(raw);
 
   std::size_t i = 0;
   for (int b = 0; b < 256; ++b) {
-    char32_t cp = cp437::utf8DecodeNext(utf8.data(), utf8.size(), i);
-    REQUIRE(cp == cp437::byteToUnicode(static_cast<uint8_t>(b)));
+    char32_t cp = cp437::Utf8DecodeNext(utf8.data(), utf8.size(), i);
+    REQUIRE(cp == cp437::ByteToUnicode(static_cast<uint8_t>(b)));
   }
   REQUIRE(i == utf8.size());
 }
@@ -44,11 +44,11 @@ TEST_CASE("cp437: malformed UTF-8 yields replacement char") {
   // Lone continuation byte
   char buf[] = {'\x80'};
   std::size_t i = 0;
-  REQUIRE(cp437::utf8DecodeNext(buf, 1, i) == 0xFFFD);
+  REQUIRE(cp437::Utf8DecodeNext(buf, 1, i) == 0xFFFD);
   REQUIRE(i == 1);
 
   // Truncated 2-byte sequence
   char buf2[] = {'\xC3'};
   i = 0;
-  REQUIRE(cp437::utf8DecodeNext(buf2, 1, i) == 0xFFFD);
+  REQUIRE(cp437::Utf8DecodeNext(buf2, 1, i) == 0xFFFD);
 }

--- a/src/tests/test_determinism.cpp
+++ b/src/tests/test_determinism.cpp
@@ -112,7 +112,8 @@ TEST_CASE("Dual simulation produces identical state", "[determinism]") {
     uint32_t hash_a = HashGameState(*f.game_a);
     uint32_t hash_b = HashGameState(*f.game_b);
 
-    INFO("Desync at frame " << frame << ": hashA=0x" << std::hex << hash_a << " hashB=0x" << hash_b);
+    INFO("Desync at frame " << frame << ": hashA=0x" << std::hex << hash_a << " hashB=0x"
+                            << hash_b);
     REQUIRE(hash_a == hash_b);
   }
 }
@@ -232,7 +233,7 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
   common->load(std::move(tc_root));
 
   auto settings = std::make_shared<Settings>();
-  settings->lives = 50;       // Many lives = many death/respawn cycles
+  settings->lives = 50;        // Many lives = many death/respawn cycles
   settings->loading_time = 0;  // Fast weapon reload
   settings->random_level = true;
   settings->game_mode = Settings::kGmKillEmAll;
@@ -371,7 +372,8 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
           auto br_a = game_a.bobjects.Begin();
           auto br_b = game_b.bobjects.Begin();
           int idx = 0;
-          for (; br_a != game_a.bobjects.End() && br_b != game_b.bobjects.End(); ++br_a, ++br_b, ++idx) {
+          for (; br_a != game_a.bobjects.End() && br_b != game_b.bobjects.End();
+               ++br_a, ++br_b, ++idx) {
             if (br_a->pos.x != br_b->pos.x || br_a->pos.y != br_b->pos.y) {
               INFO("  BObject[" << idx << "] pos differs: A=(" << br_a->pos.x << "," << br_a->pos.y
                                 << ") B=(" << br_b->pos.x << "," << br_b->pos.y << ")");
@@ -452,8 +454,9 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
           r_b = game_b.sobjects.All();
           while ((s_a = r_a.Next()) && (s_b = r_b.Next())) {
             if (s_a->id != s_b->id || s_a->cur_frame != s_b->cur_frame) {
-              INFO("  SObject[" << idx << "] differs: A id=" << s_a->id << " frame=" << s_a->cur_frame
-                                << " B id=" << s_b->id << " frame=" << s_b->cur_frame);
+              INFO("  SObject[" << idx << "] differs: A id=" << s_a->id
+                                << " frame=" << s_a->cur_frame << " B id=" << s_b->id
+                                << " frame=" << s_b->cur_frame);
               sobjects_match = false;
               break;
             }
@@ -509,8 +512,8 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
 
         INFO("Desync at frame " << frame << " (seed=" << seed << ", deaths=" << death_count << ")"
                                 << "\n  RNG match=" << rng_match << " Worms match=" << worms_match
-                                << " Level match=" << level_match << "\n  NObjects: A=" << nobjects_a
-                                << " B=" << nobjects_b << " match=" << nobjects_match
+                                << " Level match=" << level_match << "\n  NObjects: A="
+                                << nobjects_a << " B=" << nobjects_b << " match=" << nobjects_match
                                 << "\n  BObjects: A=" << bobjects_a << " B=" << bobjects_b
                                 << " match=" << bobjects_match << "\n  WObjects: A=" << wobjects_a
                                 << " B=" << wobjects_b << " match=" << wobjects_match

--- a/src/tests/test_determinism.cpp
+++ b/src/tests/test_determinism.cpp
@@ -14,85 +14,85 @@
 struct DualGameFixture {
   std::shared_ptr<Common> common;
   std::shared_ptr<Settings> settings;
-  std::shared_ptr<SoundPlayer> soundPlayerA;
-  std::shared_ptr<SoundPlayer> soundPlayerB;
-  std::unique_ptr<Game> gameA;
-  std::unique_ptr<Game> gameB;
+  std::shared_ptr<SoundPlayer> sound_player_a;
+  std::shared_ptr<SoundPlayer> sound_player_b;
+  std::unique_ptr<Game> game_a;
+  std::unique_ptr<Game> game_b;
 
   DualGameFixture() {
-    precomputeTables();
+    PrecomputeTables();
 
     common = std::make_shared<Common>();
-    FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-    common->load(std::move(tcRoot));
+    FsNode tc_root(FsNode("data") / "TC" / "openliero");
+    common->load(std::move(tc_root));
 
     settings = std::make_shared<Settings>();
     // Use default settings but ensure deterministic setup
     settings->lives = 10;
-    settings->loadingTime = 0;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
 
-    soundPlayerA = std::make_shared<NullSoundPlayer>();
-    soundPlayerB = std::make_shared<NullSoundPlayer>();
+    sound_player_a = std::make_shared<NullSoundPlayer>();
+    sound_player_b = std::make_shared<NullSoundPlayer>();
 
-    gameA = std::make_unique<Game>(common, settings, soundPlayerA);
-    gameB = std::make_unique<Game>(common, settings, soundPlayerB);
+    game_a = std::make_unique<Game>(common, settings, sound_player_a);
+    game_b = std::make_unique<Game>(common, settings, sound_player_b);
 
     // Seed both with the same value
     uint32_t seed = 42;
-    gameA->rand.seed(seed);
-    gameB->rand.seed(seed);
+    game_a->rand.Seed(seed);
+    game_b->rand.Seed(seed);
 
     // Create identical worms for both games
     for (int idx = 0; idx < 2; ++idx) {
-      auto wA = std::make_shared<Worm>();
-      wA->settings = settings->wormSettings[idx];
-      wA->health = wA->settings->health;
-      wA->index = idx;
-      wA->statsX = idx == 0 ? 0 : 218;
+      auto w_a = std::make_shared<Worm>();
+      w_a->settings = settings->worm_settings[idx];
+      w_a->health = w_a->settings->health;
+      w_a->index = idx;
+      w_a->stats_x = idx == 0 ? 0 : 218;
 
-      auto wB = std::make_shared<Worm>();
-      wB->settings = settings->wormSettings[idx];
-      wB->health = wB->settings->health;
-      wB->index = idx;
-      wB->statsX = idx == 0 ? 0 : 218;
+      auto w_b = std::make_shared<Worm>();
+      w_b->settings = settings->worm_settings[idx];
+      w_b->health = w_b->settings->health;
+      w_b->index = idx;
+      w_b->stats_x = idx == 0 ? 0 : 218;
 
-      gameA->addWorm(wA);
-      gameB->addWorm(wB);
+      game_a->AddWorm(w_a);
+      game_b->AddWorm(w_b);
     }
 
     // Add viewports (needed for processFrame's viewport logic)
-    gameA->addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    gameA->addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-    gameB->addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    gameB->addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_a->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game_a->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_b->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game_b->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
     // Generate levels with the same RNG state
-    gameA->level.generateFromSettings(*common, *settings, gameA->rand);
-    gameB->level.generateFromSettings(*common, *settings, gameB->rand);
+    game_a->level.GenerateFromSettings(*common, *settings, game_a->rand);
+    game_b->level.GenerateFromSettings(*common, *settings, game_b->rand);
 
     // Initialize weapons for all worms
-    for (auto const& w : gameA->worms) w->initWeapons(*gameA);
-    for (auto const& w : gameB->worms) w->initWeapons(*gameB);
+    for (auto const& w : game_a->worms) w->InitWeapons(*game_a);
+    for (auto const& w : game_b->worms) w->InitWeapons(*game_b);
 
     // Start games
-    gameA->paused = false;
-    gameB->paused = false;
-    gameA->startGame();
-    gameB->startGame();
+    game_a->paused = false;
+    game_b->paused = false;
+    game_a->StartGame();
+    game_b->StartGame();
 
     // Reset worms into game
-    gameA->resetWorms();
-    gameB->resetWorms();
+    game_a->ResetWorms();
+    game_b->ResetWorms();
   }
 
   // Apply identical random inputs to both games using a separate PRNG
-  void applyRandomInputs(Rand& inputRng) {
+  void ApplyRandomInputs(Rand& input_rng) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = inputRng() & 0x7f;  // 7 control bits
-      gameA->worms[idx]->controlStates.unpack(input);
-      gameB->worms[idx]->controlStates.unpack(input);
+      uint32_t input = input_rng() & 0x7f;  // 7 control bits
+      game_a->worms[idx]->control_states.Unpack(input);
+      game_b->worms[idx]->control_states.Unpack(input);
     }
   }
 };
@@ -100,20 +100,20 @@ struct DualGameFixture {
 TEST_CASE("Dual simulation produces identical state", "[determinism]") {
   DualGameFixture f;
 
-  Rand inputRng(12345);
+  Rand input_rng(12345);
 
-  constexpr int NUM_FRAMES = 1000;
+  constexpr int kNumFrames = 1000;
 
-  for (int frame = 0; frame < NUM_FRAMES; ++frame) {
-    f.applyRandomInputs(inputRng);
-    f.gameA->processFrame();
-    f.gameB->processFrame();
+  for (int frame = 0; frame < kNumFrames; ++frame) {
+    f.ApplyRandomInputs(input_rng);
+    f.game_a->ProcessFrame();
+    f.game_b->ProcessFrame();
 
-    uint32_t hashA = hashGameState(*f.gameA);
-    uint32_t hashB = hashGameState(*f.gameB);
+    uint32_t hash_a = HashGameState(*f.game_a);
+    uint32_t hash_b = HashGameState(*f.game_b);
 
-    INFO("Desync at frame " << frame << ": hashA=0x" << std::hex << hashA << " hashB=0x" << hashB);
-    REQUIRE(hashA == hashB);
+    INFO("Desync at frame " << frame << ": hashA=0x" << std::hex << hash_a << " hashB=0x" << hash_b);
+    REQUIRE(hash_a == hash_b);
   }
 }
 
@@ -123,16 +123,16 @@ TEST_CASE("Simulation is reproducible across runs", "[determinism]") {
 
   for (int run = 0; run < 2; ++run) {
     DualGameFixture f;
-    Rand inputRng(99999);
+    Rand input_rng(99999);
 
-    constexpr int NUM_FRAMES = 500;
+    constexpr int kNumFrames = 500;
 
-    for (int frame = 0; frame < NUM_FRAMES; ++frame) {
-      f.applyRandomInputs(inputRng);
-      f.gameA->processFrame();
+    for (int frame = 0; frame < kNumFrames; ++frame) {
+      f.ApplyRandomInputs(input_rng);
+      f.game_a->ProcessFrame();
     }
 
-    uint32_t h = hashGameState(*f.gameA);
+    uint32_t h = HashGameState(*f.game_a);
     if (run == 0)
       hash1 = h;
     else
@@ -145,19 +145,19 @@ TEST_CASE("Simulation is reproducible across runs", "[determinism]") {
 TEST_CASE("Same inputs produce same state regardless of construction order", "[determinism]") {
   // Construct games in different order but with same seed — should be identical
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
 
-  precomputeTables();
+  PrecomputeTables();
 
   auto settings = std::make_shared<Settings>();
-  settings->randomLevel = true;
+  settings->random_level = true;
 
   auto sp = std::make_shared<NullSoundPlayer>();
 
   // Game constructed first
   Game game1(common, settings, sp);
-  game1.rand.seed(777);
+  game1.rand.Seed(777);
 
   // Game constructed after some unrelated work
   volatile int dummy = 0;
@@ -165,56 +165,56 @@ TEST_CASE("Same inputs produce same state regardless of construction order", "[d
   (void)dummy;
 
   Game game2(common, settings, std::make_shared<NullSoundPlayer>());
-  game2.rand.seed(777);
+  game2.rand.Seed(777);
 
   // Same worm setup
   for (int idx = 0; idx < 2; ++idx) {
     auto w1 = std::make_shared<Worm>();
-    w1->settings = settings->wormSettings[idx];
+    w1->settings = settings->worm_settings[idx];
     w1->health = w1->settings->health;
     w1->index = idx;
-    game1.addWorm(w1);
+    game1.AddWorm(w1);
 
     auto w2 = std::make_shared<Worm>();
-    w2->settings = settings->wormSettings[idx];
+    w2->settings = settings->worm_settings[idx];
     w2->health = w2->settings->health;
     w2->index = idx;
-    game2.addWorm(w2);
+    game2.AddWorm(w2);
   }
 
-  game1.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game1.addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-  game2.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game2.addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+  game1.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+  game1.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+  game2.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+  game2.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-  game1.level.generateFromSettings(*common, *settings, game1.rand);
-  game2.level.generateFromSettings(*common, *settings, game2.rand);
+  game1.level.GenerateFromSettings(*common, *settings, game1.rand);
+  game2.level.GenerateFromSettings(*common, *settings, game2.rand);
 
-  for (auto const& w : game1.worms) w->initWeapons(game1);
-  for (auto const& w : game2.worms) w->initWeapons(game2);
+  for (auto const& w : game1.worms) w->InitWeapons(game1);
+  for (auto const& w : game2.worms) w->InitWeapons(game2);
 
   game1.paused = false;
   game2.paused = false;
-  game1.startGame();
-  game2.startGame();
-  game1.resetWorms();
-  game2.resetWorms();
+  game1.StartGame();
+  game2.StartGame();
+  game1.ResetWorms();
+  game2.ResetWorms();
 
-  Rand inputRng1(55555);
-  Rand inputRng2(55555);
+  Rand input_rng1(55555);
+  Rand input_rng2(55555);
 
   for (int frame = 0; frame < 300; ++frame) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input1 = inputRng1() & 0x7f;
-      uint32_t input2 = inputRng2() & 0x7f;
-      game1.worms[idx]->controlStates.unpack(input1);
-      game2.worms[idx]->controlStates.unpack(input2);
+      uint32_t input1 = input_rng1() & 0x7f;
+      uint32_t input2 = input_rng2() & 0x7f;
+      game1.worms[idx]->control_states.Unpack(input1);
+      game2.worms[idx]->control_states.Unpack(input2);
     }
-    game1.processFrame();
-    game2.processFrame();
+    game1.ProcessFrame();
+    game2.ProcessFrame();
   }
 
-  REQUIRE(hashGameState(game1) == hashGameState(game2));
+  REQUIRE(HashGameState(game1) == HashGameState(game2));
 }
 
 TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
@@ -225,177 +225,177 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
   // This targets the known desync risk in beginRespawn() where the RNG-based
   // position search depends on level pixel state.
 
-  precomputeTables();
+  PrecomputeTables();
 
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
 
   auto settings = std::make_shared<Settings>();
   settings->lives = 50;       // Many lives = many death/respawn cycles
-  settings->loadingTime = 0;  // Fast weapon reload
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;  // Fast weapon reload
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   settings->blood = 100;
 
   // Use multiple seeds to cover different level layouts
   uint32_t seeds[] = {42, 1337, 99999, 0xDEAD, 0xBEEF};
 
   for (uint32_t seed : seeds) {
-    auto spA = std::make_shared<NullSoundPlayer>();
-    auto spB = std::make_shared<NullSoundPlayer>();
+    auto sp_a = std::make_shared<NullSoundPlayer>();
+    auto sp_b = std::make_shared<NullSoundPlayer>();
 
-    Game gameA(common, settings, spA);
-    Game gameB(common, settings, spB);
+    Game game_a(common, settings, sp_a);
+    Game game_b(common, settings, sp_b);
 
-    gameA.rand.seed(seed);
-    gameB.rand.seed(seed);
+    game_a.rand.Seed(seed);
+    game_b.rand.Seed(seed);
 
     for (int idx = 0; idx < 2; ++idx) {
-      auto wA = std::make_shared<Worm>();
-      wA->settings = settings->wormSettings[idx];
-      wA->health = 25;  // Low health for quick deaths
-      wA->index = idx;
-      wA->statsX = idx == 0 ? 0 : 218;
-      gameA.addWorm(wA);
+      auto w_a = std::make_shared<Worm>();
+      w_a->settings = settings->worm_settings[idx];
+      w_a->health = 25;  // Low health for quick deaths
+      w_a->index = idx;
+      w_a->stats_x = idx == 0 ? 0 : 218;
+      game_a.AddWorm(w_a);
 
-      auto wB = std::make_shared<Worm>();
-      wB->settings = settings->wormSettings[idx];
-      wB->health = 25;
-      wB->index = idx;
-      wB->statsX = idx == 0 ? 0 : 218;
-      gameB.addWorm(wB);
+      auto w_b = std::make_shared<Worm>();
+      w_b->settings = settings->worm_settings[idx];
+      w_b->health = 25;
+      w_b->index = idx;
+      w_b->stats_x = idx == 0 ? 0 : 218;
+      game_b.AddWorm(w_b);
     }
 
-    gameA.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    gameA.addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-    gameB.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    gameB.addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_a.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game_a.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_b.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game_b.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-    gameA.level.generateFromSettings(*common, *settings, gameA.rand);
-    gameB.level.generateFromSettings(*common, *settings, gameB.rand);
+    game_a.level.GenerateFromSettings(*common, *settings, game_a.rand);
+    game_b.level.GenerateFromSettings(*common, *settings, game_b.rand);
 
-    for (auto const& w : gameA.worms) w->initWeapons(gameA);
-    for (auto const& w : gameB.worms) w->initWeapons(gameB);
+    for (auto const& w : game_a.worms) w->InitWeapons(game_a);
+    for (auto const& w : game_b.worms) w->InitWeapons(game_b);
 
-    gameA.paused = false;
-    gameB.paused = false;
-    gameA.startGame();
-    gameB.startGame();
-    gameA.resetWorms();
-    gameB.resetWorms();
+    game_a.paused = false;
+    game_b.paused = false;
+    game_a.StartGame();
+    game_b.StartGame();
+    game_a.ResetWorms();
+    game_b.ResetWorms();
 
-    Rand inputRng(seed * 2654435761u + 1);
+    Rand input_rng(seed * 2654435761u + 1);
 
-    constexpr int NUM_FRAMES = 5000;
-    int deathCount = 0;
+    constexpr int kNumFrames = 5000;
+    int death_count = 0;
 
-    for (int frame = 0; frame < NUM_FRAMES; ++frame) {
+    for (int frame = 0; frame < kNumFrames; ++frame) {
       for (int idx = 0; idx < 2; ++idx) {
-        uint32_t input = inputRng() & 0x7f;
+        uint32_t input = input_rng() & 0x7f;
         // Bias toward combat: 60% chance fire is held
-        if ((inputRng() % 10) < 6) input |= (1 << 4);  // Fire bit
+        if ((input_rng() % 10) < 6) input |= (1 << 4);  // Fire bit
         // 40% chance of movement toward opponent
-        if ((inputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));  // Left/Right toward other
+        if ((input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));  // Left/Right toward other
 
-        gameA.worms[idx]->controlStates.unpack(input);
-        gameB.worms[idx]->controlStates.unpack(input);
+        game_a.worms[idx]->control_states.Unpack(input);
+        game_b.worms[idx]->control_states.Unpack(input);
       }
 
-      gameA.processFrame();
-      gameB.processFrame();
+      game_a.ProcessFrame();
+      game_b.ProcessFrame();
 
       // Track deaths for info output — killedTimer is set to 150 on death,
       // then decremented each frame, so 149 means "just died this frame"
-      for (auto const& w : gameA.worms) {
-        if (!w->visible && w->killedTimer == Worm::KilledTimerInitial - 1) ++deathCount;
+      for (auto const& w : game_a.worms) {
+        if (!w->visible && w->killed_timer == Worm::kKilledTimerInitial - 1) ++death_count;
       }
 
       // Check state every frame
-      uint32_t hashA = hashGameState(gameA);
-      uint32_t hashB = hashGameState(gameB);
+      uint32_t hash_a = HashGameState(game_a);
+      uint32_t hash_b = HashGameState(game_b);
 
-      if (hashA != hashB) {
+      if (hash_a != hash_b) {
         // Identify which component diverged
-        uint32_t rngA = gameA.rand.last;
-        uint32_t rngB = gameB.rand.last;
-        bool rngMatch = (rngA == rngB);
+        uint32_t rng_a = game_a.rand.last;
+        uint32_t rng_b = game_b.rand.last;
+        bool rng_match = (rng_a == rng_b);
 
-        bool wormsMatch = true;
-        for (size_t i = 0; i < gameA.worms.size(); ++i) {
-          if (gameA.worms[i]->pos.x != gameB.worms[i]->pos.x ||
-              gameA.worms[i]->pos.y != gameB.worms[i]->pos.y ||
-              gameA.worms[i]->visible != gameB.worms[i]->visible ||
-              gameA.worms[i]->health != gameB.worms[i]->health ||
-              gameA.worms[i]->killedTimer != gameB.worms[i]->killedTimer) {
-            wormsMatch = false;
+        bool worms_match = true;
+        for (size_t i = 0; i < game_a.worms.size(); ++i) {
+          if (game_a.worms[i]->pos.x != game_b.worms[i]->pos.x ||
+              game_a.worms[i]->pos.y != game_b.worms[i]->pos.y ||
+              game_a.worms[i]->visible != game_b.worms[i]->visible ||
+              game_a.worms[i]->health != game_b.worms[i]->health ||
+              game_a.worms[i]->killed_timer != game_b.worms[i]->killed_timer) {
+            worms_match = false;
             break;
           }
         }
 
         // Check level pixels
-        bool levelMatch = true;
-        for (int i = 0; i < gameA.level.width * gameA.level.height; ++i) {
-          if (gameA.level.data[i] != gameB.level.data[i]) {
-            levelMatch = false;
+        bool level_match = true;
+        for (int i = 0; i < game_a.level.width * game_a.level.height; ++i) {
+          if (game_a.level.data[i] != game_b.level.data[i]) {
+            level_match = false;
             break;
           }
         }
 
         // Check object counts
-        int nobjectsA = 0, nobjectsB = 0;
+        int nobjects_a = 0, nobjects_b = 0;
         {
-          auto r = gameA.nobjects.all();
+          auto r = game_a.nobjects.All();
           NObject* n;
-          while ((n = r.next())) ++nobjectsA;
+          while ((n = r.Next())) ++nobjects_a;
         }
         {
-          auto r = gameB.nobjects.all();
+          auto r = game_b.nobjects.All();
           NObject* n;
-          while ((n = r.next())) ++nobjectsB;
+          while ((n = r.Next())) ++nobjects_b;
         }
 
-        int bobjectsA = 0, bobjectsB = 0;
+        int bobjects_a = 0, bobjects_b = 0;
         {
-          auto br = gameA.bobjects.begin();
-          for (; br != gameA.bobjects.end(); ++br) ++bobjectsA;
+          auto br = game_a.bobjects.Begin();
+          for (; br != game_a.bobjects.End(); ++br) ++bobjects_a;
         }
         {
-          auto br = gameB.bobjects.begin();
-          for (; br != gameB.bobjects.end(); ++br) ++bobjectsB;
+          auto br = game_b.bobjects.Begin();
+          for (; br != game_b.bobjects.End(); ++br) ++bobjects_b;
         }
 
         // Deep compare BObjects
-        bool bobjectsMatch = true;
+        bool bobjects_match = true;
         {
-          auto brA = gameA.bobjects.begin();
-          auto brB = gameB.bobjects.begin();
+          auto br_a = game_a.bobjects.Begin();
+          auto br_b = game_b.bobjects.Begin();
           int idx = 0;
-          for (; brA != gameA.bobjects.end() && brB != gameB.bobjects.end(); ++brA, ++brB, ++idx) {
-            if (brA->pos.x != brB->pos.x || brA->pos.y != brB->pos.y) {
-              INFO("  BObject[" << idx << "] pos differs: A=(" << brA->pos.x << "," << brA->pos.y
-                                << ") B=(" << brB->pos.x << "," << brB->pos.y << ")");
-              bobjectsMatch = false;
+          for (; br_a != game_a.bobjects.End() && br_b != game_b.bobjects.End(); ++br_a, ++br_b, ++idx) {
+            if (br_a->pos.x != br_b->pos.x || br_a->pos.y != br_b->pos.y) {
+              INFO("  BObject[" << idx << "] pos differs: A=(" << br_a->pos.x << "," << br_a->pos.y
+                                << ") B=(" << br_b->pos.x << "," << br_b->pos.y << ")");
+              bobjects_match = false;
               break;
             }
           }
         }
 
         // Deep compare NObjects
-        bool nobjectsMatch = true;
+        bool nobjects_match = true;
         {
-          auto rA = gameA.nobjects.all();
-          auto rB = gameB.nobjects.all();
-          NObject *nA, *nB;
+          auto r_a = game_a.nobjects.All();
+          auto r_b = game_b.nobjects.All();
+          NObject *n_a, *n_b;
           int idx = 0;
-          while ((nA = rA.next()) && (nB = rB.next())) {
-            if (nA->pos.x != nB->pos.x || nA->pos.y != nB->pos.y || nA->vel.x != nB->vel.x ||
-                nA->vel.y != nB->vel.y) {
-              INFO("  NObject[" << idx << "] differs: A pos=(" << nA->pos.x << "," << nA->pos.y
-                                << ") vel=(" << nA->vel.x << "," << nA->vel.y << ") B pos=("
-                                << nB->pos.x << "," << nB->pos.y << ") vel=(" << nB->vel.x << ","
-                                << nB->vel.y << ")");
-              nobjectsMatch = false;
+          while ((n_a = r_a.Next()) && (n_b = r_b.Next())) {
+            if (n_a->pos.x != n_b->pos.x || n_a->pos.y != n_b->pos.y || n_a->vel.x != n_b->vel.x ||
+                n_a->vel.y != n_b->vel.y) {
+              INFO("  NObject[" << idx << "] differs: A pos=(" << n_a->pos.x << "," << n_a->pos.y
+                                << ") vel=(" << n_a->vel.x << "," << n_a->vel.y << ") B pos=("
+                                << n_b->pos.x << "," << n_b->pos.y << ") vel=(" << n_b->vel.x << ","
+                                << n_b->vel.y << ")");
+              nobjects_match = false;
               break;
             }
             ++idx;
@@ -403,31 +403,31 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
         }
 
         // Deep compare WObjects
-        bool wobjectsMatch = true;
-        int wobjectsA = 0, wobjectsB = 0;
+        bool wobjects_match = true;
+        int wobjects_a = 0, wobjects_b = 0;
         {
-          auto rA = gameA.wobjects.all();
-          auto rB = gameB.wobjects.all();
-          WObject *wA, *wB;
+          auto r_a = game_a.wobjects.All();
+          auto r_b = game_b.wobjects.All();
+          WObject *w_a, *w_b;
           int idx = 0;
-          while ((wA = rA.next())) {
-            ++wobjectsA;
-            (void)wA;
+          while ((w_a = r_a.Next())) {
+            ++wobjects_a;
+            (void)w_a;
           }
-          while ((wB = rB.next())) {
-            ++wobjectsB;
-            (void)wB;
+          while ((w_b = r_b.Next())) {
+            ++wobjects_b;
+            (void)w_b;
           }
-          rA = gameA.wobjects.all();
-          rB = gameB.wobjects.all();
-          while ((wA = rA.next()) && (wB = rB.next())) {
-            if (wA->pos.x != wB->pos.x || wA->pos.y != wB->pos.y || wA->vel.x != wB->vel.x ||
-                wA->vel.y != wB->vel.y || wA->curFrame != wB->curFrame ||
-                wA->timeLeft != wB->timeLeft) {
-              INFO("  WObject[" << idx << "] differs: A pos=(" << wA->pos.x << "," << wA->pos.y
-                                << ") tl=" << wA->timeLeft << " B pos=(" << wB->pos.x << ","
-                                << wB->pos.y << ") tl=" << wB->timeLeft);
-              wobjectsMatch = false;
+          r_a = game_a.wobjects.All();
+          r_b = game_b.wobjects.All();
+          while ((w_a = r_a.Next()) && (w_b = r_b.Next())) {
+            if (w_a->pos.x != w_b->pos.x || w_a->pos.y != w_b->pos.y || w_a->vel.x != w_b->vel.x ||
+                w_a->vel.y != w_b->vel.y || w_a->cur_frame != w_b->cur_frame ||
+                w_a->time_left != w_b->time_left) {
+              INFO("  WObject[" << idx << "] differs: A pos=(" << w_a->pos.x << "," << w_a->pos.y
+                                << ") tl=" << w_a->time_left << " B pos=(" << w_b->pos.x << ","
+                                << w_b->pos.y << ") tl=" << w_b->time_left);
+              wobjects_match = false;
               break;
             }
             ++idx;
@@ -435,26 +435,26 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
         }
 
         // Deep compare SObjects
-        bool sobjectsMatch = true;
-        int sobjectsA = 0, sobjectsB = 0;
+        bool sobjects_match = true;
+        int sobjects_a = 0, sobjects_b = 0;
         {
-          auto rA = gameA.sobjects.all();
-          auto rB = gameB.sobjects.all();
-          SObject *sA, *sB;
+          auto r_a = game_a.sobjects.All();
+          auto r_b = game_b.sobjects.All();
+          SObject *s_a, *s_b;
           int idx = 0;
-          while ((sA = rA.next())) {
-            ++sobjectsA;
+          while ((s_a = r_a.Next())) {
+            ++sobjects_a;
           }
-          while ((sB = rB.next())) {
-            ++sobjectsB;
+          while ((s_b = r_b.Next())) {
+            ++sobjects_b;
           }
-          rA = gameA.sobjects.all();
-          rB = gameB.sobjects.all();
-          while ((sA = rA.next()) && (sB = rB.next())) {
-            if (sA->id != sB->id || sA->curFrame != sB->curFrame) {
-              INFO("  SObject[" << idx << "] differs: A id=" << sA->id << " frame=" << sA->curFrame
-                                << " B id=" << sB->id << " frame=" << sB->curFrame);
-              sobjectsMatch = false;
+          r_a = game_a.sobjects.All();
+          r_b = game_b.sobjects.All();
+          while ((s_a = r_a.Next()) && (s_b = r_b.Next())) {
+            if (s_a->id != s_b->id || s_a->cur_frame != s_b->cur_frame) {
+              INFO("  SObject[" << idx << "] differs: A id=" << s_a->id << " frame=" << s_a->cur_frame
+                                << " B id=" << s_b->id << " frame=" << s_b->cur_frame);
+              sobjects_match = false;
               break;
             }
             ++idx;
@@ -462,26 +462,26 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
         }
 
         // Deep compare Bonuses
-        bool bonusesMatch = true;
-        int bonusesA = 0, bonusesB = 0;
+        bool bonuses_match = true;
+        int bonuses_a = 0, bonuses_b = 0;
         {
-          auto rA = gameA.bonuses.all();
-          auto rB = gameB.bonuses.all();
-          Bonus *bA, *bB;
+          auto r_a = game_a.bonuses.All();
+          auto r_b = game_b.bonuses.All();
+          Bonus *b_a, *b_b;
           int idx = 0;
-          while ((bA = rA.next())) {
-            ++bonusesA;
+          while ((b_a = r_a.Next())) {
+            ++bonuses_a;
           }
-          while ((bB = rB.next())) {
-            ++bonusesB;
+          while ((b_b = r_b.Next())) {
+            ++bonuses_b;
           }
-          rA = gameA.bonuses.all();
-          rB = gameB.bonuses.all();
-          while ((bA = rA.next()) && (bB = rB.next())) {
-            if (bA->x != bB->x || bA->y != bB->y || bA->timer != bB->timer ||
-                bA->weapon != bB->weapon) {
+          r_a = game_a.bonuses.All();
+          r_b = game_b.bonuses.All();
+          while ((b_a = r_a.Next()) && (b_b = r_b.Next())) {
+            if (b_a->x != b_b->x || b_a->y != b_b->y || b_a->timer != b_b->timer ||
+                b_a->weapon != b_b->weapon) {
               INFO("  Bonus[" << idx << "] differs");
-              bonusesMatch = false;
+              bonuses_match = false;
               break;
             }
             ++idx;
@@ -489,44 +489,44 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
         }
 
         // Deep compare worm weapons
-        bool weaponsMatch = true;
-        for (size_t wi = 0; wi < gameA.worms.size(); ++wi) {
-          auto const& wA = gameA.worms[wi];
-          auto const& wB = gameB.worms[wi];
+        bool weapons_match = true;
+        for (size_t wi = 0; wi < game_a.worms.size(); ++wi) {
+          auto const& w_a = game_a.worms[wi];
+          auto const& w_b = game_b.worms[wi];
           for (int i = 0; i < NUM_WEAPONS; ++i) {
-            if (wA->weapons[i].ammo != wB->weapons[i].ammo ||
-                wA->weapons[i].delayLeft != wB->weapons[i].delayLeft ||
-                wA->weapons[i].loadingLeft != wB->weapons[i].loadingLeft) {
+            if (w_a->weapons[i].ammo != w_b->weapons[i].ammo ||
+                w_a->weapons[i].delay_left != w_b->weapons[i].delay_left ||
+                w_a->weapons[i].loading_left != w_b->weapons[i].loading_left) {
               INFO("  Worm[" << wi << "].weapons[" << i << "] differs: A ammo="
-                             << wA->weapons[i].ammo << " delay=" << wA->weapons[i].delayLeft
-                             << " loading=" << wA->weapons[i].loadingLeft << " B ammo="
-                             << wB->weapons[i].ammo << " delay=" << wB->weapons[i].delayLeft
-                             << " loading=" << wB->weapons[i].loadingLeft);
-              weaponsMatch = false;
+                             << w_a->weapons[i].ammo << " delay=" << w_a->weapons[i].delay_left
+                             << " loading=" << w_a->weapons[i].loading_left << " B ammo="
+                             << w_b->weapons[i].ammo << " delay=" << w_b->weapons[i].delay_left
+                             << " loading=" << w_b->weapons[i].loading_left);
+              weapons_match = false;
             }
           }
         }
 
-        INFO("Desync at frame " << frame << " (seed=" << seed << ", deaths=" << deathCount << ")"
-                                << "\n  RNG match=" << rngMatch << " Worms match=" << wormsMatch
-                                << " Level match=" << levelMatch << "\n  NObjects: A=" << nobjectsA
-                                << " B=" << nobjectsB << " match=" << nobjectsMatch
-                                << "\n  BObjects: A=" << bobjectsA << " B=" << bobjectsB
-                                << " match=" << bobjectsMatch << "\n  WObjects: A=" << wobjectsA
-                                << " B=" << wobjectsB << " match=" << wobjectsMatch
-                                << "\n  SObjects: A=" << sobjectsA << " B=" << sobjectsB
-                                << " match=" << sobjectsMatch << "\n  Bonuses: A=" << bonusesA
-                                << " B=" << bonusesB << " match=" << bonusesMatch
-                                << "\n  Weapons match=" << weaponsMatch << "\n  hashA=0x"
-                                << std::hex << hashA << " hashB=0x" << hashB);
-        REQUIRE(hashA == hashB);
+        INFO("Desync at frame " << frame << " (seed=" << seed << ", deaths=" << death_count << ")"
+                                << "\n  RNG match=" << rng_match << " Worms match=" << worms_match
+                                << " Level match=" << level_match << "\n  NObjects: A=" << nobjects_a
+                                << " B=" << nobjects_b << " match=" << nobjects_match
+                                << "\n  BObjects: A=" << bobjects_a << " B=" << bobjects_b
+                                << " match=" << bobjects_match << "\n  WObjects: A=" << wobjects_a
+                                << " B=" << wobjects_b << " match=" << wobjects_match
+                                << "\n  SObjects: A=" << sobjects_a << " B=" << sobjects_b
+                                << " match=" << sobjects_match << "\n  Bonuses: A=" << bonuses_a
+                                << " B=" << bonuses_b << " match=" << bonuses_match
+                                << "\n  Weapons match=" << weapons_match << "\n  hashA=0x"
+                                << std::hex << hash_a << " hashB=0x" << hash_b);
+        REQUIRE(hash_a == hash_b);
       }
 
       // Stop if game is over
-      if (gameA.isGameOver()) break;
+      if (game_a.IsGameOver()) break;
     }
 
-    INFO("Seed " << seed << " completed: " << deathCount << " deaths observed");
-    REQUIRE(deathCount > 0);  // Sanity check: we actually tested deaths
+    INFO("Seed " << seed << " completed: " << death_count << " deaths observed");
+    REQUIRE(death_count > 0);  // Sanity check: we actually tested deaths
   }
 }

--- a/src/tests/test_frame_advantage.cpp
+++ b/src/tests/test_frame_advantage.cpp
@@ -22,17 +22,17 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
@@ -42,68 +42,68 @@ std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
 // guard against a vacuously-passing test (zero stalls would mean the
 // delays were symmetric enough that the threshold never fired).
 struct AsymmetricRun {
-  int maxAbsGap;
-  uint64_t stallsA;
-  uint64_t stallsB;
+  int max_abs_gap;
+  uint64_t stalls_a;
+  uint64_t stalls_b;
 };
 
-AsymmetricRun runAsymmetric(int dAB, int dBA, int ticks) {
-  auto [common, settings] = makeEnv();
+AsymmetricRun RunAsymmetric(int d_ab, int d_ba, int ticks) {
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
-  a->game.rand.seed(0xBEEF);
-  b->game.rand.seed(0xBEEF);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
+  a->game.rand.Seed(0xBEEF);
+  b->game.rand.Seed(0xBEEF);
 
   // Asymmetric one-way delays modelled by two separate "transports":
   // one for A→B (fixed delay dAB), one for B→A (fixed delay dBA).
   // Loss/dup/jitter are off so the test isolates the time-sync feedback.
-  rollback_test::JitterTransport tAB({0x1111, dAB, dAB, 0.0, 0.0});
-  rollback_test::JitterTransport tBA({0x2222, dBA, dBA, 0.0, 0.0});
+  rollback_test::JitterTransport t_ab({0x1111, d_ab, d_ab, 0.0, 0.0});
+  rollback_test::JitterTransport t_ba({0x2222, d_ba, d_ba, 0.0, 0.0});
 
-  a->setInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    tAB.sendAToB(gen, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    t_ab.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    tBA.sendAToB(gen, bf, c, in, lf);  // B's outbound rides the B→A pipe
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    t_ba.SendAToB(gen, bf, c, in, lf);  // B's outbound rides the B→A pipe
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
-  auto deliverB = [&](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_b = [&](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverA = [&](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_a = [&](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverNoop = [&](uint8_t, uint32_t, uint8_t, uint8_t const*, uint32_t) {};
+  auto deliver_noop = [&](uint8_t, uint32_t, uint8_t, uint8_t const*, uint32_t) {};
 
-  int maxAbsGap = 0;
+  int max_abs_gap = 0;
   for (int i = 0; i < ticks; ++i) {
-    a->setLocalControlState(0);
-    b->setLocalControlState(0);
-    a->process();
-    b->process();
+    a->SetLocalControlState(0);
+    b->SetLocalControlState(0);
+    a->Process();
+    b->Process();
     // tAB pipes A→B inputs only; the "B leg" of its tick stays a no-op.
-    tAB.tick(deliverNoop, deliverB);
-    tBA.tick(deliverNoop, deliverA);
+    t_ab.Tick(deliver_noop, deliver_b);
+    t_ba.Tick(deliver_noop, deliver_a);
 
     // Window starts after both peers have had time to learn each other
     // (>= max(dAB, dBA)*4) so warm-up doesn't pollute the maximum.
-    if (i > 4 * (dAB > dBA ? dAB : dBA)) {
-      int gap = static_cast<int>(a->currentFrame()) - static_cast<int>(b->currentFrame());
+    if (i > 4 * (d_ab > d_ba ? d_ab : d_ba)) {
+      int gap = static_cast<int>(a->CurrentFrame()) - static_cast<int>(b->CurrentFrame());
       int abs = gap < 0 ? -gap : gap;
-      if (abs > maxAbsGap) maxAbsGap = abs;
+      if (abs > max_abs_gap) max_abs_gap = abs;
     }
   }
 
-  return {maxAbsGap, a->frameAdvantageStallCount(), b->frameAdvantageStallCount()};
+  return {max_abs_gap, a->FrameAdvantageStallCount(), b->FrameAdvantageStallCount()};
 }
 
 }  // namespace
@@ -111,26 +111,26 @@ AsymmetricRun runAsymmetric(int dAB, int dBA, int ticks) {
 TEST_CASE("Frame advantage caps the simFrame gap under asymmetric delay",
           "[rollback][frame-advantage]") {
   SECTION("D_AB=2, D_BA=6 — the plan's headline scenario") {
-    auto r = runAsymmetric(2, 6, 1000);
-    INFO("max |gap| = " << r.maxAbsGap << " stallsA=" << r.stallsA << " stallsB=" << r.stallsB);
+    auto r = RunAsymmetric(2, 6, 1000);
+    INFO("max |gap| = " << r.max_abs_gap << " stallsA=" << r.stalls_a << " stallsB=" << r.stalls_b);
 
     // The slower peer must have done meaningful stall work, otherwise
     // the test is vacuously passing.
-    REQUIRE((r.stallsA > 0 || r.stallsB > 0));
+    REQUIRE((r.stalls_a > 0 || r.stalls_b > 0));
 
     // The gap is bounded by a small constant (independent of run
     // length). The algorithm's steady state oscillates within
     // kFrameAdvantage of equilibrium plus a small overshoot during
     // the catch-up cycle, so the empirical bound sits comfortably
     // under 2*kFrameAdvantage.
-    REQUIRE(r.maxAbsGap <= 2 * RollbackController::kFrameAdvantage);
+    REQUIRE(r.max_abs_gap <= 2 * RollbackController::kFrameAdvantage);
   }
 
   SECTION("symmetric delay still works") {
-    auto r = runAsymmetric(3, 3, 500);
-    INFO("max |gap| = " << r.maxAbsGap << " stallsA=" << r.stallsA << " stallsB=" << r.stallsB);
+    auto r = RunAsymmetric(3, 3, 500);
+    INFO("max |gap| = " << r.max_abs_gap << " stallsA=" << r.stalls_a << " stallsB=" << r.stalls_b);
     // With symmetric one-way delay the gap stays within
     // kFrameAdvantage by construction.
-    REQUIRE(r.maxAbsGap <= 2 * RollbackController::kFrameAdvantage);
+    REQUIRE(r.max_abs_gap <= 2 * RollbackController::kFrameAdvantage);
   }
 }

--- a/src/tests/test_ice.cpp
+++ b/src/tests/test_ice.cpp
@@ -17,13 +17,13 @@
 
 // Helper: poll both agents until predicate is true or timeout
 template <typename Pred>
-static bool pollUntil(IceAgent& a, IceAgent& b, Pred&& pred, int timeoutMs = 5000) {
+static bool PollUntil(IceAgent& a, IceAgent& b, Pred&& pred, int timeout_ms = 5000) {
   auto start = std::chrono::steady_clock::now();
   while (!pred()) {
-    a.poll();
-    b.poll();
+    a.Poll();
+    b.Poll();
     auto elapsed = std::chrono::steady_clock::now() - start;
-    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= timeoutMs)
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= timeout_ms)
       return false;
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
@@ -31,12 +31,12 @@ static bool pollUntil(IceAgent& a, IceAgent& b, Pred&& pred, int timeoutMs = 500
 }
 
 template <typename Pred>
-static bool pollOneUntil(IceAgent& a, Pred&& pred, int timeoutMs = 5000) {
+static bool PollOneUntil(IceAgent& a, Pred&& pred, int timeout_ms = 5000) {
   auto start = std::chrono::steady_clock::now();
   while (!pred()) {
-    a.poll();
+    a.Poll();
     auto elapsed = std::chrono::steady_clock::now() - start;
-    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= timeoutMs)
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= timeout_ms)
       return false;
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
@@ -50,30 +50,30 @@ static bool pollOneUntil(IceAgent& a, Pred&& pred, int timeoutMs = 5000) {
 TEST_CASE("IceAgent starts and gathers candidates", "[ice]") {
   IceAgent agent;
   IceAgent::Config cfg;
-  cfg.stunServer = "";  // No STUN — only host candidates
+  cfg.stun_server = "";  // No STUN — only host candidates
 
   std::vector<std::string> candidates;
-  bool gatheringDone = false;
+  bool gathering_done = false;
 
-  agent.onLocalCandidate = [&](const std::string& c) { candidates.push_back(c); };
-  agent.onGatheringDone = [&]() { gatheringDone = true; };
+  agent.on_local_candidate = [&](const std::string& c) { candidates.push_back(c); };
+  agent.on_gathering_done = [&]() { gathering_done = true; };
 
-  agent.start(cfg);
-  REQUIRE(pollOneUntil(agent, [&] { return gatheringDone; }));
+  agent.Start(cfg);
+  REQUIRE(PollOneUntil(agent, [&] { return gathering_done; }));
   REQUIRE(!candidates.empty());
 }
 
 TEST_CASE("IceAgent local credentials available after start", "[ice]") {
   IceAgent agent;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
+  cfg.stun_server = "";
 
-  agent.start(cfg);
+  agent.Start(cfg);
   // Give it a moment to initialize
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-  auto ufrag = agent.localUfrag();
-  auto pwd = agent.localPwd();
+  auto ufrag = agent.LocalUfrag();
+  auto pwd = agent.LocalPwd();
   REQUIRE(!ufrag.empty());
   REQUIRE(!pwd.empty());
   REQUIRE(ufrag.size() >= 4);
@@ -81,128 +81,128 @@ TEST_CASE("IceAgent local credentials available after start", "[ice]") {
 }
 
 TEST_CASE("Two local IceAgents connect directly", "[ice]") {
-  IceAgent agentA, agentB;
+  IceAgent agent_a, agent_b;
   IceAgent::Config cfg;
-  cfg.stunServer = "";  // Host candidates only (localhost)
+  cfg.stun_server = "";  // Host candidates only (localhost)
 
-  std::vector<std::string> candidatesA, candidatesB;
-  bool gatherDoneA = false, gatherDoneB = false;
-  IceAgent::State stateA = IceAgent::State::New;
-  IceAgent::State stateB = IceAgent::State::New;
+  std::vector<std::string> candidates_a, candidates_b;
+  bool gather_done_a = false, gather_done_b = false;
+  IceAgent::enum State state_a = IceAgent::State::kNew;
+  IceAgent::enum State state_b = IceAgent::State::kNew;
 
-  agentA.onLocalCandidate = [&](const std::string& c) { candidatesA.push_back(c); };
-  agentA.onGatheringDone = [&]() { gatherDoneA = true; };
-  agentA.onStateChange = [&](IceAgent::State s) { stateA = s; };
+  agent_a.on_local_candidate = [&](const std::string& c) { candidates_a.push_back(c); };
+  agent_a.on_gathering_done = [&]() { gather_done_a = true; };
+  agent_a.on_state_change = [&](IceAgent::State s) { state_a = s; };
 
-  agentB.onLocalCandidate = [&](const std::string& c) { candidatesB.push_back(c); };
-  agentB.onGatheringDone = [&]() { gatherDoneB = true; };
-  agentB.onStateChange = [&](IceAgent::State s) { stateB = s; };
+  agent_b.on_local_candidate = [&](const std::string& c) { candidates_b.push_back(c); };
+  agent_b.on_gathering_done = [&]() { gather_done_b = true; };
+  agent_b.on_state_change = [&](IceAgent::State s) { state_b = s; };
 
-  agentA.start(cfg);
-  agentB.start(cfg);
+  agent_a.Start(cfg);
+  agent_b.Start(cfg);
 
   // Wait for gathering to complete on both
-  REQUIRE(pollUntil(agentA, agentB, [&] { return gatherDoneA && gatherDoneB; }));
+  REQUIRE(PollUntil(agent_a, agent_b, [&] { return gather_done_a && gather_done_b; }));
 
   // Exchange credentials
-  agentA.setRemoteCredentials(agentB.localUfrag(), agentB.localPwd());
-  agentB.setRemoteCredentials(agentA.localUfrag(), agentA.localPwd());
+  agent_a.SetRemoteCredentials(agent_b.LocalUfrag(), agent_b.LocalPwd());
+  agent_b.SetRemoteCredentials(agent_a.LocalUfrag(), agent_a.LocalPwd());
 
   // Exchange candidates
-  for (auto& c : candidatesA) agentB.addRemoteCandidate(c);
-  for (auto& c : candidatesB) agentA.addRemoteCandidate(c);
-  agentA.setRemoteGatheringDone();
-  agentB.setRemoteGatheringDone();
+  for (auto& c : candidates_a) agent_b.AddRemoteCandidate(c);
+  for (auto& c : candidates_b) agent_a.AddRemoteCandidate(c);
+  agent_a.SetRemoteGatheringDone();
+  agent_b.SetRemoteGatheringDone();
 
   // Wait for connection
-  REQUIRE(pollUntil(agentA, agentB, [&] {
-    return stateA == IceAgent::State::Connected && stateB == IceAgent::State::Connected;
+  REQUIRE(PollUntil(agent_a, agent_b, [&] {
+    return state_a == IceAgent::State::kConnected && state_b == IceAgent::State::kConnected;
   }));
 }
 
 TEST_CASE("IceAgent stop is clean", "[ice]") {
   IceAgent agent;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
+  cfg.stun_server = "";
 
-  agent.start(cfg);
+  agent.Start(cfg);
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  agent.stop();
-  REQUIRE(agent.state() == IceAgent::State::Disconnected);
+  agent.Stop();
+  REQUIRE(agent.State() == IceAgent::State::kDisconnected);
 
   // Double stop is safe
-  agent.stop();
-  REQUIRE(agent.state() == IceAgent::State::Disconnected);
+  agent.Stop();
+  REQUIRE(agent.State() == IceAgent::State::kDisconnected);
 }
 
 TEST_CASE("IceAgent data exchange via onRecv", "[ice]") {
-  IceAgent agentA, agentB;
+  IceAgent agent_a, agent_b;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
+  cfg.stun_server = "";
 
-  std::vector<std::string> candidatesA, candidatesB;
-  bool gatherDoneA = false, gatherDoneB = false;
-  IceAgent::State stateA = IceAgent::State::New;
-  IceAgent::State stateB = IceAgent::State::New;
+  std::vector<std::string> candidates_a, candidates_b;
+  bool gather_done_a = false, gather_done_b = false;
+  IceAgent::enum State state_a = IceAgent::State::kNew;
+  IceAgent::enum State state_b = IceAgent::State::kNew;
 
-  std::vector<uint8_t> receivedByA, receivedByB;
+  std::vector<uint8_t> received_by_a, received_by_b;
 
-  agentA.onLocalCandidate = [&](const std::string& c) { candidatesA.push_back(c); };
-  agentA.onGatheringDone = [&]() { gatherDoneA = true; };
-  agentA.onStateChange = [&](IceAgent::State s) { stateA = s; };
-  agentA.onRecv = [&](const uint8_t* data, size_t len) {
-    receivedByA.insert(receivedByA.end(), data, data + len);
+  agent_a.on_local_candidate = [&](const std::string& c) { candidates_a.push_back(c); };
+  agent_a.on_gathering_done = [&]() { gather_done_a = true; };
+  agent_a.on_state_change = [&](IceAgent::State s) { state_a = s; };
+  agent_a.on_recv = [&](const uint8_t* data, size_t len) {
+    received_by_a.insert(received_by_a.end(), data, data + len);
   };
 
-  agentB.onLocalCandidate = [&](const std::string& c) { candidatesB.push_back(c); };
-  agentB.onGatheringDone = [&]() { gatherDoneB = true; };
-  agentB.onStateChange = [&](IceAgent::State s) { stateB = s; };
-  agentB.onRecv = [&](const uint8_t* data, size_t len) {
-    receivedByB.insert(receivedByB.end(), data, data + len);
+  agent_b.on_local_candidate = [&](const std::string& c) { candidates_b.push_back(c); };
+  agent_b.on_gathering_done = [&]() { gather_done_b = true; };
+  agent_b.on_state_change = [&](IceAgent::State s) { state_b = s; };
+  agent_b.on_recv = [&](const uint8_t* data, size_t len) {
+    received_by_b.insert(received_by_b.end(), data, data + len);
   };
 
-  agentA.start(cfg);
-  agentB.start(cfg);
+  agent_a.Start(cfg);
+  agent_b.Start(cfg);
 
-  REQUIRE(pollUntil(agentA, agentB, [&] { return gatherDoneA && gatherDoneB; }));
+  REQUIRE(PollUntil(agent_a, agent_b, [&] { return gather_done_a && gather_done_b; }));
 
-  agentA.setRemoteCredentials(agentB.localUfrag(), agentB.localPwd());
-  agentB.setRemoteCredentials(agentA.localUfrag(), agentA.localPwd());
-  for (auto& c : candidatesA) agentB.addRemoteCandidate(c);
-  for (auto& c : candidatesB) agentA.addRemoteCandidate(c);
-  agentA.setRemoteGatheringDone();
-  agentB.setRemoteGatheringDone();
+  agent_a.SetRemoteCredentials(agent_b.LocalUfrag(), agent_b.LocalPwd());
+  agent_b.SetRemoteCredentials(agent_a.LocalUfrag(), agent_a.LocalPwd());
+  for (auto& c : candidates_a) agent_b.AddRemoteCandidate(c);
+  for (auto& c : candidates_b) agent_a.AddRemoteCandidate(c);
+  agent_a.SetRemoteGatheringDone();
+  agent_b.SetRemoteGatheringDone();
 
-  REQUIRE(pollUntil(agentA, agentB, [&] {
-    return stateA == IceAgent::State::Connected && stateB == IceAgent::State::Connected;
+  REQUIRE(PollUntil(agent_a, agent_b, [&] {
+    return state_a == IceAgent::State::kConnected && state_b == IceAgent::State::kConnected;
   }));
 
   // Send data A → B
-  const uint8_t msg[] = "Hello from A";
-  agentA.send(msg, sizeof(msg));
+  const uint8_t kMsg[] = "Hello from A";
+  agent_a.Send(kMsg, sizeof(kMsg));
 
   // Wait for delivery
   auto start = std::chrono::steady_clock::now();
-  while (receivedByB.empty()) {
+  while (received_by_b.empty()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     auto elapsed = std::chrono::steady_clock::now() - start;
     if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= 2000) break;
   }
-  REQUIRE(receivedByB.size() == sizeof(msg));
-  REQUIRE(std::memcmp(receivedByB.data(), msg, sizeof(msg)) == 0);
+  REQUIRE(received_by_b.size() == sizeof(kMsg));
+  REQUIRE(std::memcmp(received_by_b.data(), kMsg, sizeof(kMsg)) == 0);
 
   // Send data B → A
-  const uint8_t reply[] = "Hello from B";
-  agentB.send(reply, sizeof(reply));
+  const uint8_t kReply[] = "Hello from B";
+  agent_b.Send(kReply, sizeof(kReply));
 
   start = std::chrono::steady_clock::now();
-  while (receivedByA.empty()) {
+  while (received_by_a.empty()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     auto elapsed = std::chrono::steady_clock::now() - start;
     if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= 2000) break;
   }
-  REQUIRE(receivedByA.size() == sizeof(reply));
-  REQUIRE(std::memcmp(receivedByA.data(), reply, sizeof(reply)) == 0);
+  REQUIRE(received_by_a.size() == sizeof(kReply));
+  REQUIRE(std::memcmp(received_by_a.data(), kReply, sizeof(kReply)) == 0);
 }
 
 // ============================================================
@@ -212,106 +212,106 @@ TEST_CASE("IceAgent data exchange via onRecv", "[ice]") {
 TEST_CASE("IceBridge creates valid socket pair", "[ice][bridge]") {
   IceAgent agent;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
-  agent.start(cfg);
+  cfg.stun_server = "";
+  agent.Start(cfg);
 
   IceBridge bridge;
-  int fd = bridge.create(agent);
+  int fd = bridge.Create(agent);
   REQUIRE(fd >= 0);
-  REQUIRE(bridge.enetSocket() == fd);
-  REQUIRE(bridge.bridgePort() > 0);
+  REQUIRE(bridge.EnetSocket() == fd);
+  REQUIRE(bridge.BridgePort() > 0);
 
-  bridge.destroy();
-  agent.stop();
+  bridge.Destroy();
+  agent.Stop();
 }
 
 TEST_CASE("IceBridge proxies data bidirectionally", "[ice][bridge]") {
   // Connect two agents, set up bridges, and verify data flows through
-  IceAgent agentA, agentB;
+  IceAgent agent_a, agent_b;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
+  cfg.stun_server = "";
 
-  std::vector<std::string> candidatesA, candidatesB;
-  bool gatherDoneA = false, gatherDoneB = false;
-  IceAgent::State stateA = IceAgent::State::New;
-  IceAgent::State stateB = IceAgent::State::New;
+  std::vector<std::string> candidates_a, candidates_b;
+  bool gather_done_a = false, gather_done_b = false;
+  IceAgent::enum State state_a = IceAgent::State::kNew;
+  IceAgent::enum State state_b = IceAgent::State::kNew;
 
-  agentA.onLocalCandidate = [&](const std::string& c) { candidatesA.push_back(c); };
-  agentA.onGatheringDone = [&]() { gatherDoneA = true; };
-  agentA.onStateChange = [&](IceAgent::State s) { stateA = s; };
+  agent_a.on_local_candidate = [&](const std::string& c) { candidates_a.push_back(c); };
+  agent_a.on_gathering_done = [&]() { gather_done_a = true; };
+  agent_a.on_state_change = [&](IceAgent::State s) { state_a = s; };
 
-  agentB.onLocalCandidate = [&](const std::string& c) { candidatesB.push_back(c); };
-  agentB.onGatheringDone = [&]() { gatherDoneB = true; };
-  agentB.onStateChange = [&](IceAgent::State s) { stateB = s; };
+  agent_b.on_local_candidate = [&](const std::string& c) { candidates_b.push_back(c); };
+  agent_b.on_gathering_done = [&]() { gather_done_b = true; };
+  agent_b.on_state_change = [&](IceAgent::State s) { state_b = s; };
 
-  agentA.start(cfg);
-  agentB.start(cfg);
+  agent_a.Start(cfg);
+  agent_b.Start(cfg);
 
-  REQUIRE(pollUntil(agentA, agentB, [&] { return gatherDoneA && gatherDoneB; }));
+  REQUIRE(PollUntil(agent_a, agent_b, [&] { return gather_done_a && gather_done_b; }));
 
-  agentA.setRemoteCredentials(agentB.localUfrag(), agentB.localPwd());
-  agentB.setRemoteCredentials(agentA.localUfrag(), agentA.localPwd());
-  for (auto& c : candidatesA) agentB.addRemoteCandidate(c);
-  for (auto& c : candidatesB) agentA.addRemoteCandidate(c);
-  agentA.setRemoteGatheringDone();
-  agentB.setRemoteGatheringDone();
+  agent_a.SetRemoteCredentials(agent_b.LocalUfrag(), agent_b.LocalPwd());
+  agent_b.SetRemoteCredentials(agent_a.LocalUfrag(), agent_a.LocalPwd());
+  for (auto& c : candidates_a) agent_b.AddRemoteCandidate(c);
+  for (auto& c : candidates_b) agent_a.AddRemoteCandidate(c);
+  agent_a.SetRemoteGatheringDone();
+  agent_b.SetRemoteGatheringDone();
 
-  REQUIRE(pollUntil(agentA, agentB, [&] {
-    return stateA == IceAgent::State::Connected && stateB == IceAgent::State::Connected;
+  REQUIRE(PollUntil(agent_a, agent_b, [&] {
+    return state_a == IceAgent::State::kConnected && state_b == IceAgent::State::kConnected;
   }));
 
   // Now create bridges
-  IceBridge bridgeA, bridgeB;
-  int fdA = bridgeA.create(agentA);
-  int fdB = bridgeB.create(agentB);
-  REQUIRE(fdA >= 0);
-  REQUIRE(fdB >= 0);
+  IceBridge bridge_a, bridge_b;
+  int fd_a = bridge_a.Create(agent_a);
+  int fd_b = bridge_b.Create(agent_b);
+  REQUIRE(fd_a >= 0);
+  REQUIRE(fd_b >= 0);
 
   // Send from ENet side of A → should arrive on ENet side of B
-  const uint8_t msg[] = "Bridge test data";
+  const uint8_t kMsg[] = "Bridge test data";
   // Write to ENet socket A (as if ENet is sending via sendto to bridge address)
-  sockaddr_in6 bridgeAddrA{};
-  bridgeAddrA.sin6_family = AF_INET6;
-  bridgeAddrA.sin6_addr = in6addr_loopback;
-  bridgeAddrA.sin6_port = htons(bridgeA.bridgePort());
-  ::sendto(fdA, reinterpret_cast<const char*>(msg), sizeof(msg), 0,
-           reinterpret_cast<const sockaddr*>(&bridgeAddrA), sizeof(bridgeAddrA));
+  sockaddr_in6 bridge_addr_a{};
+  bridge_addr_a.sin6_family = AF_INET6;
+  bridge_addr_a.sin6_addr = in6addr_loopback;
+  bridge_addr_a.sin6_port = htons(bridge_a.BridgePort());
+  ::sendto(fd_a, reinterpret_cast<const char*>(kMsg), sizeof(kMsg), 0,
+           reinterpret_cast<const sockaddr*>(&bridge_addr_a), sizeof(bridge_addr_a));
 
   // Poll bridge A to forward to IceAgent A → network → IceAgent B → bridge B → ENet socket B
-  bridgeA.poll();
+  bridge_a.Poll();
 
   // Wait for data to arrive at ENet socket B
   uint8_t buf[256] = {};
   auto start = std::chrono::steady_clock::now();
   ssize_t n = 0;
   while (n <= 0) {
-    n = ::recv(fdB, reinterpret_cast<char*>(buf), sizeof(buf), 0);
+    n = ::recv(fd_b, reinterpret_cast<char*>(buf), sizeof(buf), 0);
     if (n <= 0) {
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
       auto elapsed = std::chrono::steady_clock::now() - start;
       if (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count() >= 2000) break;
     }
   }
-  REQUIRE(n == sizeof(msg));
-  REQUIRE(std::memcmp(buf, msg, sizeof(msg)) == 0);
+  REQUIRE(n == sizeof(kMsg));
+  REQUIRE(std::memcmp(buf, kMsg, sizeof(kMsg)) == 0);
 
-  bridgeA.destroy();
-  bridgeB.destroy();
-  agentA.stop();
-  agentB.stop();
+  bridge_a.Destroy();
+  bridge_b.Destroy();
+  agent_a.Stop();
+  agent_b.Stop();
 }
 
 TEST_CASE("IceBridge destroy is safe", "[ice][bridge]") {
   IceAgent agent;
   IceAgent::Config cfg;
-  cfg.stunServer = "";
-  agent.start(cfg);
+  cfg.stun_server = "";
+  agent.Start(cfg);
 
   IceBridge bridge;
-  bridge.create(agent);
-  bridge.destroy();
+  bridge.Create(agent);
+  bridge.Destroy();
 
   // Double destroy is safe
-  bridge.destroy();
-  agent.stop();
+  bridge.Destroy();
+  agent.Stop();
 }

--- a/src/tests/test_ice.cpp
+++ b/src/tests/test_ice.cpp
@@ -87,8 +87,8 @@ TEST_CASE("Two local IceAgents connect directly", "[ice]") {
 
   std::vector<std::string> candidates_a, candidates_b;
   bool gather_done_a = false, gather_done_b = false;
-  IceAgent::enum State state_a = IceAgent::State::kNew;
-  IceAgent::enum State state_b = IceAgent::State::kNew;
+  IceAgent::State state_a = IceAgent::State::kNew;
+  IceAgent::State state_b = IceAgent::State::kNew;
 
   agent_a.on_local_candidate = [&](const std::string& c) { candidates_a.push_back(c); };
   agent_a.on_gathering_done = [&]() { gather_done_a = true; };
@@ -128,11 +128,11 @@ TEST_CASE("IceAgent stop is clean", "[ice]") {
   agent.Start(cfg);
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   agent.Stop();
-  REQUIRE(agent.State() == IceAgent::State::kDisconnected);
+  REQUIRE(agent.CurrentState() == IceAgent::State::kDisconnected);
 
   // Double stop is safe
   agent.Stop();
-  REQUIRE(agent.State() == IceAgent::State::kDisconnected);
+  REQUIRE(agent.CurrentState() == IceAgent::State::kDisconnected);
 }
 
 TEST_CASE("IceAgent data exchange via onRecv", "[ice]") {
@@ -142,8 +142,8 @@ TEST_CASE("IceAgent data exchange via onRecv", "[ice]") {
 
   std::vector<std::string> candidates_a, candidates_b;
   bool gather_done_a = false, gather_done_b = false;
-  IceAgent::enum State state_a = IceAgent::State::kNew;
-  IceAgent::enum State state_b = IceAgent::State::kNew;
+  IceAgent::State state_a = IceAgent::State::kNew;
+  IceAgent::State state_b = IceAgent::State::kNew;
 
   std::vector<uint8_t> received_by_a, received_by_b;
 
@@ -233,8 +233,8 @@ TEST_CASE("IceBridge proxies data bidirectionally", "[ice][bridge]") {
 
   std::vector<std::string> candidates_a, candidates_b;
   bool gather_done_a = false, gather_done_b = false;
-  IceAgent::enum State state_a = IceAgent::State::kNew;
-  IceAgent::enum State state_b = IceAgent::State::kNew;
+  IceAgent::State state_a = IceAgent::State::kNew;
+  IceAgent::State state_b = IceAgent::State::kNew;
 
   agent_a.on_local_candidate = [&](const std::string& c) { candidates_a.push_back(c); };
   agent_a.on_gathering_done = [&]() { gather_done_a = true; };

--- a/src/tests/test_io.cpp
+++ b/src/tests/test_io.cpp
@@ -12,17 +12,17 @@
 TEST_CASE("io::MemReader reads exact bytes", "[io]") {
   std::vector<uint8_t> data{0x01, 0x02, 0x03};
   io::MemReader r(data);
-  REQUIRE(r.get() == 0x01);
-  REQUIRE(r.get() == 0x02);
-  REQUIRE(r.get() == 0x03);
-  REQUIRE_THROWS_AS(r.get(), io::EndOfStream);
+  REQUIRE(r.Get() == 0x01);
+  REQUIRE(r.Get() == 0x02);
+  REQUIRE(r.Get() == 0x03);
+  REQUIRE_THROWS_AS(r.Get(), io::EndOfStream);
 }
 
 TEST_CASE("io::MemReader::try_get returns short count at EOF", "[io]") {
   std::vector<uint8_t> data{0x10, 0x20};
   io::MemReader r(data);
   uint8_t buf[4]{};
-  REQUIRE(r.try_get(buf, 4) == 2);
+  REQUIRE(r.TryGet(buf, 4) == 2);
   REQUIRE(buf[0] == 0x10);
   REQUIRE(buf[1] == 0x20);
 }
@@ -30,17 +30,17 @@ TEST_CASE("io::MemReader::try_get returns short count at EOF", "[io]") {
 TEST_CASE("io::VectorWriter and StringWriter append correctly", "[io]") {
   std::vector<uint8_t> v;
   io::VectorWriter vw(v);
-  vw.put(0xAA);
+  vw.Put(0xAA);
   uint8_t more[] = {0xBB, 0xCC};
-  vw.put(more, 2);
+  vw.Put(more, 2);
   REQUIRE(v.size() == 3);
   REQUIRE(v[0] == 0xAA);
   REQUIRE(v[2] == 0xCC);
 
   std::string s;
   io::StringWriter sw(s);
-  sw.put('H');
-  sw.put(reinterpret_cast<uint8_t const*>("ello"), 4);
+  sw.Put('H');
+  sw.Put(reinterpret_cast<uint8_t const*>("ello"), 4);
   REQUIRE(s == "Hello");
 }
 
@@ -48,27 +48,27 @@ TEST_CASE("io::coding LE round-trip", "[io]") {
   std::vector<uint8_t> buf;
   {
     io::VectorWriter w(buf);
-    io::write_uint16_le(w, 0xBEEF);
-    io::write_uint32_le(w, 0xDEADBEEF);
+    io::WriteUint16Le(w, 0xBEEF);
+    io::WriteUint32Le(w, 0xDEADBEEF);
   }
   io::MemReader r(buf);
-  REQUIRE(io::read_uint16_le(r) == 0xBEEF);
-  REQUIRE(io::read_uint32_le(r) == 0xDEADBEEF);
+  REQUIRE(io::ReadUint16Le(r) == 0xBEEF);
+  REQUIRE(io::ReadUint32Le(r) == 0xDEADBEEF);
 }
 
 TEST_CASE("io::coding BE round-trip", "[io]") {
   std::vector<uint8_t> buf;
   {
     io::VectorWriter w(buf);
-    io::write_uint16(w, 0x1234);
-    io::write_uint32(w, 0x12345678);
+    io::WriteUint16(w, 0x1234);
+    io::WriteUint32(w, 0x12345678);
   }
   REQUIRE(buf[0] == 0x12);
   REQUIRE(buf[1] == 0x34);
   REQUIRE(buf[2] == 0x12);
   io::MemReader r(buf);
-  REQUIRE(io::read_uint16(r) == 0x1234);
-  REQUIRE(io::read_uint32(r) == 0x12345678);
+  REQUIRE(io::ReadUint16(r) == 0x1234);
+  REQUIRE(io::ReadUint32(r) == 0x12345678);
 }
 
 TEST_CASE("io::DeflateWriter / InflateReader round-trip random payload", "[io]") {
@@ -80,14 +80,14 @@ TEST_CASE("io::DeflateWriter / InflateReader round-trip random payload", "[io]")
   {
     auto sink = std::make_unique<io::VectorWriter>(compressed);
     io::DeflateWriter dw(std::move(sink));
-    dw.put(payload.data(), payload.size());
+    dw.Put(payload.data(), payload.size());
   }
   REQUIRE(!compressed.empty());
 
   auto src = std::make_unique<io::MemReader>(compressed);
   io::InflateReader ir(std::move(src));
   std::vector<uint8_t> roundtrip(payload.size());
-  REQUIRE(ir.try_get(roundtrip.data(), roundtrip.size()) == roundtrip.size());
+  REQUIRE(ir.TryGet(roundtrip.data(), roundtrip.size()) == roundtrip.size());
   REQUIRE(roundtrip == payload);
 }
 
@@ -103,7 +103,7 @@ TEST_CASE("io::DeflateWriter / InflateReader round-trip empty payload", "[io]") 
   auto src = std::make_unique<io::MemReader>(compressed);
   io::InflateReader ir(std::move(src));
   uint8_t buf[16];
-  REQUIRE(ir.try_get(buf, sizeof(buf)) == 0);
+  REQUIRE(ir.TryGet(buf, sizeof(buf)) == 0);
 }
 
 TEST_CASE("io::DeflateWriter compresses repetitive data well", "[io]") {
@@ -112,7 +112,7 @@ TEST_CASE("io::DeflateWriter compresses repetitive data well", "[io]") {
   {
     auto sink = std::make_unique<io::VectorWriter>(compressed);
     io::DeflateWriter dw(std::move(sink));
-    dw.put(payload.data(), payload.size());
+    dw.Put(payload.data(), payload.size());
   }
   // Highly repetitive data should compress at least 10x.
   REQUIRE(compressed.size() < payload.size() / 10);
@@ -120,6 +120,6 @@ TEST_CASE("io::DeflateWriter compresses repetitive data well", "[io]") {
   auto src = std::make_unique<io::MemReader>(compressed);
   io::InflateReader ir(std::move(src));
   std::vector<uint8_t> roundtrip(payload.size());
-  REQUIRE(ir.try_get(roundtrip.data(), roundtrip.size()) == roundtrip.size());
+  REQUIRE(ir.TryGet(roundtrip.data(), roundtrip.size()) == roundtrip.size());
   REQUIRE(roundtrip == payload);
 }

--- a/src/tests/test_paths.cpp
+++ b/src/tests/test_paths.cpp
@@ -59,7 +59,7 @@ struct Argv {
     ptrs.push_back(nullptr);
   }
   int Argc() const { return (int)storage.size(); }
-  char** Argv() { return ptrs.data(); }
+  char** Data() { return ptrs.data(); }
 };
 
 }  // namespace
@@ -102,7 +102,7 @@ TEST_CASE("paths::resolve --config-root sets both nodes to the given path") {
   TempDir root("configroot");
 
   Argv a{"--config-root", root.Str().c_str()};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), root.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), root.Str());
 
   REQUIRE(r.config_node.FullPath() == root.Str());
   REQUIRE(r.user_config_node.FullPath() == root.Str());
@@ -115,7 +115,7 @@ TEST_CASE("paths::resolve portable.txt sets both nodes to basePath") {
   Touch(base.path / "portable.txt");
 
   Argv a{};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
 
   REQUIRE(r.config_node.FullPath() == base.Str());
   REQUIRE(r.user_config_node.FullPath() == base.Str());
@@ -138,7 +138,7 @@ TEST_CASE("paths::resolve XDG: user shadows system file of same name") {
   // No portable.txt, no --config-root => XDG split.
   TempDir base("xdg_base_nosplit");  // basePath with no portable.txt
   Argv a{};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
 
   REQUIRE(r.user_config_node.FullPath() == user_dir.Str());
 
@@ -159,7 +159,7 @@ TEST_CASE("paths::resolve XDG: writer routes to user dir") {
 
   TempDir base("xdg_write_base");
   Argv a{};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
 
   // Write a file through userConfigNode.
   auto writer = (r.user_config_node / "Setups" / "liero.cfg").ToWriter();
@@ -173,14 +173,14 @@ TEST_CASE("paths::resolve XDG: writer routes to user dir") {
 TEST_CASE("paths::resolve: --port is parsed") {
   TempDir base("port_base");
   Argv a{"--port", "12345"};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
   REQUIRE(r.port == 12345);
 }
 
 TEST_CASE("paths::resolve: positional args are collected") {
   TempDir base("pos_base");
   Argv a{"myTC"};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
   REQUIRE(r.positional_args.size() == 1);
   REQUIRE(r.positional_args[0] == "myTC");
 }
@@ -188,7 +188,7 @@ TEST_CASE("paths::resolve: positional args are collected") {
 TEST_CASE("paths::resolve: --flag=value form is accepted") {
   TempDir root("eqform");
   Argv a{("--config-root=" + root.Str()).c_str(), "--port=9000"};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), root.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), root.Str());
   REQUIRE(r.config_node.FullPath() == root.Str());
   REQUIRE(r.user_config_node.FullPath() == root.Str());
   REQUIRE(r.port == 9000);
@@ -200,7 +200,7 @@ TEST_CASE("paths::resolve: --config-root refuses to swallow a following flag") {
   // directory literally named "--port" under cwd.
   TempDir base("noswallow");
   Argv a{"--config-root", "--port", "1234"};
-  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  auto r = paths::Resolve(a.Argc(), a.Data(), base.Str());
   // --config-root rejected (no usable value), so we fall through to the
   // XDG branch — userConfigNode is the user dir, not "--port".
   REQUIRE(r.user_config_node.FullPath() != std::string("--port"));

--- a/src/tests/test_paths.cpp
+++ b/src/tests/test_paths.cpp
@@ -15,18 +15,18 @@ namespace {
 struct ScopedEnv {
   std::string key;
   std::string prev;
-  bool hadPrev;
+  bool had_prev;
   ScopedEnv(char const* k, char const* v) : key(k) {
     if (const char* p = std::getenv(k)) {
       prev = p;
-      hadPrev = true;
+      had_prev = true;
     } else {
-      hadPrev = false;
+      had_prev = false;
     }
     setenv(k, v, 1);
   }
   ~ScopedEnv() {
-    if (hadPrev)
+    if (had_prev)
       setenv(key.c_str(), prev.c_str(), 1);
     else
       unsetenv(key.c_str());
@@ -40,10 +40,10 @@ struct TempDir {
     fs::create_directories(path);
   }
   ~TempDir() { fs::remove_all(path); }
-  std::string str() const { return path.string(); }
+  std::string Str() const { return path.string(); }
 };
 
-void touch(fs::path const& p) {
+void Touch(fs::path const& p) {
   fs::create_directories(p.parent_path());
   std::ofstream{p};
 }
@@ -58,8 +58,8 @@ struct Argv {
     for (auto& s : storage) ptrs.push_back(s.data());
     ptrs.push_back(nullptr);
   }
-  int argc() const { return (int)storage.size(); }
-  char** argv() { return ptrs.data(); }
+  int Argc() const { return (int)storage.size(); }
+  char** Argv() { return ptrs.data(); }
 };
 
 }  // namespace
@@ -71,26 +71,26 @@ struct Argv {
 TEST_CASE("paths::systemDataRoot honours OPENLIERO_DATADIR env var when set and existing") {
   ScopedEnv env("OPENLIERO_DATADIR", OPENLIERO_TEST_DATA_DIR);
 
-  FsNode node = paths::systemDataRoot();
+  FsNode node = paths::SystemDataRoot();
   REQUIRE(static_cast<bool>(node));
-  REQUIRE(node.exists());
-  REQUIRE((node / "TC").exists());
+  REQUIRE(node.Exists());
+  REQUIRE((node / "TC").Exists());
 }
 
 TEST_CASE("paths::systemDataRoot fullPath matches OPENLIERO_DATADIR env var") {
   ScopedEnv env("OPENLIERO_DATADIR", OPENLIERO_TEST_DATA_DIR);
 
-  FsNode node = paths::systemDataRoot();
+  FsNode node = paths::SystemDataRoot();
   REQUIRE(static_cast<bool>(node));
-  REQUIRE(node.fullPath() == std::string(OPENLIERO_TEST_DATA_DIR));
+  REQUIRE(node.FullPath() == std::string(OPENLIERO_TEST_DATA_DIR));
 }
 
 TEST_CASE("paths::systemDataRoot falls back when OPENLIERO_DATADIR points at nonexistent path") {
   ScopedEnv env("OPENLIERO_DATADIR", "/nonexistent/openliero/datadir/for/test");
 
-  FsNode node = paths::systemDataRoot();
+  FsNode node = paths::SystemDataRoot();
   if (node) {
-    REQUIRE(node.fullPath() != std::string("/nonexistent/openliero/datadir/for/test"));
+    REQUIRE(node.FullPath() != std::string("/nonexistent/openliero/datadir/for/test"));
   }
 }
 
@@ -101,96 +101,96 @@ TEST_CASE("paths::systemDataRoot falls back when OPENLIERO_DATADIR points at non
 TEST_CASE("paths::resolve --config-root sets both nodes to the given path") {
   TempDir root("configroot");
 
-  Argv a{"--config-root", root.str().c_str()};
-  auto r = paths::resolve(a.argc(), a.argv(), root.str());
+  Argv a{"--config-root", root.Str().c_str()};
+  auto r = paths::Resolve(a.Argc(), a.Argv(), root.Str());
 
-  REQUIRE(r.configNode.fullPath() == root.str());
-  REQUIRE(r.userConfigNode.fullPath() == root.str());
+  REQUIRE(r.config_node.FullPath() == root.Str());
+  REQUIRE(r.user_config_node.FullPath() == root.Str());
   REQUIRE(r.port == 0);
-  REQUIRE(r.positionalArgs.empty());
+  REQUIRE(r.positional_args.empty());
 }
 
 TEST_CASE("paths::resolve portable.txt sets both nodes to basePath") {
   TempDir base("portable_base");
-  touch(base.path / "portable.txt");
+  Touch(base.path / "portable.txt");
 
   Argv a{};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
 
-  REQUIRE(r.configNode.fullPath() == base.str());
-  REQUIRE(r.userConfigNode.fullPath() == base.str());
+  REQUIRE(r.config_node.FullPath() == base.Str());
+  REQUIRE(r.user_config_node.FullPath() == base.Str());
 }
 
 TEST_CASE("paths::resolve XDG: user shadows system file of same name") {
-  TempDir userDir("xdg_user");
-  TempDir sysDir("xdg_system");
+  TempDir user_dir("xdg_user");
+  TempDir sys_dir("xdg_system");
 
   // Both have Setups/liero.cfg but with different content.
-  touch(sysDir.path / "Setups" / "liero.cfg");
-  std::ofstream{sysDir.path / "Setups" / "liero.cfg"} << "system";
+  Touch(sys_dir.path / "Setups" / "liero.cfg");
+  std::ofstream{sys_dir.path / "Setups" / "liero.cfg"} << "system";
 
-  touch(userDir.path / "Setups" / "liero.cfg");
-  std::ofstream{userDir.path / "Setups" / "liero.cfg"} << "user";
+  Touch(user_dir.path / "Setups" / "liero.cfg");
+  std::ofstream{user_dir.path / "Setups" / "liero.cfg"} << "user";
 
-  ScopedEnv envU("OPENLIERO_TEST_USER_DIR", userDir.str().c_str());
-  ScopedEnv envS("OPENLIERO_DATADIR", sysDir.str().c_str());
+  ScopedEnv env_u("OPENLIERO_TEST_USER_DIR", user_dir.Str().c_str());
+  ScopedEnv env_s("OPENLIERO_DATADIR", sys_dir.Str().c_str());
 
   // No portable.txt, no --config-root => XDG split.
   TempDir base("xdg_base_nosplit");  // basePath with no portable.txt
   Argv a{};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
 
-  REQUIRE(r.userConfigNode.fullPath() == userDir.str());
+  REQUIRE(r.user_config_node.FullPath() == user_dir.Str());
 
   // Read through configNode should prefer user copy.
-  auto reader = (r.configNode / "Setups" / "liero.cfg").toReader();
+  auto reader = (r.config_node / "Setups" / "liero.cfg").ToReader();
   REQUIRE(reader != nullptr);
   std::string content(4, '\0');
-  reader->get(reinterpret_cast<uint8_t*>(content.data()), 4);
+  reader->Get(reinterpret_cast<uint8_t*>(content.data()), 4);
   REQUIRE(content == "user");
 }
 
 TEST_CASE("paths::resolve XDG: writer routes to user dir") {
-  TempDir userDir("xdg_write_user");
-  TempDir sysDir("xdg_write_system");
+  TempDir user_dir("xdg_write_user");
+  TempDir sys_dir("xdg_write_system");
 
-  ScopedEnv envU("OPENLIERO_TEST_USER_DIR", userDir.str().c_str());
-  ScopedEnv envS("OPENLIERO_DATADIR", sysDir.str().c_str());
+  ScopedEnv env_u("OPENLIERO_TEST_USER_DIR", user_dir.Str().c_str());
+  ScopedEnv env_s("OPENLIERO_DATADIR", sys_dir.Str().c_str());
 
   TempDir base("xdg_write_base");
   Argv a{};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
 
   // Write a file through userConfigNode.
-  auto writer = (r.userConfigNode / "Setups" / "liero.cfg").toWriter();
+  auto writer = (r.user_config_node / "Setups" / "liero.cfg").ToWriter();
   REQUIRE(writer != nullptr);
 
   // File should exist under userDir, not sysDir.
-  REQUIRE(fs::exists(userDir.path / "Setups" / "liero.cfg"));
-  REQUIRE(!fs::exists(sysDir.path / "Setups" / "liero.cfg"));
+  REQUIRE(fs::exists(user_dir.path / "Setups" / "liero.cfg"));
+  REQUIRE(!fs::exists(sys_dir.path / "Setups" / "liero.cfg"));
 }
 
 TEST_CASE("paths::resolve: --port is parsed") {
   TempDir base("port_base");
   Argv a{"--port", "12345"};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
   REQUIRE(r.port == 12345);
 }
 
 TEST_CASE("paths::resolve: positional args are collected") {
   TempDir base("pos_base");
   Argv a{"myTC"};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
-  REQUIRE(r.positionalArgs.size() == 1);
-  REQUIRE(r.positionalArgs[0] == "myTC");
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
+  REQUIRE(r.positional_args.size() == 1);
+  REQUIRE(r.positional_args[0] == "myTC");
 }
 
 TEST_CASE("paths::resolve: --flag=value form is accepted") {
   TempDir root("eqform");
-  Argv a{("--config-root=" + root.str()).c_str(), "--port=9000"};
-  auto r = paths::resolve(a.argc(), a.argv(), root.str());
-  REQUIRE(r.configNode.fullPath() == root.str());
-  REQUIRE(r.userConfigNode.fullPath() == root.str());
+  Argv a{("--config-root=" + root.Str()).c_str(), "--port=9000"};
+  auto r = paths::Resolve(a.Argc(), a.Argv(), root.Str());
+  REQUIRE(r.config_node.FullPath() == root.Str());
+  REQUIRE(r.user_config_node.FullPath() == root.Str());
   REQUIRE(r.port == 9000);
 }
 
@@ -200,10 +200,10 @@ TEST_CASE("paths::resolve: --config-root refuses to swallow a following flag") {
   // directory literally named "--port" under cwd.
   TempDir base("noswallow");
   Argv a{"--config-root", "--port", "1234"};
-  auto r = paths::resolve(a.argc(), a.argv(), base.str());
+  auto r = paths::Resolve(a.Argc(), a.Argv(), base.Str());
   // --config-root rejected (no usable value), so we fall through to the
   // XDG branch — userConfigNode is the user dir, not "--port".
-  REQUIRE(r.userConfigNode.fullPath() != std::string("--port"));
+  REQUIRE(r.user_config_node.FullPath() != std::string("--port"));
   REQUIRE(r.port == 1234);
 }
 
@@ -212,39 +212,39 @@ TEST_CASE("paths::resolve: --config-root refuses to swallow a following flag") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("paths::shadowsSystem flags shipped files in XDG mode") {
-  TempDir userDir("shadow_user");
-  TempDir sysDir("shadow_sys");
-  touch(sysDir.path / "Profiles" / "Default.toml");
-  ScopedEnv envS("OPENLIERO_DATADIR", sysDir.str().c_str());
+  TempDir user_dir("shadow_user");
+  TempDir sys_dir("shadow_sys");
+  Touch(sys_dir.path / "Profiles" / "Default.toml");
+  ScopedEnv env_s("OPENLIERO_DATADIR", sys_dir.Str().c_str());
 
-  FsNode userRoot(userDir.str());
-  REQUIRE(paths::shadowsSystem(userRoot, "Profiles", "Default.toml"));
-  REQUIRE(!paths::shadowsSystem(userRoot, "Profiles", "MyOwnName.toml"));
+  FsNode user_root(user_dir.Str());
+  REQUIRE(paths::ShadowsSystem(user_root, "Profiles", "Default.toml"));
+  REQUIRE(!paths::ShadowsSystem(user_root, "Profiles", "MyOwnName.toml"));
 }
 
 TEST_CASE("paths::shadowsSystem flags auto-managed names regardless of system layer") {
-  TempDir userDir("shadow_auto_user");
-  TempDir sysDir("shadow_auto_sys");
-  ScopedEnv envS("OPENLIERO_DATADIR", sysDir.str().c_str());
+  TempDir user_dir("shadow_auto_user");
+  TempDir sys_dir("shadow_auto_sys");
+  ScopedEnv env_s("OPENLIERO_DATADIR", sys_dir.Str().c_str());
 
   // liero.cfg is the auto-write target; even with no shipped copy it
   // must remain reserved so user Save As can't clobber it.
-  FsNode userRoot(userDir.str());
-  REQUIRE(paths::shadowsSystem(userRoot, "Setups", "liero.cfg"));
-  REQUIRE(paths::shadowsSystem(userRoot, "Setups", "LIERO.CFG"));
-  REQUIRE(!paths::shadowsSystem(userRoot, "Setups", "myoptions.cfg"));
+  FsNode user_root(user_dir.Str());
+  REQUIRE(paths::ShadowsSystem(user_root, "Setups", "liero.cfg"));
+  REQUIRE(paths::ShadowsSystem(user_root, "Setups", "LIERO.CFG"));
+  REQUIRE(!paths::ShadowsSystem(user_root, "Setups", "myoptions.cfg"));
 }
 
 TEST_CASE("paths::shadowsSystem skips on-disk check in portable mode") {
   // Portable / --config-root pointing at the install dir: userRoot
   // and the system root are the same directory, so the user's own
   // previously-saved file mustn't be treated as a shipped collision.
-  TempDir sharedDir("shadow_portable");
-  touch(sharedDir.path / "Setups" / "myoptions.cfg");
-  ScopedEnv envS("OPENLIERO_DATADIR", sharedDir.str().c_str());
+  TempDir shared_dir("shadow_portable");
+  Touch(shared_dir.path / "Setups" / "myoptions.cfg");
+  ScopedEnv env_s("OPENLIERO_DATADIR", shared_dir.Str().c_str());
 
-  FsNode userRoot(sharedDir.str());
-  REQUIRE(!paths::shadowsSystem(userRoot, "Setups", "myoptions.cfg"));
+  FsNode user_root(shared_dir.Str());
+  REQUIRE(!paths::ShadowsSystem(user_root, "Setups", "myoptions.cfg"));
   // Auto-managed names are still reserved.
-  REQUIRE(paths::shadowsSystem(userRoot, "Setups", "liero.cfg"));
+  REQUIRE(paths::ShadowsSystem(user_root, "Setups", "liero.cfg"));
 }

--- a/src/tests/test_prediction_no_rollback.cpp
+++ b/src/tests/test_prediction_no_rollback.cpp
@@ -31,149 +31,149 @@ struct Loopback {
   std::unique_ptr<Ctrl> a;
   std::unique_ptr<Ctrl> b;
 
-  Loopback(std::shared_ptr<Common> commonIn, std::shared_ptr<Settings> settingsIn, uint32_t seed)
-      : common(std::move(commonIn)), settings(std::move(settingsIn)) {
+  Loopback(std::shared_ptr<Common> common_in, std::shared_ptr<Settings> settings_in, uint32_t seed)
+      : common(std::move(common_in)), settings(std::move(settings_in)) {
     a = std::make_unique<Ctrl>(common, settings, 0);
     b = std::make_unique<Ctrl>(common, settings, 1);
-    a->setSkipWeaponSelection(true);
-    b->setSkipWeaponSelection(true);
-    a->game.rand.seed(seed);
-    b->game.rand.seed(seed);
-    a->setInputCallbacks([this](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* inputs,
-                                uint32_t lf) { b->injectRemoteBatch(bf, c, inputs, lf); });
-    b->setInputCallbacks([this](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* inputs,
-                                uint32_t lf) { a->injectRemoteBatch(bf, c, inputs, lf); });
-    a->focus();
-    b->focus();
+    a->SetSkipWeaponSelection(true);
+    b->SetSkipWeaponSelection(true);
+    a->game.rand.Seed(seed);
+    b->game.rand.Seed(seed);
+    a->SetInputCallbacks([this](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* inputs,
+                                uint32_t lf) { b->InjectRemoteBatch(bf, c, inputs, lf); });
+    b->SetInputCallbacks([this](uint8_t /*gen*/, uint32_t bf, uint8_t c, uint8_t const* inputs,
+                                uint32_t lf) { a->InjectRemoteBatch(bf, c, inputs, lf); });
+    a->Focus();
+    b->Focus();
   }
 
   // No-op now that send delivers directly; kept so the test reads as a
   // tick loop even though there's nothing queued.
-  void deliverAll() {}
+  void DeliverAll() {}
 };
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
 }  // namespace
 
 TEST_CASE("Zero jitter: predictions never trigger", "[rollback][prediction]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   Loopback<RollbackController> rb(common, settings, 0xBEEF);
 
   // Pre-seed the 3-frame input-delay window.
   for (uint32_t i = 0; i < 3; ++i) {
-    rb.a->injectRemoteInput(i, 0);
-    rb.b->injectRemoteInput(i, 0);
+    rb.a->InjectRemoteInput(i, 0);
+    rb.b->InjectRemoteInput(i, 0);
   }
 
-  Rand inputRng(0xC0FFEE);
+  Rand input_rng(0xC0FFEE);
   constexpr int kTicks = 500;
   for (int tick = 0; tick < kTicks; ++tick) {
-    uint8_t inA = inputRng() & 0x7f;
-    uint8_t inB = inputRng() & 0x7f;
-    if ((inputRng() % 10) < 6) inA |= (1 << Worm::Fire);
-    if ((inputRng() % 10) < 6) inB |= (1 << Worm::Fire);
-    rb.a->setLocalControlState(inA);
-    rb.b->setLocalControlState(inB);
+    uint8_t in_a = input_rng() & 0x7f;
+    uint8_t in_b = input_rng() & 0x7f;
+    if ((input_rng() % 10) < 6) in_a |= (1 << Worm::kFire);
+    if ((input_rng() % 10) < 6) in_b |= (1 << Worm::kFire);
+    rb.a->SetLocalControlState(in_a);
+    rb.b->SetLocalControlState(in_b);
 
-    rb.a->process();
-    rb.b->process();
-    rb.deliverAll();
+    rb.a->Process();
+    rb.b->Process();
+    rb.DeliverAll();
   }
 
   // confirmedFrame should track simFrame-1 exactly under zero jitter.
-  REQUIRE(rb.a->confirmedFrame() == static_cast<int32_t>(rb.a->currentFrame()) - 1);
-  REQUIRE(rb.b->confirmedFrame() == static_cast<int32_t>(rb.b->currentFrame()) - 1);
+  REQUIRE(rb.a->ConfirmedFrame() == static_cast<int32_t>(rb.a->CurrentFrame()) - 1);
+  REQUIRE(rb.b->ConfirmedFrame() == static_cast<int32_t>(rb.b->CurrentFrame()) - 1);
 
   // Every resident slot is Confirmed.
-  auto const& bufA = rb.a->rollbackBuffer();
-  for (int f = bufA.oldestFrame(); f <= bufA.newestFrame(); ++f) {
-    auto* slot = const_cast<rollback::RollbackBuffer&>(bufA).find(f);
+  auto const& buf_a = rb.a->RollbackBuffer();
+  for (int f = buf_a.OldestFrame(); f <= buf_a.NewestFrame(); ++f) {
+    auto* slot = const_cast<rollback::RollbackBuffer&>(buf_a).Find(f);
     REQUIRE(slot != nullptr);
-    REQUIRE(slot->remoteState == rollback::RemoteState::Confirmed);
+    REQUIRE(slot->remote_state == rollback::RemoteState::kConfirmed);
   }
 }
 
 TEST_CASE("Starvation: predict up to kMaxRollback, then stall, then recover",
           "[rollback][prediction]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   // Drive A directly via injectRemoteInput; B is unused. No transport.
   RollbackController a(common, settings, 0);
-  a.setSkipWeaponSelection(true);
-  a.game.rand.seed(0x1234);
-  a.focus();
+  a.SetSkipWeaponSelection(true);
+  a.game.rand.Seed(0x1234);
+  a.Focus();
 
   // Seed remote inputs for exactly the warm-up frames so A advances in
   // confirmed lockstep up to kWarm and no further.
   constexpr uint32_t kWarm = 20;
   for (uint32_t f = 0; f < kWarm; ++f) {
-    a.injectRemoteInput(f, 0);
+    a.InjectRemoteInput(f, 0);
   }
   for (uint32_t i = 0; i < kWarm; ++i) {
-    a.setLocalControlState(0);
-    a.process();
+    a.SetLocalControlState(0);
+    a.Process();
   }
-  REQUIRE(a.currentFrame() == kWarm);
-  REQUIRE(a.confirmedFrame() == static_cast<int32_t>(kWarm) - 1);
+  REQUIRE(a.CurrentFrame() == kWarm);
+  REQUIRE(a.ConfirmedFrame() == static_cast<int32_t>(kWarm) - 1);
 
   // Stop delivering remote inputs. A predicts up to kMaxRollback frames
   // ahead and then stalls (subsequent process() calls become no-ops on
   // simFrame).
   constexpr int kStarveTicks = rollback::kMaxRollback + 5;
-  uint32_t frameAtStarveStart = a.currentFrame();
+  uint32_t frame_at_starve_start = a.CurrentFrame();
   for (int i = 0; i < kStarveTicks; ++i) {
-    a.setLocalControlState(0);
-    a.process();
+    a.SetLocalControlState(0);
+    a.Process();
   }
   // Bound: simFrame advanced by at most kMaxRollback past confirmedFrame.
-  REQUIRE(a.currentFrame() == frameAtStarveStart + rollback::kMaxRollback);
-  REQUIRE(a.confirmedFrame() == static_cast<int32_t>(frameAtStarveStart) - 1);
+  REQUIRE(a.CurrentFrame() == frame_at_starve_start + rollback::kMaxRollback);
+  REQUIRE(a.ConfirmedFrame() == static_cast<int32_t>(frame_at_starve_start) - 1);
 
   // The predicted frames are marked Predicted in the buffer.
-  auto const& buf = a.rollbackBuffer();
-  int predictedCount = 0, confirmedCount = 0;
-  for (int f = buf.oldestFrame(); f <= buf.newestFrame(); ++f) {
-    auto* slot = const_cast<rollback::RollbackBuffer&>(buf).find(f);
+  auto const& buf = a.RollbackBuffer();
+  int predicted_count = 0, confirmed_count = 0;
+  for (int f = buf.OldestFrame(); f <= buf.NewestFrame(); ++f) {
+    auto* slot = const_cast<rollback::RollbackBuffer&>(buf).Find(f);
     REQUIRE(slot != nullptr);
-    if (slot->remoteState == rollback::RemoteState::Predicted)
-      ++predictedCount;
+    if (slot->remote_state == rollback::RemoteState::kPredicted)
+      ++predicted_count;
     else
-      ++confirmedCount;
+      ++confirmed_count;
   }
-  REQUIRE(predictedCount == rollback::kMaxRollback);
+  REQUIRE(predicted_count == rollback::kMaxRollback);
   // Buffer holds kMaxRollback+1 slots total → 1 confirmed straggler.
-  REQUIRE(confirmedCount == 1);
+  REQUIRE(confirmed_count == 1);
 
   // Late delivery: inject the previously-missing remote inputs. The
   // promote step on the next process() should catch confirmedFrame up
   // to simFrame-1 (we sent idle 0, predicted idle 0 — they match in
   // *input* terms).
-  uint32_t simFrameAtStall = a.currentFrame();
-  for (uint32_t f = frameAtStarveStart; f < simFrameAtStall; ++f) {
-    a.injectRemoteInput(f, 0);
+  uint32_t sim_frame_at_stall = a.CurrentFrame();
+  for (uint32_t f = frame_at_starve_start; f < sim_frame_at_stall; ++f) {
+    a.InjectRemoteInput(f, 0);
   }
   // One more process() drains the late-arriving inputs via the promote
   // step. Then a second tick can actually advance again because we keep
   // delivering input-delay frames (we also inject inputs for the next
   // few frames so the new frame can be Confirmed-advanced).
-  for (uint32_t f = simFrameAtStall; f < simFrameAtStall + 3; ++f) {
-    a.injectRemoteInput(f, 0);
+  for (uint32_t f = sim_frame_at_stall; f < sim_frame_at_stall + 3; ++f) {
+    a.InjectRemoteInput(f, 0);
   }
-  a.setLocalControlState(0);
-  a.process();
+  a.SetLocalControlState(0);
+  a.Process();
 
-  REQUIRE(a.confirmedFrame() >= static_cast<int32_t>(simFrameAtStall) - 1);
-  REQUIRE(a.currentFrame() > simFrameAtStall);
+  REQUIRE(a.ConfirmedFrame() >= static_cast<int32_t>(sim_frame_at_stall) - 1);
+  REQUIRE(a.CurrentFrame() > sim_frame_at_stall);
 }

--- a/src/tests/test_rollback_buffer.cpp
+++ b/src/tests/test_rollback_buffer.cpp
@@ -17,36 +17,36 @@ using rollback::Slot;
 
 TEST_CASE("RollbackBuffer is empty on construction", "[rollback]") {
   RollbackBuffer buf;
-  REQUIRE(buf.empty());
-  REQUIRE(buf.size() == 0);
-  REQUIRE(buf.newestFrame() == -1);
-  REQUIRE(buf.oldestFrame() == -1);
-  REQUIRE(buf.find(0) == nullptr);
-  REQUIRE(buf.find(42) == nullptr);
+  REQUIRE(buf.Empty());
+  REQUIRE(buf.Size() == 0);
+  REQUIRE(buf.NewestFrame() == -1);
+  REQUIRE(buf.OldestFrame() == -1);
+  REQUIRE(buf.Find(0) == nullptr);
+  REQUIRE(buf.Find(42) == nullptr);
 }
 
 TEST_CASE("RollbackBuffer stores and retrieves consecutive frames", "[rollback]") {
   RollbackBuffer buf;
 
   for (int f = 0; f < static_cast<int>(RollbackBuffer::kCapacity); ++f) {
-    Slot& s = buf.write(f);
-    s.localInput = static_cast<uint8_t>(0x10 + f);
-    s.remoteInput = static_cast<uint8_t>(0x80 + f);
-    s.remoteState = RemoteState::Confirmed;
+    Slot& s = buf.Write(f);
+    s.local_input = static_cast<uint8_t>(0x10 + f);
+    s.remote_input = static_cast<uint8_t>(0x80 + f);
+    s.remote_state = RemoteState::kConfirmed;
     s.snapshot.checksum = static_cast<uint32_t>(0xC0DE0000u + f);
   }
 
-  REQUIRE(buf.size() == RollbackBuffer::kCapacity);
-  REQUIRE(buf.newestFrame() == static_cast<int>(RollbackBuffer::kCapacity) - 1);
-  REQUIRE(buf.oldestFrame() == 0);
+  REQUIRE(buf.Size() == RollbackBuffer::kCapacity);
+  REQUIRE(buf.NewestFrame() == static_cast<int>(RollbackBuffer::kCapacity) - 1);
+  REQUIRE(buf.OldestFrame() == 0);
 
   for (int f = 0; f < static_cast<int>(RollbackBuffer::kCapacity); ++f) {
-    Slot const* s = buf.find(f);
+    Slot const* s = buf.Find(f);
     REQUIRE(s != nullptr);
     REQUIRE(s->frame == f);
-    REQUIRE(s->localInput == static_cast<uint8_t>(0x10 + f));
-    REQUIRE(s->remoteInput == static_cast<uint8_t>(0x80 + f));
-    REQUIRE(s->remoteState == RemoteState::Confirmed);
+    REQUIRE(s->local_input == static_cast<uint8_t>(0x10 + f));
+    REQUIRE(s->remote_input == static_cast<uint8_t>(0x80 + f));
+    REQUIRE(s->remote_state == RemoteState::kConfirmed);
     REQUIRE(s->snapshot.checksum == static_cast<uint32_t>(0xC0DE0000u + f));
   }
 }
@@ -56,31 +56,31 @@ TEST_CASE("RollbackBuffer wraps around and evicts oldest frame", "[rollback]") {
 
   constexpr int kFrames = static_cast<int>(RollbackBuffer::kCapacity) * 3 + 2;
   for (int f = 0; f < kFrames; ++f) {
-    Slot& s = buf.write(f);
-    s.localInput = static_cast<uint8_t>(f & 0xff);
+    Slot& s = buf.Write(f);
+    s.local_input = static_cast<uint8_t>(f & 0xff);
     s.snapshot.checksum = static_cast<uint32_t>(0xA0000000u + f);
   }
 
-  int const newest = kFrames - 1;
-  int const oldest = newest - static_cast<int>(RollbackBuffer::kCapacity) + 1;
-  REQUIRE(buf.newestFrame() == newest);
-  REQUIRE(buf.oldestFrame() == oldest);
+  int const kNewest = kFrames - 1;
+  int const kOldest = kNewest - static_cast<int>(RollbackBuffer::kCapacity) + 1;
+  REQUIRE(buf.NewestFrame() == kNewest);
+  REQUIRE(buf.OldestFrame() == kOldest);
 
   // Everything below the eviction horizon is gone.
-  for (int f = 0; f < oldest; ++f) {
+  for (int f = 0; f < kOldest; ++f) {
     INFO("frame " << f << " should have been evicted");
-    REQUIRE(buf.find(f) == nullptr);
+    REQUIRE(buf.Find(f) == nullptr);
   }
   // Everything in [oldest, newest] is resident and carries the latest data.
-  for (int f = oldest; f <= newest; ++f) {
-    Slot const* s = buf.find(f);
+  for (int f = kOldest; f <= kNewest; ++f) {
+    Slot const* s = buf.Find(f);
     REQUIRE(s != nullptr);
     REQUIRE(s->frame == f);
-    REQUIRE(s->localInput == static_cast<uint8_t>(f & 0xff));
+    REQUIRE(s->local_input == static_cast<uint8_t>(f & 0xff));
     REQUIRE(s->snapshot.checksum == static_cast<uint32_t>(0xA0000000u + f));
   }
   // Future frames are not resident.
-  REQUIRE(buf.find(newest + 1) == nullptr);
+  REQUIRE(buf.Find(kNewest + 1) == nullptr);
 }
 
 TEST_CASE("RollbackBuffer write to existing frame preserves snapshot", "[rollback]") {
@@ -91,26 +91,26 @@ TEST_CASE("RollbackBuffer write to existing frame preserves snapshot", "[rollbac
   // frame matches.
   RollbackBuffer buf;
 
-  Slot& first = buf.write(5);
+  Slot& first = buf.Write(5);
   first.snapshot.checksum = 0xDEADBEEF;
-  first.localInput = 0x11;
-  first.remoteInput = 0x22;
-  first.remoteState = RemoteState::Predicted;
+  first.local_input = 0x11;
+  first.remote_input = 0x22;
+  first.remote_state = RemoteState::kPredicted;
 
-  Slot& again = buf.write(5);
+  Slot& again = buf.Write(5);
   REQUIRE(&again == &first);
   REQUIRE(again.snapshot.checksum == 0xDEADBEEF);
-  REQUIRE(again.localInput == 0x11);
-  REQUIRE(again.remoteInput == 0x22);
-  REQUIRE(again.remoteState == RemoteState::Predicted);
+  REQUIRE(again.local_input == 0x11);
+  REQUIRE(again.remote_input == 0x22);
+  REQUIRE(again.remote_state == RemoteState::kPredicted);
 
   // Mutate via the second handle, then look up via find: same slot.
-  again.remoteInput = 0x33;
-  again.remoteState = RemoteState::Confirmed;
-  Slot const* found = buf.find(5);
+  again.remote_input = 0x33;
+  again.remote_state = RemoteState::kConfirmed;
+  Slot const* found = buf.Find(5);
   REQUIRE(found == &first);
-  REQUIRE(found->remoteInput == 0x33);
-  REQUIRE(found->remoteState == RemoteState::Confirmed);
+  REQUIRE(found->remote_input == 0x33);
+  REQUIRE(found->remote_state == RemoteState::kConfirmed);
 }
 
 TEST_CASE("RollbackBuffer write to a different frame evicts ring slot", "[rollback]") {
@@ -119,74 +119,74 @@ TEST_CASE("RollbackBuffer write to a different frame evicts ring slot", "[rollba
   // cannot leak into the new one.
   RollbackBuffer buf;
 
-  Slot& original = buf.write(3);
-  original.localInput = 0xAA;
-  original.remoteInput = 0xBB;
-  original.remoteState = RemoteState::Confirmed;
+  Slot& original = buf.Write(3);
+  original.local_input = 0xAA;
+  original.remote_input = 0xBB;
+  original.remote_state = RemoteState::kConfirmed;
   original.snapshot.checksum = 0x12345678;
 
-  int const collision = 3 + static_cast<int>(RollbackBuffer::kCapacity);
-  Slot& replaced = buf.write(collision);
+  int const kCollision = 3 + static_cast<int>(RollbackBuffer::kCapacity);
+  Slot& replaced = buf.Write(kCollision);
   REQUIRE(&replaced == &original);  // same physical slot
-  REQUIRE(replaced.frame == collision);
-  REQUIRE(replaced.localInput == 0);
-  REQUIRE(replaced.remoteInput == 0);
-  REQUIRE(replaced.remoteState == RemoteState::Predicted);
+  REQUIRE(replaced.frame == kCollision);
+  REQUIRE(replaced.local_input == 0);
+  REQUIRE(replaced.remote_input == 0);
+  REQUIRE(replaced.remote_state == RemoteState::kPredicted);
   // Snapshot field is deliberately not cleared by write() — the controller
   // overwrites it via Game::saveSnapshotFast. Verify the carried-over
   // checksum is still there so callers can rely on this contract.
   REQUIRE(replaced.snapshot.checksum == 0x12345678);
 
-  REQUIRE(buf.find(3) == nullptr);
-  REQUIRE(buf.find(collision) == &original);
+  REQUIRE(buf.Find(3) == nullptr);
+  REQUIRE(buf.Find(kCollision) == &original);
 }
 
 TEST_CASE("RollbackBuffer supports Predicted -> Confirmed transition", "[rollback]") {
   RollbackBuffer buf;
   for (int f = 0; f < 4; ++f) {
-    Slot& s = buf.write(f);
-    s.remoteInput = 0;
-    s.remoteState = RemoteState::Predicted;
+    Slot& s = buf.Write(f);
+    s.remote_input = 0;
+    s.remote_state = RemoteState::kPredicted;
   }
 
   // Remote input for frame 2 arrives.
-  Slot* s = buf.find(2);
+  Slot* s = buf.Find(2);
   REQUIRE(s != nullptr);
-  s->remoteInput = 0x5A;
-  s->remoteState = RemoteState::Confirmed;
+  s->remote_input = 0x5A;
+  s->remote_state = RemoteState::kConfirmed;
 
   // Lookup-by-frame after the transition reflects the change.
-  Slot const* readback = buf.find(2);
+  Slot const* readback = buf.Find(2);
   REQUIRE(readback != nullptr);
-  REQUIRE(readback->remoteState == RemoteState::Confirmed);
-  REQUIRE(readback->remoteInput == 0x5A);
+  REQUIRE(readback->remote_state == RemoteState::kConfirmed);
+  REQUIRE(readback->remote_input == 0x5A);
 
   // Other frames are unchanged.
   for (int f : {0, 1, 3}) {
-    Slot const* other = buf.find(f);
+    Slot const* other = buf.Find(f);
     REQUIRE(other != nullptr);
-    REQUIRE(other->remoteState == RemoteState::Predicted);
-    REQUIRE(other->remoteInput == 0);
+    REQUIRE(other->remote_state == RemoteState::kPredicted);
+    REQUIRE(other->remote_input == 0);
   }
 }
 
 TEST_CASE("RollbackBuffer clear empties without losing capacity", "[rollback]") {
   RollbackBuffer buf;
-  for (int f = 0; f < 5; ++f) buf.write(f).localInput = 0x77;
-  REQUIRE(!buf.empty());
+  for (int f = 0; f < 5; ++f) buf.Write(f).local_input = 0x77;
+  REQUIRE(!buf.Empty());
 
-  buf.clear();
-  REQUIRE(buf.empty());
-  REQUIRE(buf.size() == 0);
-  REQUIRE(buf.newestFrame() == -1);
-  REQUIRE(buf.oldestFrame() == -1);
-  for (int f = 0; f < 5; ++f) REQUIRE(buf.find(f) == nullptr);
+  buf.Clear();
+  REQUIRE(buf.Empty());
+  REQUIRE(buf.Size() == 0);
+  REQUIRE(buf.NewestFrame() == -1);
+  REQUIRE(buf.OldestFrame() == -1);
+  for (int f = 0; f < 5; ++f) REQUIRE(buf.Find(f) == nullptr);
 
   // Still usable after clear.
-  buf.write(100).localInput = 0x99;
-  REQUIRE(buf.newestFrame() == 100);
-  REQUIRE(buf.find(100) != nullptr);
-  REQUIRE(buf.find(100)->localInput == 0x99);
+  buf.Write(100).local_input = 0x99;
+  REQUIRE(buf.NewestFrame() == 100);
+  REQUIRE(buf.Find(100) != nullptr);
+  REQUIRE(buf.Find(100)->local_input == 0x99);
 }
 
 TEST_CASE("RollbackBuffer reports oldestFrame correctly while filling", "[rollback]") {
@@ -194,12 +194,12 @@ TEST_CASE("RollbackBuffer reports oldestFrame correctly while filling", "[rollba
   // it tracks the eviction horizon.
   RollbackBuffer buf;
   for (int f = 0; f < static_cast<int>(RollbackBuffer::kCapacity); ++f) {
-    buf.write(f);
-    REQUIRE(buf.oldestFrame() == 0);
-    REQUIRE(buf.newestFrame() == f);
+    buf.Write(f);
+    REQUIRE(buf.OldestFrame() == 0);
+    REQUIRE(buf.NewestFrame() == f);
   }
   // One more frame triggers eviction.
-  buf.write(static_cast<int>(RollbackBuffer::kCapacity));
-  REQUIRE(buf.oldestFrame() == 1);
-  REQUIRE(buf.newestFrame() == static_cast<int>(RollbackBuffer::kCapacity));
+  buf.Write(static_cast<int>(RollbackBuffer::kCapacity));
+  REQUIRE(buf.OldestFrame() == 1);
+  REQUIRE(buf.NewestFrame() == static_cast<int>(RollbackBuffer::kCapacity));
 }

--- a/src/tests/test_rollback_correctness.cpp
+++ b/src/tests/test_rollback_correctness.cpp
@@ -206,8 +206,10 @@ TEST_CASE("Rollback recovers from mispredictions under random delay", "[rollback
         b->SetLocalControlState(script.b[i]);
         a->Process();
         b->Process();
-        if (a->LastTickResimFrames() > max_resim_in_a_tick) max_resim_in_a_tick = a->LastTickResimFrames();
-        if (b->LastTickResimFrames() > max_resim_in_a_tick) max_resim_in_a_tick = b->LastTickResimFrames();
+        if (a->LastTickResimFrames() > max_resim_in_a_tick)
+          max_resim_in_a_tick = a->LastTickResimFrames();
+        if (b->LastTickResimFrames() > max_resim_in_a_tick)
+          max_resim_in_a_tick = b->LastTickResimFrames();
         transport.Tick(deliver_a, deliver_b);
       }
       REQUIRE(max_resim_in_a_tick > 0);

--- a/src/tests/test_rollback_correctness.cpp
+++ b/src/tests/test_rollback_correctness.cpp
@@ -27,17 +27,17 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
@@ -46,18 +46,18 @@ struct ScriptedInputs {
   std::vector<uint8_t> b;
 };
 
-ScriptedInputs generateInputs(uint32_t seed, int ticks) {
+ScriptedInputs GenerateInputs(uint32_t seed, int ticks) {
   Rand rng(seed);
   ScriptedInputs out;
   out.a.reserve(ticks);
   out.b.reserve(ticks);
   for (int i = 0; i < ticks; ++i) {
-    uint8_t inA = rng() & 0x7f;
-    uint8_t inB = rng() & 0x7f;
-    if ((rng() % 10) < 6) inA |= (1 << Worm::Fire);
-    if ((rng() % 10) < 6) inB |= (1 << Worm::Fire);
-    out.a.push_back(inA);
-    out.b.push_back(inB);
+    uint8_t in_a = rng() & 0x7f;
+    uint8_t in_b = rng() & 0x7f;
+    if ((rng() % 10) < 6) in_a |= (1 << Worm::kFire);
+    if ((rng() % 10) < 6) in_b |= (1 << Worm::kFire);
+    out.a.push_back(in_a);
+    out.b.push_back(in_b);
   }
   return out;
 }
@@ -67,69 +67,69 @@ ScriptedInputs generateInputs(uint32_t seed, int ticks) {
 // the peer reached.
 struct RefResult {
   uint32_t checksum;
-  uint32_t simFrame;
+  uint32_t sim_frame;
 };
 
-RefResult runReference(uint32_t worldSeed, ScriptedInputs const& script, int ticks) {
-  auto [common, settings] = makeEnv();
+RefResult RunReference(uint32_t world_seed, ScriptedInputs const& script, int ticks) {
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
   // Isolate the rollback algorithm from the frame-advantage stall so
   // the peers freely run ahead and exercise prediction.
-  a->setFrameAdvantageEnabled(false);
-  b->setFrameAdvantageEnabled(false);
-  a->game.rand.seed(worldSeed);
-  b->game.rand.seed(worldSeed);
+  a->SetFrameAdvantageEnabled(false);
+  b->SetFrameAdvantageEnabled(false);
+  a->game.rand.Seed(world_seed);
+  b->game.rand.Seed(world_seed);
 
   struct Pkt {
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
-    uint32_t localFrame;
+    uint32_t local_frame;
   };
-  std::vector<Pkt> aToB, bToA;
+  std::vector<Pkt> a_to_b, b_to_a;
   auto enqueue = [](std::vector<Pkt>& q, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
     Pkt p{};
-    p.baseFrame = bf;
+    p.base_frame = bf;
     p.count = c;
-    p.localFrame = lf;
+    p.local_frame = lf;
     for (uint8_t i = 0; i < c; ++i) p.inputs[i] = in[i];
     q.push_back(p);
   };
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(aToB, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(a_to_b, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(bToA, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(b_to_a, bf, c, in, lf);
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
   for (int i = 0; i < ticks; ++i) {
-    a->setLocalControlState(script.a[i]);
-    b->setLocalControlState(script.b[i]);
-    a->process();
-    b->process();
-    for (auto const& p : aToB)
-      b->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    for (auto const& p : bToA)
-      a->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    aToB.clear();
-    bToA.clear();
+    a->SetLocalControlState(script.a[i]);
+    b->SetLocalControlState(script.b[i]);
+    a->Process();
+    b->Process();
+    for (auto const& p : a_to_b)
+      b->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    for (auto const& p : b_to_a)
+      a->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    a_to_b.clear();
+    b_to_a.clear();
   }
 
-  REQUIRE(a->currentFrame() == b->currentFrame());
-  uint32_t cA = wideRollbackChecksum(a->game);
-  uint32_t cB = wideRollbackChecksum(b->game);
-  REQUIRE(cA == cB);
-  return {cA, a->currentFrame()};
+  REQUIRE(a->CurrentFrame() == b->CurrentFrame());
+  uint32_t c_a = WideRollbackChecksum(a->game);
+  uint32_t c_b = WideRollbackChecksum(b->game);
+  REQUIRE(c_a == c_b);
+  return {c_a, a->CurrentFrame()};
 }
 
 }  // namespace
@@ -139,14 +139,14 @@ TEST_CASE("Rollback recovers from mispredictions under random delay", "[rollback
   constexpr int kTicks = 800;
   constexpr uint32_t kInputSeed = 0xC0FFEE;
 
-  ScriptedInputs script = generateInputs(kInputSeed, kTicks);
-  RefResult ref = runReference(kWorldSeed, script, kTicks);
+  ScriptedInputs script = GenerateInputs(kInputSeed, kTicks);
+  RefResult ref = RunReference(kWorldSeed, script, kTicks);
 
   struct Case {
     char const* name;
-    int minDelay;
-    int maxDelay;
-    uint32_t transportSeed;
+    int min_delay;
+    int max_delay;
+    uint32_t transport_seed;
   };
   // Delays are chosen so the steady-state gap stays well under
   // kMaxRollback even when unlucky runs of high-delay packets cluster.
@@ -159,95 +159,95 @@ TEST_CASE("Rollback recovers from mispredictions under random delay", "[rollback
 
   for (auto const& tc : cases) {
     SECTION(tc.name) {
-      INFO("transport seed = " << tc.transportSeed);
+      INFO("transport seed = " << tc.transport_seed);
 
-      auto [common, settings] = makeEnv();
+      auto [common, settings] = MakeEnv();
       auto a = std::make_unique<RollbackController>(common, settings, 0);
       auto b = std::make_unique<RollbackController>(common, settings, 1);
-      a->setSkipWeaponSelection(true);
-      b->setSkipWeaponSelection(true);
+      a->SetSkipWeaponSelection(true);
+      b->SetSkipWeaponSelection(true);
       // Disable the frame-advantage stall so the rollback algorithm
       // is exercised under jitter without the time-sync clamp.
-      a->setFrameAdvantageEnabled(false);
-      b->setFrameAdvantageEnabled(false);
-      a->game.rand.seed(kWorldSeed);
-      b->game.rand.seed(kWorldSeed);
+      a->SetFrameAdvantageEnabled(false);
+      b->SetFrameAdvantageEnabled(false);
+      a->game.rand.Seed(kWorldSeed);
+      b->game.rand.Seed(kWorldSeed);
 
-      rollback_test::JitterTransport transport({tc.transportSeed, tc.minDelay, tc.maxDelay});
+      rollback_test::JitterTransport transport({tc.transport_seed, tc.min_delay, tc.max_delay});
 
-      a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in,
-                               uint32_t lf) { transport.sendAToB(gen_, bf, c, in, lf); });
-      b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in,
-                               uint32_t lf) { transport.sendBToA(gen_, bf, c, in, lf); });
-      a->focus();
-      b->focus();
+      a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in,
+                               uint32_t lf) { transport.SendAToB(gen, bf, c, in, lf); });
+      b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in,
+                               uint32_t lf) { transport.SendBToA(gen, bf, c, in, lf); });
+      a->Focus();
+      b->Focus();
 
       // Pre-seed the input-delay window. These bypass the transport so
       // both peers can start advancing immediately, mirroring how a real
       // session would synchronise its starting frames.
       for (uint32_t f = 0; f < 3; ++f) {
-        a->injectRemoteInput(f, 0);
-        b->injectRemoteInput(f, 0);
+        a->InjectRemoteInput(f, 0);
+        b->InjectRemoteInput(f, 0);
       }
 
-      auto deliverA = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-        a->injectRemoteBatch(gen, bf, c, in, lf);
+      auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+        a->InjectRemoteBatch(gen, bf, c, in, lf);
       };
-      auto deliverB = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-        b->injectRemoteBatch(gen, bf, c, in, lf);
+      auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+        b->InjectRemoteBatch(gen, bf, c, in, lf);
       };
 
       // Track that lastTickResimFrames() goes non-zero at some point
       // during the run, catching a regression where rollback counting
       // falls back to the cumulative rollbackCount() metric.
-      uint32_t maxResimInATick = 0;
+      uint32_t max_resim_in_a_tick = 0;
       for (int i = 0; i < kTicks; ++i) {
-        a->setLocalControlState(script.a[i]);
-        b->setLocalControlState(script.b[i]);
-        a->process();
-        b->process();
-        if (a->lastTickResimFrames() > maxResimInATick) maxResimInATick = a->lastTickResimFrames();
-        if (b->lastTickResimFrames() > maxResimInATick) maxResimInATick = b->lastTickResimFrames();
-        transport.tick(deliverA, deliverB);
+        a->SetLocalControlState(script.a[i]);
+        b->SetLocalControlState(script.b[i]);
+        a->Process();
+        b->Process();
+        if (a->LastTickResimFrames() > max_resim_in_a_tick) max_resim_in_a_tick = a->LastTickResimFrames();
+        if (b->LastTickResimFrames() > max_resim_in_a_tick) max_resim_in_a_tick = b->LastTickResimFrames();
+        transport.Tick(deliver_a, deliver_b);
       }
-      REQUIRE(maxResimInATick > 0);
+      REQUIRE(max_resim_in_a_tick > 0);
 
       // Flush any in-flight tail packets, then run additional ticks
       // until both peers' confirmedFrame catches up. We use idle inputs
       // for the catch-up window so the test doesn't outrun the script,
       // but the comparison frame is the final scripted-tick state.
-      transport.flush(deliverA, deliverB);
+      transport.Flush(deliver_a, deliver_b);
 
       // Both peers must agree on every still-resident slot's
       // post-resim state. After flush, the promote loop on the next
       // tick of each peer will absorb the late arrivals.
-      a->setLocalControlState(0);
-      b->setLocalControlState(0);
+      a->SetLocalControlState(0);
+      b->SetLocalControlState(0);
       // A couple of extra ticks lets the promote loop drain.
       for (int i = 0; i < 12; ++i) {
-        a->process();
-        b->process();
-        transport.tick(deliverA, deliverB);
+        a->Process();
+        b->Process();
+        transport.Tick(deliver_a, deliver_b);
       }
 
-      REQUIRE(a->currentFrame() == b->currentFrame());
+      REQUIRE(a->CurrentFrame() == b->CurrentFrame());
 
       // Sanity: the test would trivially pass if rollback never fired
       // (predictions always matching means the algorithm wasn't exercised).
       // With random inputs and any delay, mispredictions are inevitable.
-      REQUIRE(a->rollbackCount() > 0);
-      REQUIRE(b->rollbackCount() > 0);
+      REQUIRE(a->RollbackCount() > 0);
+      REQUIRE(b->RollbackCount() > 0);
 
-      uint32_t cA = wideRollbackChecksum(a->game);
-      uint32_t cB = wideRollbackChecksum(b->game);
-      REQUIRE(cA == cB);
+      uint32_t c_a = WideRollbackChecksum(a->game);
+      uint32_t c_b = WideRollbackChecksum(b->game);
+      REQUIRE(c_a == c_b);
 
       // And it has to match what a zero-jitter peer would have produced
       // from the same input sequence at the same frame. The reference
       // ran `kTicks` ticks; this peer ran `kTicks` scripted + 12 idle.
       // Run the reference the same number of idle ticks so the
       // comparison frames line up.
-      auto refAdvanced = runReference(
+      auto ref_advanced = RunReference(
           kWorldSeed,
           [&] {
             ScriptedInputs ext = script;
@@ -258,8 +258,8 @@ TEST_CASE("Rollback recovers from mispredictions under random delay", "[rollback
             return ext;
           }(),
           kTicks + 12);
-      REQUIRE(a->currentFrame() == refAdvanced.simFrame);
-      REQUIRE(cA == refAdvanced.checksum);
+      REQUIRE(a->CurrentFrame() == ref_advanced.sim_frame);
+      REQUIRE(c_a == ref_advanced.checksum);
     }
   }
 }

--- a/src/tests/test_rollback_desync.cpp
+++ b/src/tests/test_rollback_desync.cpp
@@ -35,17 +35,17 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
@@ -54,18 +54,18 @@ struct ScriptedInputs {
   std::vector<uint8_t> b;
 };
 
-ScriptedInputs generateInputs(uint32_t seed, int ticks) {
+ScriptedInputs GenerateInputs(uint32_t seed, int ticks) {
   Rand rng(seed);
   ScriptedInputs out;
   out.a.reserve(ticks);
   out.b.reserve(ticks);
   for (int i = 0; i < ticks; ++i) {
-    uint8_t inA = rng() & 0x7f;
-    uint8_t inB = rng() & 0x7f;
-    if ((rng() % 10) < 6) inA |= (1 << Worm::Fire);
-    if ((rng() % 10) < 6) inB |= (1 << Worm::Fire);
-    out.a.push_back(inA);
-    out.b.push_back(inB);
+    uint8_t in_a = rng() & 0x7f;
+    uint8_t in_b = rng() & 0x7f;
+    if ((rng() % 10) < 6) in_a |= (1 << Worm::kFire);
+    if ((rng() % 10) < 6) in_b |= (1 << Worm::kFire);
+    out.a.push_back(in_a);
+    out.b.push_back(in_b);
   }
   return out;
 }
@@ -78,83 +78,83 @@ TEST_CASE("Rollback desync detection — clean run produces no alarms", "[rollba
   constexpr uint32_t kTransportSeed = 0xA1B2;
   constexpr int kTicks = 1500;
 
-  ScriptedInputs script = generateInputs(kInputSeed, kTicks);
+  ScriptedInputs script = GenerateInputs(kInputSeed, kTicks);
 
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
   // Disable the frame-advantage stall so prediction + rollback are
   // exercised at the same rate as in test_rollback_correctness.
-  a->setFrameAdvantageEnabled(false);
-  b->setFrameAdvantageEnabled(false);
-  a->game.rand.seed(kWorldSeed);
-  b->game.rand.seed(kWorldSeed);
+  a->SetFrameAdvantageEnabled(false);
+  b->SetFrameAdvantageEnabled(false);
+  a->game.rand.Seed(kWorldSeed);
+  b->game.rand.Seed(kWorldSeed);
 
   rollback_test::JitterTransport transport({kTransportSeed, 1, 4});
 
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendAToB(gen_, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendBToA(gen_, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
   });
 
   // Capture every emitted checksum. The last value wins on duplicates
   // (e.g. a resim that overwrites a prior promote's value for the same
   // frame after a misprediction cascade).
-  std::unordered_map<uint32_t, uint32_t> aChecks, bChecks;
-  a->setChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { aChecks[f] = c; });
-  b->setChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { bChecks[f] = c; });
+  std::unordered_map<uint32_t, uint32_t> a_checks, b_checks;
+  a->SetChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { a_checks[f] = c; });
+  b->SetChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { b_checks[f] = c; });
 
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
-  auto deliverA = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverB = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(bf, c, in, lf);
   };
 
   for (int i = 0; i < kTicks; ++i) {
-    a->setLocalControlState(script.a[i]);
-    b->setLocalControlState(script.b[i]);
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    a->SetLocalControlState(script.a[i]);
+    b->SetLocalControlState(script.b[i]);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
   }
-  transport.flush(deliverA, deliverB);
+  transport.Flush(deliver_a, deliver_b);
 
   // Drain the promote loop on both sides.
-  a->setLocalControlState(0);
-  b->setLocalControlState(0);
+  a->SetLocalControlState(0);
+  b->SetLocalControlState(0);
   for (int i = 0; i < 12; ++i) {
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
   }
 
-  REQUIRE(a->currentFrame() == b->currentFrame());
-  REQUIRE(a->rollbackCount() > 0);
-  REQUIRE(b->rollbackCount() > 0);
+  REQUIRE(a->CurrentFrame() == b->CurrentFrame());
+  REQUIRE(a->RollbackCount() > 0);
+  REQUIRE(b->RollbackCount() > 0);
 
   // Both peers must emit checksums for a substantial fraction of frames
   // (otherwise the test is vacuous — no detection signal is being sent).
-  REQUIRE(aChecks.size() > static_cast<std::size_t>(kTicks / 2));
-  REQUIRE(bChecks.size() > static_cast<std::size_t>(kTicks / 2));
+  REQUIRE(a_checks.size() > static_cast<std::size_t>(kTicks / 2));
+  REQUIRE(b_checks.size() > static_cast<std::size_t>(kTicks / 2));
 
   std::size_t compared = 0;
   std::size_t alarms = 0;
-  for (auto const& [frame, ca] : aChecks) {
-    auto it = bChecks.find(frame);
-    if (it == bChecks.end()) continue;
+  for (auto const& [frame, ca] : a_checks) {
+    auto it = b_checks.find(frame);
+    if (it == b_checks.end()) continue;
     ++compared;
     if (ca != it->second) {
       ++alarms;
@@ -177,77 +177,77 @@ TEST_CASE("Rollback desync detection — 1-bit injection fires within 200 frames
   // the desync detection has to survive prediction/resim noise.
   constexpr uint32_t kInjectFrame = 200;
 
-  ScriptedInputs script = generateInputs(kInputSeed, kTicks);
+  ScriptedInputs script = GenerateInputs(kInputSeed, kTicks);
 
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
-  a->setFrameAdvantageEnabled(false);
-  b->setFrameAdvantageEnabled(false);
-  a->game.rand.seed(kWorldSeed);
-  b->game.rand.seed(kWorldSeed);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
+  a->SetFrameAdvantageEnabled(false);
+  b->SetFrameAdvantageEnabled(false);
+  a->game.rand.Seed(kWorldSeed);
+  b->game.rand.Seed(kWorldSeed);
 
   rollback_test::JitterTransport transport({kTransportSeed, 1, 4});
 
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendAToB(gen_, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendBToA(gen_, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
   });
 
-  std::unordered_map<uint32_t, uint32_t> aChecks, bChecks;
-  a->setChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { aChecks[f] = c; });
+  std::unordered_map<uint32_t, uint32_t> a_checks, b_checks;
+  a->SetChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) { a_checks[f] = c; });
   // Inject: corrupt B's reported checksum starting at kInjectFrame to
   // simulate a peer whose post-frame state has diverged by one bit.
   // We perturb at the emit boundary rather than poking sim state
   // mid-frame — the latter would feed back into B's snapshot, get
   // restored on rollback, and turn into a structural divergence rather
   // than the "1-bit drift" the plan calls for.
-  b->setChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) {
+  b->SetChecksumCallback([&](uint8_t /*gen*/, uint32_t f, uint32_t c) {
     if (f >= kInjectFrame) c ^= 1u;
-    bChecks[f] = c;
+    b_checks[f] = c;
   });
 
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
-  auto deliverA = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverB = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(bf, c, in, lf);
   };
 
-  uint32_t firstAlarmFrame = UINT32_MAX;
+  uint32_t first_alarm_frame = UINT32_MAX;
   for (int i = 0; i < kTicks; ++i) {
-    a->setLocalControlState(script.a[i]);
-    b->setLocalControlState(script.b[i]);
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    a->SetLocalControlState(script.a[i]);
+    b->SetLocalControlState(script.b[i]);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
 
     // Sweep newly-matched (frame, checksum) pairs and look for the
     // first mismatch ≥ kInjectFrame.
-    for (auto const& [frame, ca] : aChecks) {
+    for (auto const& [frame, ca] : a_checks) {
       if (frame < kInjectFrame) continue;
-      auto it = bChecks.find(frame);
-      if (it == bChecks.end()) continue;
-      if (ca != it->second && frame < firstAlarmFrame) {
-        firstAlarmFrame = frame;
+      auto it = b_checks.find(frame);
+      if (it == b_checks.end()) continue;
+      if (ca != it->second && frame < first_alarm_frame) {
+        first_alarm_frame = frame;
       }
     }
-    if (firstAlarmFrame != UINT32_MAX) break;
+    if (first_alarm_frame != UINT32_MAX) break;
   }
 
-  REQUIRE(firstAlarmFrame != UINT32_MAX);
-  REQUIRE(firstAlarmFrame >= kInjectFrame);
-  REQUIRE(firstAlarmFrame < kInjectFrame + 200);
+  REQUIRE(first_alarm_frame != UINT32_MAX);
+  REQUIRE(first_alarm_frame >= kInjectFrame);
+  REQUIRE(first_alarm_frame < kInjectFrame + 200);
 }

--- a/src/tests/test_rollback_generation_drop.cpp
+++ b/src/tests/test_rollback_generation_drop.cpp
@@ -18,34 +18,34 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
 }  // namespace
 
 TEST_CASE("Rollback controller drops batches from an older generation", "[rollback][generation]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   RollbackController a(common, settings, 0);
-  a.setSkipWeaponSelection(true);
-  a.game.rand.seed(0xC0FFEE);
-  a.focus();
+  a.SetSkipWeaponSelection(true);
+  a.game.rand.Seed(0xC0FFEE);
+  a.Focus();
 
   // Put the controller into the post-transition state directly
   // (production code crosses this via finishWeaponSelect).
-  a.setGenerationForTest(1);
-  REQUIRE(a.generation() == 1);
-  REQUIRE(a.droppedOldGenerationBatches() == 0);
+  a.SetGenerationForTest(1);
+  REQUIRE(a.Generation() == 1);
+  REQUIRE(a.DroppedOldGenerationBatches() == 0);
 
   // Build a stale-generation batch covering frames [0, 7]. With kInputDelay
   // = 1 (rollback default), confirmedFrame() starts at -1 and the ring
@@ -55,46 +55,46 @@ TEST_CASE("Rollback controller drops batches from an older generation", "[rollba
   uint8_t inputs[8] = {0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8};
 
   SECTION("older generation is dropped") {
-    a.injectRemoteBatch(/*generation=*/0, /*baseFrame=*/0, /*count=*/8, inputs,
+    a.InjectRemoteBatch(/*generation=*/0, /*baseFrame=*/0, /*count=*/8, inputs,
                         /*remoteLocalFrame=*/3);
 
-    REQUIRE(a.droppedOldGenerationBatches() == 1);
+    REQUIRE(a.DroppedOldGenerationBatches() == 1);
     // lastKnownRemoteFrame_ stays at its sentinel — a dropped packet
     // must not advance the frame-advantage estimate either.
-    REQUIRE(a.lastKnownRemoteFrame() == -1);
+    REQUIRE(a.LastKnownRemoteFrame() == -1);
     // confirmedFrame is unchanged.
-    REQUIRE(a.confirmedFrame() == -1);
+    REQUIRE(a.ConfirmedFrame() == -1);
   }
 
   SECTION("matching generation is accepted") {
-    a.injectRemoteBatch(/*generation=*/1, /*baseFrame=*/0, /*count=*/8, inputs,
+    a.InjectRemoteBatch(/*generation=*/1, /*baseFrame=*/0, /*count=*/8, inputs,
                         /*remoteLocalFrame=*/3);
 
-    REQUIRE(a.droppedOldGenerationBatches() == 0);
-    REQUIRE(a.lastKnownRemoteFrame() == 3);
+    REQUIRE(a.DroppedOldGenerationBatches() == 0);
+    REQUIRE(a.LastKnownRemoteFrame() == 3);
   }
 
   SECTION("immediate-future generation is buffered") {
     // gen+1 batches are buffered until resetForGamePhase bumps
     // generation_. Until then no input is applied and the drop counter
     // doesn't bump.
-    a.injectRemoteBatch(/*generation=*/2, /*baseFrame=*/0, /*count=*/8, inputs,
+    a.InjectRemoteBatch(/*generation=*/2, /*baseFrame=*/0, /*count=*/8, inputs,
                         /*remoteLocalFrame=*/3);
 
-    REQUIRE(a.droppedOldGenerationBatches() == 0);
-    REQUIRE(a.pendingFutureBatchCount() == 1);
-    REQUIRE(a.lastKnownRemoteFrame() == -1);
+    REQUIRE(a.DroppedOldGenerationBatches() == 0);
+    REQUIRE(a.PendingFutureBatchCount() == 1);
+    REQUIRE(a.LastKnownRemoteFrame() == -1);
   }
 
   SECTION("far-future generation (gen+2 or more) is dropped") {
     // Beyond one phase ahead, the packet describes a simFrame numbering
     // we may never reach in this match. Drop conservatively.
-    a.injectRemoteBatch(/*generation=*/3, /*baseFrame=*/0, /*count=*/8, inputs,
+    a.InjectRemoteBatch(/*generation=*/3, /*baseFrame=*/0, /*count=*/8, inputs,
                         /*remoteLocalFrame=*/3);
 
-    REQUIRE(a.droppedOldGenerationBatches() == 1);
-    REQUIRE(a.pendingFutureBatchCount() == 0);
-    REQUIRE(a.lastKnownRemoteFrame() == -1);
+    REQUIRE(a.DroppedOldGenerationBatches() == 1);
+    REQUIRE(a.PendingFutureBatchCount() == 0);
+    REQUIRE(a.LastKnownRemoteFrame() == -1);
   }
 }
 
@@ -102,52 +102,52 @@ TEST_CASE("Rollback controller drops batches from an older generation", "[rollba
 // game phase starts from a known-empty baseline.
 TEST_CASE("resetForGamePhase clears controller state and bumps generation",
           "[rollback][generation]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   RollbackController c(common, settings, 0);
-  c.setSkipWeaponSelection(true);
-  c.game.rand.seed(0xC0FFEE);
-  c.focus();
+  c.SetSkipWeaponSelection(true);
+  c.game.rand.Seed(0xC0FFEE);
+  c.Focus();
 
   // Drive a handful of frames so simFrame, confirmedFrame, the rollback
   // ring, lastKnownRemoteFrame, etc. are non-default. Seed remote inputs
   // for the input-delay window so frames advance as confirmed.
-  for (uint32_t f = 0; f < 16; ++f) c.injectRemoteInput(f, 0);
+  for (uint32_t f = 0; f < 16; ++f) c.InjectRemoteInput(f, 0);
   for (int i = 0; i < 10; ++i) {
-    c.setLocalControlState(0);
-    c.process();
+    c.SetLocalControlState(0);
+    c.Process();
   }
   // Also feed a batched packet so lastKnownRemoteFrame advances.
   uint8_t bytes[2] = {0, 0};
-  c.injectRemoteBatch(/*generation=*/0, /*baseFrame=*/8, /*count=*/2, bytes,
+  c.InjectRemoteBatch(/*generation=*/0, /*baseFrame=*/8, /*count=*/2, bytes,
                       /*remoteLocalFrame=*/9);
 
-  REQUIRE(c.currentFrame() > 0);
-  REQUIRE(c.confirmedFrame() >= 0);
-  REQUIRE(c.lastKnownRemoteFrame() >= 0);
-  REQUIRE_FALSE(c.rollbackBuffer().empty());
-  uint8_t prevGen = c.generation();
+  REQUIRE(c.CurrentFrame() > 0);
+  REQUIRE(c.ConfirmedFrame() >= 0);
+  REQUIRE(c.LastKnownRemoteFrame() >= 0);
+  REQUIRE_FALSE(c.RollbackBuffer().Empty());
+  uint8_t prev_gen = c.Generation();
 
-  c.resetForGamePhaseForTest();
+  c.ResetForGamePhaseForTest();
 
-  REQUIRE(c.currentFrame() == 0);
-  REQUIRE(c.confirmedFrame() == -1);
-  REQUIRE(c.lastKnownRemoteFrame() == -1);
-  REQUIRE(c.lastTickResimFrames() == 0);
-  REQUIRE(c.generation() == static_cast<uint8_t>(prevGen + 1));
+  REQUIRE(c.CurrentFrame() == 0);
+  REQUIRE(c.ConfirmedFrame() == -1);
+  REQUIRE(c.LastKnownRemoteFrame() == -1);
+  REQUIRE(c.LastTickResimFrames() == 0);
+  REQUIRE(c.Generation() == static_cast<uint8_t>(prev_gen + 1));
   // Ring is empty: no slot can be looked up by frame, oldest/newest
   // sentinel back to -1.
-  REQUIRE(c.rollbackBuffer().empty());
-  REQUIRE(c.rollbackBuffer().newestFrame() == -1);
-  REQUIRE(c.rollbackBuffer().oldestFrame() == -1);
+  REQUIRE(c.RollbackBuffer().Empty());
+  REQUIRE(c.RollbackBuffer().NewestFrame() == -1);
+  REQUIRE(c.RollbackBuffer().OldestFrame() == -1);
 
   // And the post-reset filter accepts gen-1 (= prevGen+1) batches but
   // drops gen-prevGen ones — proving the new generation took effect.
-  c.injectRemoteBatch(prevGen, /*baseFrame=*/0, /*count=*/2, bytes,
+  c.InjectRemoteBatch(prev_gen, /*baseFrame=*/0, /*count=*/2, bytes,
                       /*remoteLocalFrame=*/1);
-  REQUIRE(c.droppedOldGenerationBatches() >= 1);
-  REQUIRE(c.confirmedFrame() == -1);
+  REQUIRE(c.DroppedOldGenerationBatches() >= 1);
+  REQUIRE(c.ConfirmedFrame() == -1);
 
-  c.injectRemoteBatch(static_cast<uint8_t>(prevGen + 1), /*baseFrame=*/0,
+  c.InjectRemoteBatch(static_cast<uint8_t>(prev_gen + 1), /*baseFrame=*/0,
                       /*count=*/2, bytes, /*remoteLocalFrame=*/1);
-  REQUIRE(c.lastKnownRemoteFrame() == 1);
+  REQUIRE(c.LastKnownRemoteFrame() == 1);
 }

--- a/src/tests/test_rollback_generation_future.cpp
+++ b/src/tests/test_rollback_generation_future.cpp
@@ -19,67 +19,67 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
 }  // namespace
 
 TEST_CASE("Future-generation batches buffer and drain on reset", "[rollback][generation]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   RollbackController c(common, settings, 0);
-  c.setSkipWeaponSelection(true);
-  c.game.rand.seed(0xC0FFEE);
-  c.focus();
+  c.SetSkipWeaponSelection(true);
+  c.game.rand.Seed(0xC0FFEE);
+  c.Focus();
 
-  REQUIRE(c.generation() == 0);
-  REQUIRE(c.pendingFutureBatchCount() == 0);
+  REQUIRE(c.Generation() == 0);
+  REQUIRE(c.PendingFutureBatchCount() == 0);
 
   // Peer is ~5 game-phase frames ahead — sends generation-1 batches
   // covering its frames [0..7], [1..8], ... while we're still at gen 0.
   // The buffer holds one window's worth (= one full K-wide batch).
   uint8_t inputs[8] = {0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7};
-  c.injectRemoteBatch(/*generation=*/1, /*baseFrame=*/0, /*count=*/8, inputs,
+  c.InjectRemoteBatch(/*generation=*/1, /*baseFrame=*/0, /*count=*/8, inputs,
                       /*remoteLocalFrame=*/5);
 
   // Not applied yet — generation_ is still 0 so the wire layer holds
   // the batch. The drop counter must NOT increment (this isn't a drop).
-  REQUIRE(c.pendingFutureBatchCount() == 1);
-  REQUIRE(c.droppedOldGenerationBatches() == 0);
-  REQUIRE(c.lastKnownRemoteFrame() == -1);
+  REQUIRE(c.PendingFutureBatchCount() == 1);
+  REQUIRE(c.DroppedOldGenerationBatches() == 0);
+  REQUIRE(c.LastKnownRemoteFrame() == -1);
 
   // Far-future packets ARE dropped (no buffer slot, no recovery path).
-  c.injectRemoteBatch(/*generation=*/2, /*baseFrame=*/0, /*count=*/8, inputs,
+  c.InjectRemoteBatch(/*generation=*/2, /*baseFrame=*/0, /*count=*/8, inputs,
                       /*remoteLocalFrame=*/5);
-  REQUIRE(c.pendingFutureBatchCount() == 1);
-  REQUIRE(c.droppedOldGenerationBatches() == 1);
+  REQUIRE(c.PendingFutureBatchCount() == 1);
+  REQUIRE(c.DroppedOldGenerationBatches() == 1);
 
   // Now we transition. resetForGamePhase bumps generation_ to 1, then
   // drains the buffered batch through injectRemoteBatch as if it had
   // just arrived.
-  c.resetForGamePhaseForTest();
+  c.ResetForGamePhaseForTest();
 
-  REQUIRE(c.generation() == 1);
-  REQUIRE(c.pendingFutureBatchCount() == 0);
+  REQUIRE(c.Generation() == 1);
+  REQUIRE(c.PendingFutureBatchCount() == 0);
   // The drained batch advances lastKnownRemoteFrame_ — proves the
   // batch was actually replayed through the normal receive path, not
   // just discarded.
-  REQUIRE(c.lastKnownRemoteFrame() == 5);
+  REQUIRE(c.LastKnownRemoteFrame() == 5);
   // confirmedSimFrame_ stays at -1: no local frame has been advanced
   // yet, so even though remote inputs are present the local can't have
   // "confirmed" them — the new-frame block in advanceSimulation will
   // consume them on the next process() tick.
-  REQUIRE(c.confirmedFrame() == -1);
+  REQUIRE(c.ConfirmedFrame() == -1);
 }
 
 // Bounded buffer: only kMaxRollback+1 entries fit. Beyond that the
@@ -88,28 +88,28 @@ TEST_CASE("Future-generation batches buffer and drain on reset", "[rollback][gen
 // the next batch usually contains the same window — but this test
 // pins the cap so a future enlarged buffer doesn't silently grow.
 TEST_CASE("Future-generation buffer is bounded", "[rollback][generation]") {
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   RollbackController c(common, settings, 0);
-  c.setSkipWeaponSelection(true);
-  c.game.rand.seed(0xBEEF);
-  c.focus();
+  c.SetSkipWeaponSelection(true);
+  c.game.rand.Seed(0xBEEF);
+  c.Focus();
 
   uint8_t inputs[8] = {0};
 
   constexpr int kCap = rollback::kMaxRollback + 1;
   for (int i = 0; i < kCap; ++i) {
-    c.injectRemoteBatch(/*generation=*/1,
+    c.InjectRemoteBatch(/*generation=*/1,
                         /*baseFrame=*/static_cast<uint32_t>(i),
                         /*count=*/1, inputs,
                         /*remoteLocalFrame=*/static_cast<uint32_t>(i));
   }
-  REQUIRE(c.pendingFutureBatchCount() == kCap);
-  REQUIRE(c.droppedOldGenerationBatches() == 0);
+  REQUIRE(c.PendingFutureBatchCount() == kCap);
+  REQUIRE(c.DroppedOldGenerationBatches() == 0);
 
   // One past the cap: the buffer is full, falls through, drop counter
   // bumps but the buffer doesn't grow.
-  c.injectRemoteBatch(/*generation=*/1, /*baseFrame=*/100, /*count=*/1, inputs,
+  c.InjectRemoteBatch(/*generation=*/1, /*baseFrame=*/100, /*count=*/1, inputs,
                       /*remoteLocalFrame=*/100);
-  REQUIRE(c.pendingFutureBatchCount() == kCap);
-  REQUIRE(c.droppedOldGenerationBatches() == 1);
+  REQUIRE(c.PendingFutureBatchCount() == kCap);
+  REQUIRE(c.DroppedOldGenerationBatches() == 1);
 }

--- a/src/tests/test_rollback_packet_loss.cpp
+++ b/src/tests/test_rollback_packet_loss.cpp
@@ -26,17 +26,17 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
@@ -47,98 +47,98 @@ TEST_CASE("Rollback survives 10% packet loss via input redundancy", "[rollback][
   constexpr int kTicks = 1500;
   constexpr uint32_t kInputSeed = 0xC0FFEE;
 
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
   // Frame-advantage stall is orthogonal to packet loss; turn it off so
   // the peers freely run ahead and we measure redundancy in isolation.
-  a->setFrameAdvantageEnabled(false);
-  b->setFrameAdvantageEnabled(false);
-  a->game.rand.seed(kWorldSeed);
-  b->game.rand.seed(kWorldSeed);
+  a->SetFrameAdvantageEnabled(false);
+  b->SetFrameAdvantageEnabled(false);
+  a->game.rand.Seed(kWorldSeed);
+  b->game.rand.Seed(kWorldSeed);
 
   rollback_test::JitterTransport transport({0x10ADED, /*minDelay*/ 1, /*maxDelay*/ 3,
                                             /*lossProb*/ 0.10, /*dupProb*/ 0.0});
 
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendAToB(gen_, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendBToA(gen_, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
-  auto deliverA = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverB = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(bf, c, in, lf);
   };
 
-  Rand inputRng(kInputSeed);
-  uint32_t maxLagA = 0;
-  uint32_t maxLagB = 0;
-  int stallTicks = 0;
-  uint32_t prevA = 0;
-  uint32_t prevB = 0;
+  Rand input_rng(kInputSeed);
+  uint32_t max_lag_a = 0;
+  uint32_t max_lag_b = 0;
+  int stall_ticks = 0;
+  uint32_t prev_a = 0;
+  uint32_t prev_b = 0;
 
   for (int tick = 0; tick < kTicks; ++tick) {
-    uint8_t inA = inputRng() & 0x7f;
-    uint8_t inB = inputRng() & 0x7f;
-    if ((inputRng() % 10) < 6) inA |= (1 << Worm::Fire);
-    if ((inputRng() % 10) < 6) inB |= (1 << Worm::Fire);
-    a->setLocalControlState(inA);
-    b->setLocalControlState(inB);
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    uint8_t in_a = input_rng() & 0x7f;
+    uint8_t in_b = input_rng() & 0x7f;
+    if ((input_rng() % 10) < 6) in_a |= (1 << Worm::kFire);
+    if ((input_rng() % 10) < 6) in_b |= (1 << Worm::kFire);
+    a->SetLocalControlState(in_a);
+    b->SetLocalControlState(in_b);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
 
     // Steady-state observation begins after the first ~50 ticks so the
     // warm-up doesn't pollute the running maxima.
     if (tick > 50) {
-      uint32_t lagA = a->currentFrame() - static_cast<uint32_t>(a->confirmedFrame() + 1);
-      uint32_t lagB = b->currentFrame() - static_cast<uint32_t>(b->confirmedFrame() + 1);
-      if (lagA > maxLagA) maxLagA = lagA;
-      if (lagB > maxLagB) maxLagB = lagB;
-      if (a->currentFrame() == prevA && b->currentFrame() == prevB) ++stallTicks;
+      uint32_t lag_a = a->CurrentFrame() - static_cast<uint32_t>(a->ConfirmedFrame() + 1);
+      uint32_t lag_b = b->CurrentFrame() - static_cast<uint32_t>(b->ConfirmedFrame() + 1);
+      if (lag_a > max_lag_a) max_lag_a = lag_a;
+      if (lag_b > max_lag_b) max_lag_b = lag_b;
+      if (a->CurrentFrame() == prev_a && b->CurrentFrame() == prev_b) ++stall_ticks;
     }
-    prevA = a->currentFrame();
-    prevB = b->currentFrame();
+    prev_a = a->CurrentFrame();
+    prev_b = b->CurrentFrame();
   }
 
   // Steady-state lag never reaches the stall threshold (kMaxRollback+1).
   // With K-wide redundancy a single dropped packet is covered by the
   // next packet, so the lag tops out at the natural network delay
   // plus a handful of redundant-covered drops.
-  REQUIRE(maxLagA <= static_cast<uint32_t>(rollback::kMaxRollback));
-  REQUIRE(maxLagB <= static_cast<uint32_t>(rollback::kMaxRollback));
+  REQUIRE(max_lag_a <= static_cast<uint32_t>(rollback::kMaxRollback));
+  REQUIRE(max_lag_b <= static_cast<uint32_t>(rollback::kMaxRollback));
 
   // The pair never enters a cascading stall — at least one peer
   // advances every tick under 10% loss.
-  REQUIRE(stallTicks == 0);
+  REQUIRE(stall_ticks == 0);
 
   // Loss should actually have fired; otherwise the test is vacuous.
-  REQUIRE(transport.packetsDropped > 0);
-  REQUIRE(a->rollbackCount() > 0);
-  REQUIRE(b->rollbackCount() > 0);
+  REQUIRE(transport.packets_dropped > 0);
+  REQUIRE(a->RollbackCount() > 0);
+  REQUIRE(b->RollbackCount() > 0);
 
   // Flush and drain, then assert checksums agree.
-  transport.flush(deliverA, deliverB);
-  a->setLocalControlState(0);
-  b->setLocalControlState(0);
+  transport.Flush(deliver_a, deliver_b);
+  a->SetLocalControlState(0);
+  b->SetLocalControlState(0);
   for (int i = 0; i < 16; ++i) {
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
   }
-  REQUIRE(a->currentFrame() == b->currentFrame());
-  REQUIRE(wideRollbackChecksum(a->game) == wideRollbackChecksum(b->game));
+  REQUIRE(a->CurrentFrame() == b->CurrentFrame());
+  REQUIRE(WideRollbackChecksum(a->game) == WideRollbackChecksum(b->game));
 }

--- a/src/tests/test_rollback_reorder.cpp
+++ b/src/tests/test_rollback_reorder.cpp
@@ -26,17 +26,17 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   return {common, settings};
 }
 
@@ -47,18 +47,18 @@ TEST_CASE("Rollback survives reorder + duplication", "[rollback][reorder]") {
   constexpr int kTicks = 1000;
   constexpr uint32_t kInputSeed = 0xC0FFEE;
 
-  auto [common, settings] = makeEnv();
+  auto [common, settings] = MakeEnv();
   auto a = std::make_unique<RollbackController>(common, settings, 0);
   auto b = std::make_unique<RollbackController>(common, settings, 1);
-  a->setSkipWeaponSelection(true);
-  b->setSkipWeaponSelection(true);
+  a->SetSkipWeaponSelection(true);
+  b->SetSkipWeaponSelection(true);
   // Frame-advantage stall clamps the peers to lockstep and
   // suppresses the prediction window we need to exercise the reorder
   // path — disable it so we measure the dedup mechanism directly.
-  a->setFrameAdvantageEnabled(false);
-  b->setFrameAdvantageEnabled(false);
-  a->game.rand.seed(kWorldSeed);
-  b->game.rand.seed(kWorldSeed);
+  a->SetFrameAdvantageEnabled(false);
+  b->SetFrameAdvantageEnabled(false);
+  a->game.rand.Seed(kWorldSeed);
+  b->game.rand.Seed(kWorldSeed);
 
   // Wide delay band + duplication. With min=1, max=5 the variance is
   // large enough that earlier-sent packets routinely arrive after
@@ -68,52 +68,52 @@ TEST_CASE("Rollback survives reorder + duplication", "[rollback][reorder]") {
   rollback_test::JitterTransport transport({0xACE1, /*minDelay*/ 1, /*maxDelay*/ 5,
                                             /*lossProb*/ 0.0, /*dupProb*/ 0.30});
 
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendAToB(gen_, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendBToA(gen_, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   for (uint32_t f = 0; f < 3; ++f) {
-    a->injectRemoteInput(f, 0);
-    b->injectRemoteInput(f, 0);
+    a->InjectRemoteInput(f, 0);
+    b->InjectRemoteInput(f, 0);
   }
 
-  auto deliverA = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(bf, c, in, lf);
   };
-  auto deliverB = [&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(bf, c, in, lf);
   };
 
-  Rand inputRng(kInputSeed);
+  Rand input_rng(kInputSeed);
   for (int tick = 0; tick < kTicks; ++tick) {
-    uint8_t inA = inputRng() & 0x7f;
-    uint8_t inB = inputRng() & 0x7f;
-    if ((inputRng() % 10) < 6) inA |= (1 << Worm::Fire);
-    if ((inputRng() % 10) < 6) inB |= (1 << Worm::Fire);
-    a->setLocalControlState(inA);
-    b->setLocalControlState(inB);
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    uint8_t in_a = input_rng() & 0x7f;
+    uint8_t in_b = input_rng() & 0x7f;
+    if ((input_rng() % 10) < 6) in_a |= (1 << Worm::kFire);
+    if ((input_rng() % 10) < 6) in_b |= (1 << Worm::kFire);
+    a->SetLocalControlState(in_a);
+    b->SetLocalControlState(in_b);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
   }
 
-  transport.flush(deliverA, deliverB);
-  a->setLocalControlState(0);
-  b->setLocalControlState(0);
+  transport.Flush(deliver_a, deliver_b);
+  a->SetLocalControlState(0);
+  b->SetLocalControlState(0);
   for (int i = 0; i < 16; ++i) {
-    a->process();
-    b->process();
-    transport.tick(deliverA, deliverB);
+    a->Process();
+    b->Process();
+    transport.Tick(deliver_a, deliver_b);
   }
 
-  REQUIRE(transport.packetsDuplicated > 0);
-  REQUIRE(a->rollbackCount() > 0);
-  REQUIRE(b->rollbackCount() > 0);
-  REQUIRE(a->currentFrame() == b->currentFrame());
-  REQUIRE(wideRollbackChecksum(a->game) == wideRollbackChecksum(b->game));
+  REQUIRE(transport.packets_duplicated > 0);
+  REQUIRE(a->RollbackCount() > 0);
+  REQUIRE(b->RollbackCount() > 0);
+  REQUIRE(a->CurrentFrame() == b->CurrentFrame());
+  REQUIRE(WideRollbackChecksum(a->game) == WideRollbackChecksum(b->game));
 }

--- a/src/tests/test_rollback_replay.cpp
+++ b/src/tests/test_rollback_replay.cpp
@@ -21,41 +21,41 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
-  settings->selectBotWeapons = 0;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
+  settings->select_bot_weapons = 0;
   return {common, settings};
 }
 
-std::unique_ptr<RollbackController> makePeer(std::shared_ptr<Common> common,
-                                             std::shared_ptr<Settings> settings, int localIdx,
-                                             uint32_t worldSeed) {
-  auto c = std::make_unique<RollbackController>(common, settings, localIdx);
-  c->setInputDelay(1);
-  c->game.rand.seed(worldSeed);
+std::unique_ptr<RollbackController> MakePeer(std::shared_ptr<Common> common,
+                                             std::shared_ptr<Settings> settings, int local_idx,
+                                             uint32_t world_seed) {
+  auto c = std::make_unique<RollbackController>(common, settings, local_idx);
+  c->SetInputDelay(1);
+  c->game.rand.Seed(world_seed);
   return c;
 }
 
-constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
-std::vector<uint8_t> navigateAndConfirm(int nDown) {
+std::vector<uint8_t> NavigateAndConfirm(int n_down) {
   std::vector<uint8_t> out;
-  for (int i = 0; i < nDown; ++i) {
-    out.push_back(BIT_DOWN);
+  for (int i = 0; i < n_down; ++i) {
+    out.push_back(kBitDown);
     out.push_back(0);
   }
   out.push_back(0);
-  out.push_back(BIT_FIRE);
+  out.push_back(kBitFire);
   out.push_back(0);
   return out;
 }
@@ -65,116 +65,116 @@ std::vector<uint8_t> navigateAndConfirm(int nDown) {
 // Common round-trip body parameterised on which peer (localIdx) records.
 // Both indices use the same makePeer fixture so the test exercises the
 // host (localIdx=0) and client (localIdx=1) paths symmetrically.
-static void runRoundTrip(int recorderIdx) {
+static void RunRoundTrip(int recorder_idx) {
   constexpr uint32_t kWorldSeed = 0xDEADBEEF;
-  auto [common, settings] = makeEnv();
-  auto a = makePeer(common, settings, recorderIdx, kWorldSeed);
-  auto b = makePeer(common, settings, recorderIdx ^ 1, kWorldSeed);
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, recorder_idx, kWorldSeed);
+  auto b = MakePeer(common, settings, recorder_idx ^ 1, kWorldSeed);
 
   // Capture peer A's replay stream into a vector via VectorWriter, so
   // the test can read it back after the match without touching disk.
-  std::vector<uint8_t> replayBytes;
-  a->setReplayWriterOverride(std::make_unique<io::VectorWriter>(replayBytes));
+  std::vector<uint8_t> replay_bytes;
+  a->SetReplayWriterOverride(std::make_unique<io::VectorWriter>(replay_bytes));
 
   // Direct synchronous batch delivery — same pattern test_rollback_weapsel
   // uses for its zero-jitter case.
   struct Pkt {
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
-    uint32_t localFrame;
+    uint32_t local_frame;
   };
-  std::vector<Pkt> aToB, bToA;
+  std::vector<Pkt> a_to_b, b_to_a;
   auto enqueue = [](std::vector<Pkt>& q, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
     Pkt p{};
-    p.baseFrame = bf;
+    p.base_frame = bf;
     p.count = c;
-    p.localFrame = lf;
+    p.local_frame = lf;
     for (uint8_t i = 0; i < c; ++i) p.inputs[i] = in[i];
     q.push_back(p);
   };
-  a->setInputCallbacks([&](uint8_t, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(aToB, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(a_to_b, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(bToA, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(b_to_a, bf, c, in, lf);
   });
 
-  a->focus();
-  b->focus();
-  a->injectRemoteInput(0, 0);
-  b->injectRemoteInput(0, 0);
+  a->Focus();
+  b->Focus();
+  a->InjectRemoteInput(0, 0);
+  b->InjectRemoteInput(0, 0);
 
   // Run the WS script, then a tail of idle ticks so the WS→Game
   // transition lands. Then run game-phase ticks until peer A's shadow
   // has confirmed a decent number of frames worth of recording.
-  auto wsScript = navigateAndConfirm(6);
+  auto ws_script = NavigateAndConfirm(6);
   constexpr int kWsTail = 40;
   constexpr int kGameTicks = 120;
 
-  int totalTicks = static_cast<int>(wsScript.size()) + kWsTail + kGameTicks;
-  for (int i = 0; i < totalTicks; ++i) {
-    uint8_t in = (i < static_cast<int>(wsScript.size())) ? wsScript[i] : 0;
-    a->setLocalControlState(in);
-    b->setLocalControlState(in);
-    a->process();
-    b->process();
-    for (auto const& p : aToB)
-      b->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    for (auto const& p : bToA)
-      a->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    aToB.clear();
-    bToA.clear();
+  int total_ticks = static_cast<int>(ws_script.size()) + kWsTail + kGameTicks;
+  for (int i = 0; i < total_ticks; ++i) {
+    uint8_t in = (i < static_cast<int>(ws_script.size())) ? ws_script[i] : 0;
+    a->SetLocalControlState(in);
+    b->SetLocalControlState(in);
+    a->Process();
+    b->Process();
+    for (auto const& p : a_to_b)
+      b->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    for (auto const& p : b_to_a)
+      a->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    a_to_b.clear();
+    b_to_a.clear();
   }
 
-  REQUIRE(a->gameState() == StateGame);
-  REQUIRE(b->gameState() == StateGame);
-  REQUIRE(a->rollbackCount() == 0);
+  REQUIRE(a->State() == kStateGame);
+  REQUIRE(b->State() == kStateGame);
+  REQUIRE(a->RollbackCount() == 0);
 
   // Snapshot the shadow's expected final state BEFORE endMatch so
   // additional fade-out ticks can't advance it past what the recording
   // captured.
-  Game* shadow = a->shadowGameForTest();
+  Game* shadow = a->ShadowGameForTest();
   REQUIRE(shadow != nullptr);
-  uint32_t shadowChecksum = wideRollbackChecksum(*shadow);
-  int shadowCycles = shadow->cycles;
+  uint32_t shadow_checksum = WideRollbackChecksum(*shadow);
+  int shadow_cycles = shadow->cycles;
 
   // End the match so ReplayWriter's terminator gets flushed and the
   // DeflateWriter inside it gets finalized. Up until this point the
   // DeflateWriter has been buffering uncompressed output; endMatch
   // triggers ~ReplayWriter which triggers ~DeflateWriter which flushes
   // the compressed stream into replayBytes via VectorWriter.
-  a->endMatch();
+  a->EndMatch();
 
-  REQUIRE(!replayBytes.empty());
+  REQUIRE(!replay_bytes.empty());
 
   // Read back. ReplayReader inflates the captured bytes during
   // construction; the Game returned by beginPlayback isn't yet wired
   // into the reader (ReplayController does that, see
   // replayController.cpp:55) so we do it explicitly here.
-  ReplayReader rr(std::make_unique<io::MemReader>(replayBytes));
-  auto playSp = std::make_shared<NullSoundPlayer>();
-  std::unique_ptr<Game> playback = rr.beginPlayback(common, playSp);
+  ReplayReader rr(std::make_unique<io::MemReader>(replay_bytes));
+  auto play_sp = std::make_shared<NullSoundPlayer>();
+  std::unique_ptr<Game> playback = rr.BeginPlayback(common, play_sp);
   REQUIRE(playback != nullptr);
   rr.game = playback.get();
 
   // Step playback until the file's 0x83 terminator.
   Renderer renderer;
-  int playedFrames = 0;
-  while (rr.playbackFrame(renderer)) {
-    playback->processFrame();
-    ++playedFrames;
-    if (playedFrames > 10000) FAIL("playback ran past expected length");
+  int played_frames = 0;
+  while (rr.PlaybackFrame(renderer)) {
+    playback->ProcessFrame();
+    ++played_frames;
+    if (played_frames > 10000) FAIL("playback ran past expected length");
   }
 
-  REQUIRE(playedFrames > 0);
+  REQUIRE(played_frames > 0);
 
   // The playback should land on exactly the same sim state the shadow
   // was in when recording stopped: same cycles count, same wide
   // checksum. Any divergence here means the recorded delta stream
   // doesn't faithfully reproduce the simulation it captured.
-  REQUIRE(playback->cycles == shadowCycles);
-  REQUIRE(wideRollbackChecksum(*playback) == shadowChecksum);
+  REQUIRE(playback->cycles == shadow_cycles);
+  REQUIRE(WideRollbackChecksum(*playback) == shadow_checksum);
 
   // The recorded level palette must round-trip to the same bytes the
   // shadow saw when it began recording. Regression guard for the
@@ -196,9 +196,9 @@ static void runRoundTrip(int recorderIdx) {
 }
 
 TEST_CASE("Multiplayer replay round-trip matches live shadow (host)", "[rollback][replay]") {
-  runRoundTrip(0);
+  RunRoundTrip(0);
 }
 
 TEST_CASE("Multiplayer replay round-trip matches live shadow (client)", "[rollback][replay]") {
-  runRoundTrip(1);
+  RunRoundTrip(1);
 }

--- a/src/tests/test_rollback_skew_repro.cpp
+++ b/src/tests/test_rollback_skew_repro.cpp
@@ -29,41 +29,41 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
-  settings->selectBotWeapons = 0;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
+  settings->select_bot_weapons = 0;
   return {common, settings};
 }
 
-std::unique_ptr<RollbackController> makePeer(std::shared_ptr<Common> common,
-                                             std::shared_ptr<Settings> settings, int localIdx,
-                                             uint32_t worldSeed) {
-  auto c = std::make_unique<RollbackController>(common, settings, localIdx);
-  c->setInputDelay(1);
-  c->game.rand.seed(worldSeed);
+std::unique_ptr<RollbackController> MakePeer(std::shared_ptr<Common> common,
+                                             std::shared_ptr<Settings> settings, int local_idx,
+                                             uint32_t world_seed) {
+  auto c = std::make_unique<RollbackController>(common, settings, local_idx);
+  c->SetInputDelay(1);
+  c->game.rand.Seed(world_seed);
   return c;
 }
 
-constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
-std::vector<uint8_t> navigateToDoneAndConfirm(int nDown) {
+std::vector<uint8_t> NavigateToDoneAndConfirm(int n_down) {
   std::vector<uint8_t> out;
-  for (int i = 0; i < nDown; ++i) {
-    out.push_back(BIT_DOWN);
+  for (int i = 0; i < n_down; ++i) {
+    out.push_back(kBitDown);
     out.push_back(0);
   }
   out.push_back(0);
-  out.push_back(BIT_FIRE);
+  out.push_back(kBitFire);
   out.push_back(0);
   return out;
 }
@@ -72,9 +72,9 @@ std::vector<uint8_t> navigateToDoneAndConfirm(int nDown) {
 
 TEST_CASE("WS simFrame skew is erased at the WS→game transition", "[rollback][step14][skew]") {
   constexpr uint32_t kWorldSeed = 0xF00DBABE;
-  auto [common, settings] = makeEnv();
-  auto a = makePeer(common, settings, 0, kWorldSeed);
-  auto b = makePeer(common, settings, 1, kWorldSeed);
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, 0, kWorldSeed);
+  auto b = MakePeer(common, settings, 1, kWorldSeed);
 
   // Asymmetric delays — A→B fast (1 frame), B→A slow (4 frames). Plus
   // we disable A's frame-advantage stall so A runs ahead freely while B
@@ -82,96 +82,96 @@ TEST_CASE("WS simFrame skew is erased at the WS→game transition", "[rollback][
   // slower. The combination reliably produces a multi-frame WS-phase
   // skew while keeping both peers progressing enough to eventually
   // confirm wsDone.
-  rollback_test::JitterTransport tAB(
+  rollback_test::JitterTransport t_ab(
       {0x1111, /*minDelay=*/1, /*maxDelay=*/1, /*loss=*/0.0, /*dup=*/0.0});
-  rollback_test::JitterTransport tBA(
+  rollback_test::JitterTransport t_ba(
       {0x2222, /*minDelay=*/4, /*maxDelay=*/4, /*loss=*/0.0, /*dup=*/0.0});
-  a->setFrameAdvantageEnabled(false);
+  a->SetFrameAdvantageEnabled(false);
 
-  a->setInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    tAB.sendAToB(gen, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    t_ab.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    tBA.sendAToB(gen, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    t_ba.SendAToB(gen, bf, c, in, lf);
   });
 
-  a->focus();
-  b->focus();
-  a->injectRemoteInput(0, 0);
-  b->injectRemoteInput(0, 0);
+  a->Focus();
+  b->Focus();
+  a->InjectRemoteInput(0, 0);
+  b->InjectRemoteInput(0, 0);
 
-  auto deliverB = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(gen, bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(gen, bf, c, in, lf);
   };
-  auto deliverA = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(gen, bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(gen, bf, c, in, lf);
   };
   auto noop = [&](uint8_t, uint32_t, uint8_t, uint8_t const*, uint32_t) {};
 
-  auto script = navigateToDoneAndConfirm(6);
+  auto script = NavigateToDoneAndConfirm(6);
   constexpr int kWsTail = 80;  // extra ticks so the slower peer catches up
 
-  bool aTransitioned = false, bTransitioned = false;
-  uint32_t aTransitionFrame = 0, bTransitionFrame = 0;
-  int maxObservedSkew = 0;
+  bool a_transitioned = false, b_transitioned = false;
+  uint32_t a_transition_frame = 0, b_transition_frame = 0;
+  int max_observed_skew = 0;
 
-  auto stepBoth = [&](uint8_t inA, uint8_t inB) {
-    a->setLocalControlState(inA);
-    b->setLocalControlState(inB);
-    bool aPre = !aTransitioned;
-    bool bPre = !bTransitioned;
-    a->process();
-    b->process();
-    if (aPre && a->gameState() == StateGame) {
-      aTransitioned = true;
-      aTransitionFrame = a->currentFrame();
+  auto step_both = [&](uint8_t in_a, uint8_t in_b) {
+    a->SetLocalControlState(in_a);
+    b->SetLocalControlState(in_b);
+    bool a_pre = !a_transitioned;
+    bool b_pre = !b_transitioned;
+    a->Process();
+    b->Process();
+    if (a_pre && a->State() == kStateGame) {
+      a_transitioned = true;
+      a_transition_frame = a->CurrentFrame();
     }
-    if (bPre && b->gameState() == StateGame) {
-      bTransitioned = true;
-      bTransitionFrame = b->currentFrame();
+    if (b_pre && b->State() == kStateGame) {
+      b_transitioned = true;
+      b_transition_frame = b->CurrentFrame();
     }
     // tAB carries A→B; the "deliverA" leg of its tick is unused.
-    tAB.tick(noop, deliverB);
-    tBA.tick(noop, deliverA);
+    t_ab.Tick(noop, deliver_b);
+    t_ba.Tick(noop, deliver_a);
   };
 
   for (int i = 0;
-       i < static_cast<int>(script.size()) + kWsTail && !(aTransitioned && bTransitioned); ++i) {
+       i < static_cast<int>(script.size()) + kWsTail && !(a_transitioned && b_transitioned); ++i) {
     uint8_t in = (i < static_cast<int>(script.size())) ? script[i] : 0;
-    stepBoth(in, in);
+    step_both(in, in);
     // Observe WS-phase skew while at least one peer is still pre-transition.
-    if (!aTransitioned || !bTransitioned) {
-      int gap = static_cast<int>(a->currentFrame()) - static_cast<int>(b->currentFrame());
+    if (!a_transitioned || !b_transitioned) {
+      int gap = static_cast<int>(a->CurrentFrame()) - static_cast<int>(b->CurrentFrame());
       if (gap < 0) gap = -gap;
-      if (gap > maxObservedSkew) maxObservedSkew = gap;
+      if (gap > max_observed_skew) max_observed_skew = gap;
     }
   }
 
   // Flush any tail packets, then a few idle ticks to finish either peer
   // that hasn't transitioned yet.
-  tAB.flush(noop, deliverB);
-  tBA.flush(noop, deliverA);
-  for (int i = 0; i < 24 && !(aTransitioned && bTransitioned); ++i) {
-    stepBoth(0, 0);
+  t_ab.Flush(noop, deliver_b);
+  t_ba.Flush(noop, deliver_a);
+  for (int i = 0; i < 24 && !(a_transitioned && b_transitioned); ++i) {
+    step_both(0, 0);
   }
 
-  INFO("maxObservedSkew=" << maxObservedSkew << " aTransitionFrame=" << aTransitionFrame
-                          << " bTransitionFrame=" << bTransitionFrame);
-  REQUIRE(aTransitioned);
-  REQUIRE(bTransitioned);
+  INFO("maxObservedSkew=" << max_observed_skew << " aTransitionFrame=" << a_transition_frame
+                          << " bTransitionFrame=" << b_transition_frame);
+  REQUIRE(a_transitioned);
+  REQUIRE(b_transitioned);
 
   // Headline: regardless of WS skew, both peers entered game phase at
   // simFrame=0. Removing the post-WS reset would leave the peers at
   // whatever simFrame WS reached on each side.
-  REQUIRE(aTransitionFrame == 0);
-  REQUIRE(bTransitionFrame == 0);
+  REQUIRE(a_transition_frame == 0);
+  REQUIRE(b_transition_frame == 0);
 
   // Vacuity guard: if we never observed a WS-phase skew the test isn't
   // exercising the bug class. The asymmetric delay + disabled
   // frame-advantage on A routinely produces a multi-frame gap; a
   // single-frame gap is still meaningful evidence the timeline went
   // asymmetric.
-  REQUIRE(maxObservedSkew >= 1);
+  REQUIRE(max_observed_skew >= 1);
 
   // Drive ~32 game-phase frames in sync, then a flush + short drain.
   // Both peers stay idle so the sim produces identical state on each
@@ -179,12 +179,12 @@ TEST_CASE("WS simFrame skew is erased at the WS→game transition", "[rollback][
   // because the B→A pipe still delays inputs by 4 frames.
   constexpr int kGameFrames = 32;
   for (int i = 0; i < kGameFrames; ++i) {
-    stepBoth(0, 0);
+    step_both(0, 0);
   }
-  tAB.flush(noop, deliverB);
-  tBA.flush(noop, deliverA);
+  t_ab.Flush(noop, deliver_b);
+  t_ba.Flush(noop, deliver_a);
   for (int i = 0; i < 16; ++i) {
-    stepBoth(0, 0);
+    step_both(0, 0);
   }
 
   // Cached wideRollbackChecksum match across the slots currently
@@ -196,17 +196,17 @@ TEST_CASE("WS simFrame skew is erased at the WS→game transition", "[rollback][
   // checksumming this guards the first ~32 game-phase frames'
   // determinism (any earlier mismatch would propagate forward into
   // the still-resident frames).
-  rollback::RollbackBuffer const& bufA = a->rollbackBuffer();
-  rollback::RollbackBuffer const& bufB = b->rollbackBuffer();
+  rollback::RollbackBuffer const& buf_a = a->RollbackBuffer();
+  rollback::RollbackBuffer const& buf_b = b->RollbackBuffer();
   int compared = 0;
-  int loF = std::max(bufA.oldestFrame(), bufB.oldestFrame());
-  int hiF = std::min(bufA.newestFrame(), bufB.newestFrame());
-  for (int f = loF; f <= hiF; ++f) {
-    auto* slotA = const_cast<rollback::RollbackBuffer&>(bufA).find(f);
-    auto* slotB = const_cast<rollback::RollbackBuffer&>(bufB).find(f);
-    if (!slotA || !slotB) continue;
-    INFO("frame " << f << " A=" << slotA->checksum << " B=" << slotB->checksum);
-    REQUIRE(slotA->checksum == slotB->checksum);
+  int lo_f = std::max(buf_a.OldestFrame(), buf_b.OldestFrame());
+  int hi_f = std::min(buf_a.NewestFrame(), buf_b.NewestFrame());
+  for (int f = lo_f; f <= hi_f; ++f) {
+    auto* slot_a = const_cast<rollback::RollbackBuffer&>(buf_a).Find(f);
+    auto* slot_b = const_cast<rollback::RollbackBuffer&>(buf_b).Find(f);
+    if (!slot_a || !slot_b) continue;
+    INFO("frame " << f << " A=" << slot_a->checksum << " B=" << slot_b->checksum);
+    REQUIRE(slot_a->checksum == slot_b->checksum);
     ++compared;
   }
   // Vacuity guard.

--- a/src/tests/test_rollback_weapsel.cpp
+++ b/src/tests/test_rollback_weapsel.cpp
@@ -153,7 +153,7 @@ TEST_CASE("WeaponSelectSnap round-trip preserves state", "[rollback][weapsel]") 
   // one observable axis — otherwise the test wouldn't have exercised
   // any state change to round-trip.
   bool mutated_differs = mutated.players[0].menu_selection != snap.players[0].menu_selection ||
-                        mutated.local_prev_input != snap.local_prev_input;
+                         mutated.local_prev_input != snap.local_prev_input;
   REQUIRE(mutated_differs);
 }
 

--- a/src/tests/test_rollback_weapsel.cpp
+++ b/src/tests/test_rollback_weapsel.cpp
@@ -38,50 +38,50 @@
 
 namespace {
 
-std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> makeEnv() {
-  precomputeTables();
+std::pair<std::shared_ptr<Common>, std::shared_ptr<Settings>> MakeEnv() {
+  PrecomputeTables();
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-  common->load(std::move(tcRoot));
+  FsNode tc_root(FsNode("data") / "TC" / "openliero");
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
   settings->lives = 10;
-  settings->loadingTime = 0;
-  settings->loadChange = true;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
   // Disable bot weapon auto-pick path so the test drives the menu
   // explicitly rather than auto-ready'ing.
-  settings->selectBotWeapons = 0;
+  settings->select_bot_weapons = 0;
   return {common, settings};
 }
 
-std::unique_ptr<RollbackController> makePeer(std::shared_ptr<Common> common,
-                                             std::shared_ptr<Settings> settings, int localIdx,
-                                             uint32_t worldSeed) {
-  auto c = std::make_unique<RollbackController>(common, settings, localIdx);
-  c->setInputDelay(1);
-  c->game.rand.seed(worldSeed);
+std::unique_ptr<RollbackController> MakePeer(std::shared_ptr<Common> common,
+                                             std::shared_ptr<Settings> settings, int local_idx,
+                                             uint32_t world_seed) {
+  auto c = std::make_unique<RollbackController>(common, settings, local_idx);
+  c->SetInputDelay(1);
+  c->game.rand.Seed(world_seed);
   return c;
 }
 
-constexpr uint8_t BIT_UP = uint8_t{1} << Worm::Up;
-constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+constexpr uint8_t kBitUp = uint8_t{1} << Worm::kUp;
+constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
 // Build a navigation script that presses Down `nDown` times then Fire.
 // Each press is two ticks (on, off) to produce a clean rising edge per
 // press; the trailing idle tick lets the input settle before the next.
 // Returns a vector of input bytes, one per tick.
-std::vector<uint8_t> navigateToDoneAndConfirm(int nDown) {
+std::vector<uint8_t> NavigateToDoneAndConfirm(int n_down) {
   std::vector<uint8_t> out;
-  for (int i = 0; i < nDown; ++i) {
-    out.push_back(BIT_DOWN);
+  for (int i = 0; i < n_down; ++i) {
+    out.push_back(kBitDown);
     out.push_back(0);
   }
   // A short idle pad lets any held-key repeat settle. Then a clean
   // Fire press.
   out.push_back(0);
-  out.push_back(BIT_FIRE);
+  out.push_back(kBitFire);
   out.push_back(0);
   return out;
 }
@@ -89,255 +89,255 @@ std::vector<uint8_t> navigateToDoneAndConfirm(int nDown) {
 }  // namespace
 
 TEST_CASE("WeaponSelectSnap round-trip preserves state", "[rollback][weapsel]") {
-  auto [common, settings] = makeEnv();
-  auto a = makePeer(common, settings, 0, 0xC0FFEE);
-  a->focus();
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, 0, 0xC0FFEE);
+  a->Focus();
 
   // Run a handful of ticks to mutate ws / worm state from its initial
   // value (cursor moves, possibly a weapon cycle). Use scripted local
   // input + a couple of pre-fill remote inputs for symmetry.
-  a->injectRemoteInput(0, 0);
+  a->InjectRemoteInput(0, 0);
   for (int i = 0; i < 6; ++i) {
-    a->setLocalControlState((i % 2 == 0) ? BIT_DOWN : 0);
-    a->process();
-    a->injectRemoteInput(static_cast<uint32_t>(i + 1), 0);
+    a->SetLocalControlState((i % 2 == 0) ? kBitDown : 0);
+    a->Process();
+    a->InjectRemoteInput(static_cast<uint32_t>(i + 1), 0);
   }
-  REQUIRE(a->currentFrame() > 0);
+  REQUIRE(a->CurrentFrame() > 0);
 
   // Capture the snapshot.
   WeaponSelectSnap snap;
-  a->saveWeaponSelectSnap(snap);
+  a->SaveWeaponSelectSnap(snap);
   REQUIRE(snap.valid);
 
   // Independently capture state we expect restore to recover.
-  int wormCurrentWeaponBefore = a->game.worms[0]->currentWeapon;
-  uint32_t weaponIdBefore = a->game.worms[0]->settings->weapons[0];
+  int worm_current_weapon_before = a->game.worms[0]->current_weapon;
+  uint32_t weapon_id_before = a->game.worms[0]->settings->weapons[0];
 
   // Mutate further by running more ticks with a different input.
   for (int i = 0; i < 8; ++i) {
-    a->setLocalControlState((i % 2 == 0) ? BIT_UP : 0);
-    a->process();
-    a->injectRemoteInput(static_cast<uint32_t>(7 + i), 0);
+    a->SetLocalControlState((i % 2 == 0) ? kBitUp : 0);
+    a->Process();
+    a->InjectRemoteInput(static_cast<uint32_t>(7 + i), 0);
   }
 
   // Save a "mutated" snapshot to verify it differs from the original.
   WeaponSelectSnap mutated;
-  a->saveWeaponSelectSnap(mutated);
+  a->SaveWeaponSelectSnap(mutated);
 
   // Restore the original snapshot.
-  a->loadWeaponSelectSnap(snap);
+  a->LoadWeaponSelectSnap(snap);
 
   // Verify the restored state matches what we captured.
-  REQUIRE(a->game.worms[0]->currentWeapon == wormCurrentWeaponBefore);
-  REQUIRE(a->game.worms[0]->settings->weapons[0] == weaponIdBefore);
+  REQUIRE(a->game.worms[0]->current_weapon == worm_current_weapon_before);
+  REQUIRE(a->game.worms[0]->settings->weapons[0] == weapon_id_before);
 
   // Save a third snapshot after restore — it must match the original.
   WeaponSelectSnap restored;
-  a->saveWeaponSelectSnap(restored);
+  a->SaveWeaponSelectSnap(restored);
   REQUIRE(restored.valid);
   for (int i = 0; i < 2; ++i) {
     REQUIRE(restored.players[i].weapons == snap.players[i].weapons);
-    REQUIRE(restored.players[i].isReady == snap.players[i].isReady);
-    REQUIRE(restored.players[i].menuSelection == snap.players[i].menuSelection);
-    REQUIRE(restored.players[i].menuTopItem == snap.players[i].menuTopItem);
-    REQUIRE(restored.players[i].menuBottomItem == snap.players[i].menuBottomItem);
-    REQUIRE(restored.players[i].wormControlStates == snap.players[i].wormControlStates);
-    REQUIRE(restored.players[i].currentWeapon == snap.players[i].currentWeapon);
+    REQUIRE(restored.players[i].is_ready == snap.players[i].is_ready);
+    REQUIRE(restored.players[i].menu_selection == snap.players[i].menu_selection);
+    REQUIRE(restored.players[i].menu_top_item == snap.players[i].menu_top_item);
+    REQUIRE(restored.players[i].menu_bottom_item == snap.players[i].menu_bottom_item);
+    REQUIRE(restored.players[i].worm_control_states == snap.players[i].worm_control_states);
+    REQUIRE(restored.players[i].current_weapon == snap.players[i].current_weapon);
   }
-  REQUIRE(restored.localPrevInput == snap.localPrevInput);
-  REQUIRE(restored.remotePrevInput == snap.remotePrevInput);
-  REQUIRE(restored.localHeldFrames == snap.localHeldFrames);
-  REQUIRE(restored.remoteHeldFrames == snap.remoteHeldFrames);
+  REQUIRE(restored.local_prev_input == snap.local_prev_input);
+  REQUIRE(restored.remote_prev_input == snap.remote_prev_input);
+  REQUIRE(restored.local_held_frames == snap.local_held_frames);
+  REQUIRE(restored.remote_held_frames == snap.remote_held_frames);
 
   // And the mutated snapshot must differ from the original on at least
   // one observable axis — otherwise the test wouldn't have exercised
   // any state change to round-trip.
-  bool mutatedDiffers = mutated.players[0].menuSelection != snap.players[0].menuSelection ||
-                        mutated.localPrevInput != snap.localPrevInput;
-  REQUIRE(mutatedDiffers);
+  bool mutated_differs = mutated.players[0].menu_selection != snap.players[0].menu_selection ||
+                        mutated.local_prev_input != snap.local_prev_input;
+  REQUIRE(mutated_differs);
 }
 
 TEST_CASE("Weapon select reaches StateGame in sync under zero jitter", "[rollback][weapsel]") {
   constexpr uint32_t kWorldSeed = 0xC0FFEE;
-  auto [common, settings] = makeEnv();
-  auto a = makePeer(common, settings, 0, kWorldSeed);
-  auto b = makePeer(common, settings, 1, kWorldSeed);
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, 0, kWorldSeed);
+  auto b = MakePeer(common, settings, 1, kWorldSeed);
 
   // Direct synchronous delivery — bypass the transport queue so the
   // peers behave like the production session under zero loss / zero
   // delay.
   struct Pkt {
-    uint32_t baseFrame;
+    uint32_t base_frame;
     uint8_t count;
     std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
-    uint32_t localFrame;
+    uint32_t local_frame;
   };
-  std::vector<Pkt> aToB, bToA;
+  std::vector<Pkt> a_to_b, b_to_a;
   auto enqueue = [](std::vector<Pkt>& q, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
     Pkt p{};
-    p.baseFrame = bf;
+    p.base_frame = bf;
     p.count = c;
-    p.localFrame = lf;
+    p.local_frame = lf;
     for (uint8_t i = 0; i < c; ++i) p.inputs[i] = in[i];
     q.push_back(p);
   };
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(aToB, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(a_to_b, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    enqueue(bToA, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(b_to_a, bf, c, in, lf);
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
   // Pre-fill the inputDelay=1 window.
-  a->injectRemoteInput(0, 0);
-  b->injectRemoteInput(0, 0);
+  a->InjectRemoteInput(0, 0);
+  b->InjectRemoteInput(0, 0);
 
-  auto script = navigateToDoneAndConfirm(6);
+  auto script = NavigateToDoneAndConfirm(6);
   // Run the script + a healthy tail of idle ticks. The transition only
   // happens at a confirmed frame, so we need enough ticks past the Fire
   // press for the chain to catch up.
   constexpr int kIdleTail = 30;
 
-  bool aTransitioned = false, bTransitioned = false;
-  uint32_t aTransitionFrame = 0, bTransitionFrame = 0;
+  bool a_transitioned = false, b_transitioned = false;
+  uint32_t a_transition_frame = 0, b_transition_frame = 0;
 
   for (int i = 0; i < static_cast<int>(script.size()) + kIdleTail; ++i) {
     uint8_t in = (i < static_cast<int>(script.size())) ? script[i] : 0;
-    a->setLocalControlState(in);
-    b->setLocalControlState(in);
-    bool aInWeapselBefore = !aTransitioned;
-    bool bInWeapselBefore = !bTransitioned;
-    a->process();
-    b->process();
+    a->SetLocalControlState(in);
+    b->SetLocalControlState(in);
+    bool a_in_weapsel_before = !a_transitioned;
+    bool b_in_weapsel_before = !b_transitioned;
+    a->Process();
+    b->Process();
     // Track the first tick at which each peer crosses into StateGame.
-    if (aInWeapselBefore && a->gameState() == StateGame) {
-      aTransitioned = true;
-      aTransitionFrame = a->currentFrame();
+    if (a_in_weapsel_before && a->State() == kStateGame) {
+      a_transitioned = true;
+      a_transition_frame = a->CurrentFrame();
     }
-    if (bInWeapselBefore && b->gameState() == StateGame) {
-      bTransitioned = true;
-      bTransitionFrame = b->currentFrame();
+    if (b_in_weapsel_before && b->State() == kStateGame) {
+      b_transitioned = true;
+      b_transition_frame = b->CurrentFrame();
     }
-    for (auto const& p : aToB)
-      b->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    for (auto const& p : bToA)
-      a->injectRemoteBatch(p.baseFrame, p.count, p.inputs.data(), p.localFrame);
-    aToB.clear();
-    bToA.clear();
+    for (auto const& p : a_to_b)
+      b->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    for (auto const& p : b_to_a)
+      a->InjectRemoteBatch(p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    a_to_b.clear();
+    b_to_a.clear();
   }
 
-  REQUIRE(aTransitioned);
-  REQUIRE(bTransitioned);
-  REQUIRE(aTransitionFrame == bTransitionFrame);
+  REQUIRE(a_transitioned);
+  REQUIRE(b_transitioned);
+  REQUIRE(a_transition_frame == b_transition_frame);
 
   // With zero jitter, predictions always match real input — no rollback
   // should have fired.
-  REQUIRE(a->rollbackCount() == 0);
-  REQUIRE(b->rollbackCount() == 0);
+  REQUIRE(a->RollbackCount() == 0);
+  REQUIRE(b->RollbackCount() == 0);
 
   // Both peers picked the same weapons.
   for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
       REQUIRE(a->game.worms[i]->settings->weapons[j] == b->game.worms[i]->settings->weapons[j]);
     }
   }
 
   // Game-phase state hashes match after transition.
-  REQUIRE(wideRollbackChecksum(a->game) == wideRollbackChecksum(b->game));
+  REQUIRE(WideRollbackChecksum(a->game) == WideRollbackChecksum(b->game));
 }
 
 TEST_CASE("Weapon select transitions cleanly under jitter", "[rollback][weapsel]") {
   constexpr uint32_t kWorldSeed = 0xBEEF1234;
-  auto [common, settings] = makeEnv();
-  auto a = makePeer(common, settings, 0, kWorldSeed);
-  auto b = makePeer(common, settings, 1, kWorldSeed);
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, 0, kWorldSeed);
+  auto b = MakePeer(common, settings, 1, kWorldSeed);
 
   rollback_test::JitterTransport transport({0xA5A5, /*minDelay=*/1, /*maxDelay=*/3,
                                             /*loss=*/0.0, /*duplicate=*/0.0});
 
-  a->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendAToB(gen_, bf, c, in, lf);
+  a->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
   });
-  b->setInputCallbacks([&](uint8_t gen_, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    transport.sendBToA(gen_, bf, c, in, lf);
+  b->SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
   });
-  a->focus();
-  b->focus();
+  a->Focus();
+  b->Focus();
 
-  a->injectRemoteInput(0, 0);
-  b->injectRemoteInput(0, 0);
+  a->InjectRemoteInput(0, 0);
+  b->InjectRemoteInput(0, 0);
 
-  auto deliverA = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    a->injectRemoteBatch(gen, bf, c, in, lf);
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a->InjectRemoteBatch(gen, bf, c, in, lf);
   };
-  auto deliverB = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
-    b->injectRemoteBatch(gen, bf, c, in, lf);
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b->InjectRemoteBatch(gen, bf, c, in, lf);
   };
 
-  auto script = navigateToDoneAndConfirm(6);
+  auto script = NavigateToDoneAndConfirm(6);
   constexpr int kIdleTail = 60;
 
-  bool aTransitioned = false, bTransitioned = false;
-  uint32_t aTransitionFrame = 0, bTransitionFrame = 0;
+  bool a_transitioned = false, b_transitioned = false;
+  uint32_t a_transition_frame = 0, b_transition_frame = 0;
 
   for (int i = 0; i < static_cast<int>(script.size()) + kIdleTail; ++i) {
     uint8_t in = (i < static_cast<int>(script.size())) ? script[i] : 0;
-    a->setLocalControlState(in);
-    b->setLocalControlState(in);
-    bool aInWeapselBefore = !aTransitioned;
-    bool bInWeapselBefore = !bTransitioned;
-    a->process();
-    b->process();
-    if (aInWeapselBefore && a->currentGame()->statsRecorder) {
-      aTransitioned = true;
-      aTransitionFrame = a->currentFrame();
+    a->SetLocalControlState(in);
+    b->SetLocalControlState(in);
+    bool a_in_weapsel_before = !a_transitioned;
+    bool b_in_weapsel_before = !b_transitioned;
+    a->Process();
+    b->Process();
+    if (a_in_weapsel_before && a->CurrentGame()->stats_recorder) {
+      a_transitioned = true;
+      a_transition_frame = a->CurrentFrame();
     }
-    if (bInWeapselBefore && b->currentGame()->statsRecorder) {
-      bTransitioned = true;
-      bTransitionFrame = b->currentFrame();
+    if (b_in_weapsel_before && b->CurrentGame()->stats_recorder) {
+      b_transitioned = true;
+      b_transition_frame = b->CurrentFrame();
     }
-    transport.tick(deliverA, deliverB);
+    transport.Tick(deliver_a, deliver_b);
   }
 
   // Flush any tail packets, then a few more ticks to let promote loops
   // drain.
-  transport.flush(deliverA, deliverB);
-  a->setLocalControlState(0);
-  b->setLocalControlState(0);
+  transport.Flush(deliver_a, deliver_b);
+  a->SetLocalControlState(0);
+  b->SetLocalControlState(0);
   for (int i = 0; i < 16; ++i) {
-    bool aInWeapselBefore = !aTransitioned;
-    bool bInWeapselBefore = !bTransitioned;
-    a->process();
-    b->process();
-    if (aInWeapselBefore && a->gameState() == StateGame) {
-      aTransitioned = true;
-      aTransitionFrame = a->currentFrame();
+    bool a_in_weapsel_before = !a_transitioned;
+    bool b_in_weapsel_before = !b_transitioned;
+    a->Process();
+    b->Process();
+    if (a_in_weapsel_before && a->State() == kStateGame) {
+      a_transitioned = true;
+      a_transition_frame = a->CurrentFrame();
     }
-    if (bInWeapselBefore && b->gameState() == StateGame) {
-      bTransitioned = true;
-      bTransitionFrame = b->currentFrame();
+    if (b_in_weapsel_before && b->State() == kStateGame) {
+      b_transitioned = true;
+      b_transition_frame = b->CurrentFrame();
     }
-    transport.tick(deliverA, deliverB);
+    transport.Tick(deliver_a, deliver_b);
   }
 
-  REQUIRE(aTransitioned);
-  REQUIRE(bTransitioned);
-  REQUIRE(aTransitionFrame == bTransitionFrame);
+  REQUIRE(a_transitioned);
+  REQUIRE(b_transitioned);
+  REQUIRE(a_transition_frame == b_transition_frame);
 
   // Same weapon picks, same checksums.
   for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
       REQUIRE(a->game.worms[i]->settings->weapons[j] == b->game.worms[i]->settings->weapons[j]);
     }
   }
 
-  REQUIRE(wideRollbackChecksum(a->game) == wideRollbackChecksum(b->game));
+  REQUIRE(WideRollbackChecksum(a->game) == WideRollbackChecksum(b->game));
 
   // Vacuity guard: jitter must have caused at least some prediction
   // events; otherwise this test devolves into the zero-jitter case.
-  bool anyRollback = a->rollbackCount() > 0 || b->rollbackCount() > 0;
-  INFO("a rollbacks=" << a->rollbackCount() << " b rollbacks=" << b->rollbackCount());
-  REQUIRE(anyRollback);
+  bool any_rollback = a->RollbackCount() > 0 || b->RollbackCount() > 0;
+  INFO("a rollbacks=" << a->RollbackCount() << " b rollbacks=" << b->RollbackCount());
+  REQUIRE(any_rollback);
 }

--- a/src/tests/test_session.cpp
+++ b/src/tests/test_session.cpp
@@ -59,8 +59,7 @@ TEST_CASE("NetSession host and client connect and handshake", "[session]") {
 
   // Poll until both reach Playing state
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);
@@ -95,8 +94,7 @@ TEST_CASE("NetSession syncs host settings to client", "[session]") {
 
   // Poll until both reach Playing — host settings are authoritative
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);
@@ -119,7 +117,8 @@ TEST_CASE("NetSession syncs worm colors and weapons between peers", "[session]")
   auto settings_host = std::make_shared<Settings>(*f.settings);
   // Create distinct WormSettings objects so shared_ptr sharing doesn't cause issues
   for (int i = 0; i < Settings::kNumWormSettings; ++i)
-    settings_host->worm_settings[i] = std::make_shared<WormSettings>(*settings_host->worm_settings[i]);
+    settings_host->worm_settings[i] =
+        std::make_shared<WormSettings>(*settings_host->worm_settings[i]);
   settings_host->worm_settings[Settings::kNetworkPlayerIdx]->color = 3;
   settings_host->worm_settings[Settings::kNetworkPlayerIdx]->rgb[0] = 255;
   settings_host->worm_settings[Settings::kNetworkPlayerIdx]->rgb[1] = 0;
@@ -152,8 +151,7 @@ TEST_CASE("NetSession syncs worm colors and weapons between peers", "[session]")
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -191,8 +189,7 @@ TEST_CASE("NetSession client detects host disconnect", "[session]") {
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -294,8 +291,7 @@ TEST_CASE("NetSession TC sync transfers data when hashes differ", "[session][tc]
   bool ready = PollUntil(
       host, client,
       [&]() {
-        return host.State() == NetSession::kPlaying &&
-               client.State() == NetSession::kPlaying;
+        return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
       },
       10000);  // Allow more time for TC transfer
 
@@ -330,8 +326,7 @@ TEST_CASE("NetSession TC sync skips transfer when hashes match", "[session][tc]"
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);

--- a/src/tests/test_session.cpp
+++ b/src/tests/test_session.cpp
@@ -15,30 +15,30 @@
 struct SessionFixture {
   std::shared_ptr<Common> common;
   std::shared_ptr<Settings> settings;
-  FsNode tcRoot;
+  FsNode tc_root;
 
   SessionFixture() {
-    precomputeTables();
+    PrecomputeTables();
 
     common = std::make_shared<Common>();
-    tcRoot = FsNode("data") / "TC" / "openliero";
-    common->load(tcRoot);
+    tc_root = FsNode("data") / "TC" / "openliero";
+    common->load(tc_root);
 
     settings = std::make_shared<Settings>();
     settings->lives = 10;
-    settings->loadingTime = 0;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
   }
 };
 
 // Poll both sessions until a condition is met or timeout
 template <typename Pred>
-static bool pollUntil(NetSession& a, NetSession& b, Pred pred, int maxMs = 3000) {
-  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(maxMs);
+static bool PollUntil(NetSession& a, NetSession& b, Pred pred, int max_ms = 3000) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_ms);
   while (!pred() && std::chrono::steady_clock::now() < deadline) {
-    a.update();
-    b.update();
+    a.Update();
+    b.Update();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return pred();
@@ -47,165 +47,165 @@ static bool pollUntil(NetSession& a, NetSession& b, Pred pred, int maxMs = 3000)
 TEST_CASE("NetSession host and client connect and handshake", "[session]") {
   SessionFixture f;
 
-  NetSession host(f.common, f.settings, f.tcRoot);
-  NetSession client(f.common, f.settings, f.tcRoot);
+  NetSession host(f.common, f.settings, f.tc_root);
+  NetSession client(f.common, f.settings, f.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(host.sessionState() == NetSession::WaitingForPeer);
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(host.State() == NetSession::kWaitingForPeer);
 
-  REQUIRE(client.joinGame("127.0.0.1", port));
-  REQUIRE(client.sessionState() == NetSession::WaitingForPeer);
+  REQUIRE(client.JoinGame("127.0.0.1", port));
+  REQUIRE(client.State() == NetSession::kWaitingForPeer);
 
   // Poll until both reach Playing state
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);
-  REQUIRE(host.rollbackController() != nullptr);
-  REQUIRE(client.rollbackController() != nullptr);
+  REQUIRE(host.Rollback() != nullptr);
+  REQUIRE(client.Rollback() != nullptr);
 
   // Both games should have the same RNG seed
-  REQUIRE(host.rollbackController()->game.rand == client.rollbackController()->game.rand);
+  REQUIRE(host.Rollback()->game.rand == client.Rollback()->game.rand);
 }
 
 TEST_CASE("NetSession syncs host settings to client", "[session]") {
   SessionFixture f;
 
-  auto settingsB = std::make_shared<Settings>(*f.settings);
-  settingsB->lives = 99;
-  settingsB->blood = 200;
-  settingsB->loadingTime = 50;
-  settingsB->gameMode = Settings::GMGameOfTag;
-  settingsB->maxBonuses = 7;
-  settingsB->timeToLose = 999;
-  settingsB->flagsToWin = 3;
-  settingsB->loadChange = true;
+  auto settings_b = std::make_shared<Settings>(*f.settings);
+  settings_b->lives = 99;
+  settings_b->blood = 200;
+  settings_b->loading_time = 50;
+  settings_b->game_mode = Settings::kGmGameOfTag;
+  settings_b->max_bonuses = 7;
+  settings_b->time_to_lose = 999;
+  settings_b->flags_to_win = 3;
+  settings_b->load_change = true;
   // Modify some weapTable entries
-  for (int i = 0; i < 40; ++i) settingsB->weapTable[i] = (i < 10) ? 2 : 0;
+  for (int i = 0; i < 40; ++i) settings_b->weap_table[i] = (i < 10) ? 2 : 0;
 
-  NetSession host(f.common, f.settings, f.tcRoot);
-  NetSession client(f.common, settingsB, f.tcRoot);
+  NetSession host(f.common, f.settings, f.tc_root);
+  NetSession client(f.common, settings_b, f.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
   // Poll until both reach Playing — host settings are authoritative
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);
   // Client should have received and applied host's settings
-  REQUIRE(settingsB->lives == f.settings->lives);
-  REQUIRE(settingsB->blood == f.settings->blood);
-  REQUIRE(settingsB->loadingTime == f.settings->loadingTime);
-  REQUIRE(settingsB->gameMode == f.settings->gameMode);
-  REQUIRE(settingsB->maxBonuses == f.settings->maxBonuses);
-  REQUIRE(settingsB->timeToLose == f.settings->timeToLose);
-  REQUIRE(settingsB->flagsToWin == f.settings->flagsToWin);
-  REQUIRE(settingsB->loadChange == f.settings->loadChange);
-  for (int i = 0; i < 40; ++i) REQUIRE(settingsB->weapTable[i] == f.settings->weapTable[i]);
+  REQUIRE(settings_b->lives == f.settings->lives);
+  REQUIRE(settings_b->blood == f.settings->blood);
+  REQUIRE(settings_b->loading_time == f.settings->loading_time);
+  REQUIRE(settings_b->game_mode == f.settings->game_mode);
+  REQUIRE(settings_b->max_bonuses == f.settings->max_bonuses);
+  REQUIRE(settings_b->time_to_lose == f.settings->time_to_lose);
+  REQUIRE(settings_b->flags_to_win == f.settings->flags_to_win);
+  REQUIRE(settings_b->load_change == f.settings->load_change);
+  for (int i = 0; i < 40; ++i) REQUIRE(settings_b->weap_table[i] == f.settings->weap_table[i]);
 }
 
 TEST_CASE("NetSession syncs worm colors and weapons between peers", "[session]") {
   SessionFixture f;
 
   // Give each player distinct colors and weapons in the network player slot
-  auto settingsHost = std::make_shared<Settings>(*f.settings);
+  auto settings_host = std::make_shared<Settings>(*f.settings);
   // Create distinct WormSettings objects so shared_ptr sharing doesn't cause issues
-  for (int i = 0; i < Settings::NumWormSettings; ++i)
-    settingsHost->wormSettings[i] = std::make_shared<WormSettings>(*settingsHost->wormSettings[i]);
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->color = 3;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->rgb[0] = 255;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->rgb[1] = 0;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->rgb[2] = 0;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->weapons[0] = 10;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->weapons[1] = 20;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->weapons[2] = 30;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->weapons[3] = 5;
-  settingsHost->wormSettings[Settings::NetworkPlayerIdx]->weapons[4] = 15;
+  for (int i = 0; i < Settings::kNumWormSettings; ++i)
+    settings_host->worm_settings[i] = std::make_shared<WormSettings>(*settings_host->worm_settings[i]);
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->color = 3;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->rgb[0] = 255;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->rgb[1] = 0;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->rgb[2] = 0;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->weapons[0] = 10;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->weapons[1] = 20;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->weapons[2] = 30;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->weapons[3] = 5;
+  settings_host->worm_settings[Settings::kNetworkPlayerIdx]->weapons[4] = 15;
 
-  auto settingsClient = std::make_shared<Settings>(*f.settings);
-  for (int i = 0; i < Settings::NumWormSettings; ++i)
-    settingsClient->wormSettings[i] =
-        std::make_shared<WormSettings>(*settingsClient->wormSettings[i]);
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->color = 6;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->rgb[0] = 0;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->rgb[1] = 255;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->rgb[2] = 128;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->weapons[0] = 35;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->weapons[1] = 8;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->weapons[2] = 22;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->weapons[3] = 14;
-  settingsClient->wormSettings[Settings::NetworkPlayerIdx]->weapons[4] = 40;
+  auto settings_client = std::make_shared<Settings>(*f.settings);
+  for (int i = 0; i < Settings::kNumWormSettings; ++i)
+    settings_client->worm_settings[i] =
+        std::make_shared<WormSettings>(*settings_client->worm_settings[i]);
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->color = 6;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->rgb[0] = 0;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->rgb[1] = 255;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->rgb[2] = 128;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->weapons[0] = 35;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->weapons[1] = 8;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->weapons[2] = 22;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->weapons[3] = 14;
+  settings_client->worm_settings[Settings::kNetworkPlayerIdx]->weapons[4] = 40;
 
-  NetSession host(f.common, settingsHost, f.tcRoot);
-  NetSession client(f.common, settingsClient, f.tcRoot);
+  NetSession host(f.common, settings_host, f.tc_root);
+  NetSession client(f.common, settings_client, f.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
   // Host's remote worm (index 1) should have client's color/weapons
-  Worm* hostRemoteWorm = host.rollbackController()->game.wormByIdx(1);
-  REQUIRE(hostRemoteWorm->settings->color == 6);
-  REQUIRE(hostRemoteWorm->settings->rgb[0] == 0);
-  REQUIRE(hostRemoteWorm->settings->rgb[1] == 255);
-  REQUIRE(hostRemoteWorm->settings->rgb[2] == 128);
-  REQUIRE(hostRemoteWorm->settings->weapons[0] == 35);
-  REQUIRE(hostRemoteWorm->settings->weapons[4] == 40);
+  Worm* host_remote_worm = host.Rollback()->game.WormByIdx(1);
+  REQUIRE(host_remote_worm->settings->color == 6);
+  REQUIRE(host_remote_worm->settings->rgb[0] == 0);
+  REQUIRE(host_remote_worm->settings->rgb[1] == 255);
+  REQUIRE(host_remote_worm->settings->rgb[2] == 128);
+  REQUIRE(host_remote_worm->settings->weapons[0] == 35);
+  REQUIRE(host_remote_worm->settings->weapons[4] == 40);
 
   // Client's remote worm (index 0) should have host's color/weapons
-  Worm* clientRemoteWorm = client.rollbackController()->game.wormByIdx(0);
-  REQUIRE(clientRemoteWorm->settings->color == 3);
-  REQUIRE(clientRemoteWorm->settings->rgb[0] == 255);
-  REQUIRE(clientRemoteWorm->settings->rgb[1] == 0);
-  REQUIRE(clientRemoteWorm->settings->rgb[2] == 0);
-  REQUIRE(clientRemoteWorm->settings->weapons[0] == 10);
-  REQUIRE(clientRemoteWorm->settings->weapons[4] == 15);
+  Worm* client_remote_worm = client.Rollback()->game.WormByIdx(0);
+  REQUIRE(client_remote_worm->settings->color == 3);
+  REQUIRE(client_remote_worm->settings->rgb[0] == 255);
+  REQUIRE(client_remote_worm->settings->rgb[1] == 0);
+  REQUIRE(client_remote_worm->settings->rgb[2] == 0);
+  REQUIRE(client_remote_worm->settings->weapons[0] == 10);
+  REQUIRE(client_remote_worm->settings->weapons[4] == 15);
 
   // Persistent settings should NOT be modified
-  REQUIRE(settingsHost->wormSettings[1]->color != 6);
-  REQUIRE(settingsClient->wormSettings[0]->color != 3);
+  REQUIRE(settings_host->worm_settings[1]->color != 6);
+  REQUIRE(settings_client->worm_settings[0]->color != 3);
 }
 
 TEST_CASE("NetSession client detects host disconnect", "[session]") {
   SessionFixture f;
 
-  NetSession host(f.common, f.settings, f.tcRoot);
-  NetSession client(f.common, f.settings, f.tcRoot);
+  NetSession host(f.common, f.settings, f.tc_root);
+  NetSession client(f.common, f.settings, f.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
   // Host disconnects
-  host.disconnect();
-  REQUIRE(host.sessionState() == NetSession::Idle);
+  host.Disconnect();
+  REQUIRE(host.State() == NetSession::kIdle);
 
   // Client should detect the disconnect
   bool disconnected = false;
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
   while (!disconnected && std::chrono::steady_clock::now() < deadline) {
-    client.update();
-    disconnected = (client.sessionState() == NetSession::Disconnected);
+    client.Update();
+    disconnected = (client.State() == NetSession::kDisconnected);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   REQUIRE(disconnected);
@@ -214,20 +214,20 @@ TEST_CASE("NetSession client detects host disconnect", "[session]") {
 TEST_CASE("NetSession connect to non-existent host fails", "[session]") {
   SessionFixture f;
 
-  NetSession client(f.common, f.settings, f.tcRoot);
+  NetSession client(f.common, f.settings, f.tc_root);
   // Connect to a port where nobody is listening
-  REQUIRE(client.joinGame("127.0.0.1", 19599));
+  REQUIRE(client.JoinGame("127.0.0.1", 19599));
 
   // Poll — should eventually fail or stay in WaitingForPeer
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
-  while (client.sessionState() == NetSession::WaitingForPeer &&
+  while (client.State() == NetSession::kWaitingForPeer &&
          std::chrono::steady_clock::now() < deadline) {
-    client.update();
+    client.Update();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
   // Should not be in Playing state
-  REQUIRE(client.sessionState() != NetSession::Playing);
+  REQUIRE(client.State() != NetSession::kPlaying);
 }
 
 TEST_CASE("NetSession TC sync transfers data when hashes differ", "[session][tc]") {
@@ -235,21 +235,21 @@ TEST_CASE("NetSession TC sync transfers data when hashes differ", "[session][tc]
 
   // Create a modified TC in a temp directory so the client has a different hash.
   // Copy the real TC and append a byte to tc.cfg to change the hash.
-  std::string tempTcDir = "/tmp/openliero_test_tc_modified";
+  std::string temp_tc_dir = "/tmp/openliero_test_tc_modified";
 
   // Pack the real TC, unpack to temp dir, then modify a file
-  auto archive = TcArchive::pack(f.tcRoot);
-  auto files = TcArchive::unpack(archive.data(), archive.size());
+  auto archive = tc_archive::Pack(f.tc_root);
+  auto files = tc_archive::Unpack(archive.data(), archive.size());
   REQUIRE(!files.empty());
 
   // Write files to temp dir
-  std::filesystem::remove_all(tempTcDir);
-  std::filesystem::create_directories(tempTcDir);
+  std::filesystem::remove_all(temp_tc_dir);
+  std::filesystem::create_directories(temp_tc_dir);
 
   for (auto& file : files) {
-    std::filesystem::path fullPath = std::filesystem::path(tempTcDir) / file.name;
-    std::filesystem::create_directories(fullPath.parent_path());
-    std::ofstream ofs(fullPath, std::ios::binary);
+    std::filesystem::path full_path = std::filesystem::path(temp_tc_dir) / file.name;
+    std::filesystem::create_directories(full_path.parent_path());
+    std::ofstream ofs(full_path, std::ios::binary);
     REQUIRE(ofs.is_open());
     ofs.write(reinterpret_cast<const char*>(file.data.data()),
               static_cast<std::streamsize>(file.data.size()));
@@ -257,84 +257,84 @@ TEST_CASE("NetSession TC sync transfers data when hashes differ", "[session][tc]
 
   // Modify a sound file to change the hash without breaking TOML parsing
   {
-    std::filesystem::path wavPath = std::filesystem::path(tempTcDir) / "sounds/shotgun.wav";
-    std::ofstream ofs(wavPath, std::ios::binary | std::ios::app);
+    std::filesystem::path wav_path = std::filesystem::path(temp_tc_dir) / "sounds/shotgun.wav";
+    std::ofstream ofs(wav_path, std::ios::binary | std::ios::app);
     REQUIRE(ofs.is_open());
     ofs.put('\0');
   }
 
-  FsNode clientTcRoot(tempTcDir);
-  uint32_t clientHash = TcArchive::computeHash(clientTcRoot);
-  uint32_t hostHash = TcArchive::computeHash(f.tcRoot);
-  REQUIRE(clientHash != hostHash);  // Ensure hashes actually differ
+  FsNode client_tc_root(temp_tc_dir);
+  uint32_t client_hash = tc_archive::ComputeHash(client_tc_root);
+  uint32_t host_hash = tc_archive::ComputeHash(f.tc_root);
+  REQUIRE(client_hash != host_hash);  // Ensure hashes actually differ
 
   // Client uses the modified TC
-  auto clientCommon = std::make_shared<Common>();
-  clientCommon->load(clientTcRoot);
+  auto client_common = std::make_shared<Common>();
+  client_common->load(client_tc_root);
 
-  auto clientSettings = std::make_shared<Settings>(*f.settings);
+  auto client_settings = std::make_shared<Settings>(*f.settings);
 
   // Track if onTcReloaded fires
-  bool tcReloaded = false;
-  std::shared_ptr<Common> receivedCommon;
+  bool tc_reloaded = false;
+  std::shared_ptr<Common> received_common;
 
-  NetSession host(f.common, f.settings, f.tcRoot);
-  NetSession client(clientCommon, clientSettings, clientTcRoot);
+  NetSession host(f.common, f.settings, f.tc_root);
+  NetSession client(client_common, client_settings, client_tc_root);
 
-  client.onTcReloaded = [&](std::shared_ptr<Common> newCommon) {
-    tcReloaded = true;
-    receivedCommon = newCommon;
+  client.on_tc_reloaded = [&](std::shared_ptr<Common> new_common) {
+    tc_reloaded = true;
+    received_common = new_common;
   };
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
   // Poll until both reach Playing state (TC transfer included)
-  bool ready = pollUntil(
+  bool ready = PollUntil(
       host, client,
       [&]() {
-        return host.sessionState() == NetSession::Playing &&
-               client.sessionState() == NetSession::Playing;
+        return host.State() == NetSession::kPlaying &&
+               client.State() == NetSession::kPlaying;
       },
       10000);  // Allow more time for TC transfer
 
-  INFO("Host state: " << (int)host.sessionState());
-  INFO("Client state: " << (int)client.sessionState());
+  INFO("Host state: " << (int)host.State());
+  INFO("Client state: " << (int)client.State());
   REQUIRE(ready);
 
   // TC should have been reloaded on the client
-  REQUIRE(tcReloaded);
-  REQUIRE(receivedCommon != nullptr);
+  REQUIRE(tc_reloaded);
+  REQUIRE(received_common != nullptr);
 
   // Both games should have the same RNG seed (basic sanity)
-  REQUIRE(host.rollbackController()->game.rand.last == client.rollbackController()->game.rand.last);
+  REQUIRE(host.Rollback()->game.rand.last == client.Rollback()->game.rand.last);
 
   // Clean up
-  std::filesystem::remove_all(tempTcDir);
+  std::filesystem::remove_all(temp_tc_dir);
 }
 
 TEST_CASE("NetSession TC sync skips transfer when hashes match", "[session][tc]") {
   SessionFixture f;
 
   // Both sides use the same TC — no transfer should happen
-  bool tcReloaded = false;
+  bool tc_reloaded = false;
 
-  NetSession host(f.common, f.settings, f.tcRoot);
-  NetSession client(f.common, f.settings, f.tcRoot);
+  NetSession host(f.common, f.settings, f.tc_root);
+  NetSession client(f.common, f.settings, f.tc_root);
 
-  client.onTcReloaded = [&](std::shared_ptr<Common>) { tcReloaded = true; };
+  client.on_tc_reloaded = [&](std::shared_ptr<Common>) { tc_reloaded = true; };
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
 
   REQUIRE(ready);
   // TC should NOT have been reloaded (same hash → skip)
-  REQUIRE_FALSE(tcReloaded);
+  REQUIRE_FALSE(tc_reloaded);
 }

--- a/src/tests/test_session_rollback.cpp
+++ b/src/tests/test_session_rollback.cpp
@@ -25,28 +25,28 @@ namespace {
 struct Env {
   std::shared_ptr<Common> common;
   std::shared_ptr<Settings> settings;
-  FsNode tcRoot;
+  FsNode tc_root;
 
   Env() {
-    precomputeTables();
+    PrecomputeTables();
     common = std::make_shared<Common>();
-    tcRoot = FsNode("data") / "TC" / "openliero";
-    common->load(tcRoot);
+    tc_root = FsNode("data") / "TC" / "openliero";
+    common->load(tc_root);
     settings = std::make_shared<Settings>();
     settings->lives = 10;
-    settings->loadingTime = 0;
-    settings->loadChange = true;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->load_change = true;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
   }
 };
 
 template <typename Pred>
-bool pollUntil(NetSession& a, NetSession& b, Pred pred, int maxMs = 5000) {
-  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(maxMs);
+bool PollUntil(NetSession& a, NetSession& b, Pred pred, int max_ms = 5000) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_ms);
   while (!pred() && std::chrono::steady_clock::now() < deadline) {
-    a.update();
-    b.update();
+    a.Update();
+    b.Update();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return pred();
@@ -57,52 +57,52 @@ bool pollUntil(NetSession& a, NetSession& b, Pred pred, int maxMs = 5000) {
 TEST_CASE("NetSession reaches Playing and runs ticks", "[session][rollback]") {
   Env e;
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, e.settings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, e.settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  REQUIRE(host.rollbackController() != nullptr);
-  REQUIRE(client.rollbackController() != nullptr);
+  REQUIRE(host.Rollback() != nullptr);
+  REQUIRE(client.Rollback() != nullptr);
 
   // Both peers seeded the same RNG via handshake — identical game
   // state at frame 0.
-  REQUIRE(host.rollbackController()->game.rand == client.rollbackController()->game.rand);
+  REQUIRE(host.Rollback()->game.rand == client.Rollback()->game.rand);
 
   // Run a few sim ticks. Process pumps the controller (which sends
   // input batches via the wired NetTransport callback), and
   // session.update() polls the transport so received batches reach
   // the other controller. With zero loopback jitter prediction
   // should never trip a rollback.
-  host.rollbackController()->focus();
-  client.rollbackController()->focus();
+  host.Rollback()->Focus();
+  client.Rollback()->Focus();
   for (int i = 0; i < 50; ++i) {
-    host.rollbackController()->process();
-    client.rollbackController()->process();
-    host.update();
-    client.update();
+    host.Rollback()->Process();
+    client.Rollback()->Process();
+    host.Update();
+    client.Update();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(host.rollbackController()->rollbackCount() == 0);
-  REQUIRE(client.rollbackController()->rollbackCount() == 0);
-  REQUIRE(host.rollbackController()->currentFrame() > 0);
+  REQUIRE(host.Rollback()->RollbackCount() == 0);
+  REQUIRE(client.Rollback()->RollbackCount() == 0);
+  REQUIRE(host.Rollback()->CurrentFrame() > 0);
   // With inputDelay=1 the peers can be up to kFrameAdvantage frames
   // apart at any snapshot — the frame-advantage stall bounds the gap
   // but doesn't guarantee frame-by-frame parity mid-loop.
-  int32_t gap = static_cast<int32_t>(host.rollbackController()->currentFrame()) -
-                static_cast<int32_t>(client.rollbackController()->currentFrame());
+  int32_t gap = static_cast<int32_t>(host.Rollback()->CurrentFrame()) -
+                static_cast<int32_t>(client.Rollback()->CurrentFrame());
   REQUIRE(std::abs(gap) <= RollbackController::kFrameAdvantage);
-  REQUIRE(!host.desyncDetected());
-  REQUIRE(!client.desyncDetected());
+  REQUIRE(!host.DesyncDetected());
+  REQUIRE(!client.DesyncDetected());
 }
 
 TEST_CASE("Rollback weapon select transitions to game over a real session",
@@ -114,98 +114,98 @@ TEST_CASE("Rollback weapon select transitions to game over a real session",
   // weapon-select-rollback integration with the session/transport layer
   // (not just the controller in isolation).
   Env e;
-  e.settings->inputDelay = 1;
-  e.settings->selectBotWeapons = 0;
+  e.settings->input_delay = 1;
+  e.settings->select_bot_weapons = 0;
 
-  auto clientSettings = std::make_shared<Settings>(*e.settings);
+  auto client_settings = std::make_shared<Settings>(*e.settings);
   // Default copy ctor shallow-copies the wormSettings shared_ptrs;
   // give each peer its own copies so single-process weapon-select
   // mutations on one side don't bleed into the other.
-  for (auto& ws : clientSettings->wormSettings) {
+  for (auto& ws : client_settings->worm_settings) {
     if (ws) ws = std::make_shared<WormSettings>(*ws);
   }
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, clientSettings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, client_settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  auto* hc = host.rollbackController();
-  auto* cc = client.rollbackController();
+  auto* hc = host.Rollback();
+  auto* cc = client.Rollback();
   REQUIRE(hc != nullptr);
   REQUIRE(cc != nullptr);
 
-  hc->focus();
-  cc->focus();
+  hc->Focus();
+  cc->Focus();
 
-  constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-  constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+  constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+  constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
   // Same script the controller-level test uses: 6× Down (each press is
   // on/off to produce a clean rising edge), a short idle pad, then a
   // single Fire press.
   std::vector<uint8_t> script;
   for (int i = 0; i < 6; ++i) {
-    script.push_back(BIT_DOWN);
+    script.push_back(kBitDown);
     script.push_back(0);
   }
   script.push_back(0);
-  script.push_back(BIT_FIRE);
+  script.push_back(kBitFire);
   script.push_back(0);
 
-  uint32_t hostTransitionFrame = 0;
-  uint32_t clientTransitionFrame = 0;
-  bool hostTransitioned = false;
-  bool clientTransitioned = false;
+  uint32_t host_transition_frame = 0;
+  uint32_t client_transition_frame = 0;
+  bool host_transitioned = false;
+  bool client_transitioned = false;
 
-  auto runTick = [&](uint8_t inByte) {
-    hc->setLocalControlState(inByte);
-    cc->setLocalControlState(inByte);
-    bool hostInWs = !hostTransitioned;
-    bool clientInWs = !clientTransitioned;
-    hc->process();
-    cc->process();
-    host.update();
-    client.update();
-    if (hostInWs && hc->gameState() == StateGame) {
-      hostTransitioned = true;
-      hostTransitionFrame = hc->currentFrame();
+  auto run_tick = [&](uint8_t in_byte) {
+    hc->SetLocalControlState(in_byte);
+    cc->SetLocalControlState(in_byte);
+    bool host_in_ws = !host_transitioned;
+    bool client_in_ws = !client_transitioned;
+    hc->Process();
+    cc->Process();
+    host.Update();
+    client.Update();
+    if (host_in_ws && hc->State() == kStateGame) {
+      host_transitioned = true;
+      host_transition_frame = hc->CurrentFrame();
     }
-    if (clientInWs && cc->gameState() == StateGame) {
-      clientTransitioned = true;
-      clientTransitionFrame = cc->currentFrame();
+    if (client_in_ws && cc->State() == kStateGame) {
+      client_transitioned = true;
+      client_transition_frame = cc->CurrentFrame();
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
 
-  for (uint8_t inByte : script) runTick(inByte);
+  for (uint8_t in_byte : script) run_tick(in_byte);
   // Idle tail to let promote loops drain and the transition fire on
   // both peers under loopback's small but non-zero RTT.
-  for (int i = 0; i < 200 && !(hostTransitioned && clientTransitioned); ++i) {
-    runTick(0);
+  for (int i = 0; i < 200 && !(host_transitioned && client_transitioned); ++i) {
+    run_tick(0);
   }
 
-  REQUIRE(hostTransitioned);
-  REQUIRE(clientTransitioned);
-  REQUIRE(hostTransitionFrame == clientTransitionFrame);
+  REQUIRE(host_transitioned);
+  REQUIRE(client_transitioned);
+  REQUIRE(host_transition_frame == client_transition_frame);
 
   // Both peers picked the same weapons.
   for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < Settings::selectableWeapons; ++j) {
+    for (int j = 0; j < Settings::kSelectableWeapons; ++j) {
       REQUIRE(hc->game.worms[i]->settings->weapons[j] == cc->game.worms[i]->settings->weapons[j]);
     }
   }
 
-  REQUIRE(!host.desyncDetected());
-  REQUIRE(!client.desyncDetected());
+  REQUIRE(!host.DesyncDetected());
+  REQUIRE(!client.DesyncDetected());
 }
 
 // End-to-end session test exercising the full WS→game boundary plus a
@@ -214,80 +214,80 @@ TEST_CASE("Rollback weapon select transitions to game over a real session",
 // real WS and keep producing checksums for several seconds.
 TEST_CASE("Rollback session runs ≥5s game-phase post-WS without desync", "[session][rollback]") {
   Env e;
-  e.settings->inputDelay = 1;
-  e.settings->selectBotWeapons = 0;
+  e.settings->input_delay = 1;
+  e.settings->select_bot_weapons = 0;
 
-  auto clientSettings = std::make_shared<Settings>(*e.settings);
-  for (auto& ws : clientSettings->wormSettings) {
+  auto client_settings = std::make_shared<Settings>(*e.settings);
+  for (auto& ws : client_settings->worm_settings) {
     if (ws) ws = std::make_shared<WormSettings>(*ws);
   }
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, clientSettings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, client_settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  auto* hc = host.rollbackController();
-  auto* cc = client.rollbackController();
+  auto* hc = host.Rollback();
+  auto* cc = client.Rollback();
   REQUIRE(hc != nullptr);
   REQUIRE(cc != nullptr);
 
-  hc->focus();
-  cc->focus();
+  hc->Focus();
+  cc->Focus();
 
-  constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-  constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+  constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+  constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
-  std::vector<uint8_t> wsScript;
+  std::vector<uint8_t> ws_script;
   for (int i = 0; i < 6; ++i) {
-    wsScript.push_back(BIT_DOWN);
-    wsScript.push_back(0);
+    ws_script.push_back(kBitDown);
+    ws_script.push_back(0);
   }
-  wsScript.push_back(0);
-  wsScript.push_back(BIT_FIRE);
-  wsScript.push_back(0);
+  ws_script.push_back(0);
+  ws_script.push_back(kBitFire);
+  ws_script.push_back(0);
 
-  bool hostTransitioned = false, clientTransitioned = false;
-  uint32_t hostTransitionFrame = 0, clientTransitionFrame = 0;
+  bool host_transitioned = false, client_transitioned = false;
+  uint32_t host_transition_frame = 0, client_transition_frame = 0;
 
-  auto runTick = [&](uint8_t inByte) {
-    hc->setLocalControlState(inByte);
-    cc->setLocalControlState(inByte);
-    bool hostInWs = !hostTransitioned;
-    bool clientInWs = !clientTransitioned;
-    hc->process();
-    cc->process();
-    host.update();
-    client.update();
-    if (hostInWs && hc->gameState() == StateGame) {
-      hostTransitioned = true;
-      hostTransitionFrame = hc->currentFrame();
+  auto run_tick = [&](uint8_t in_byte) {
+    hc->SetLocalControlState(in_byte);
+    cc->SetLocalControlState(in_byte);
+    bool host_in_ws = !host_transitioned;
+    bool client_in_ws = !client_transitioned;
+    hc->Process();
+    cc->Process();
+    host.Update();
+    client.Update();
+    if (host_in_ws && hc->State() == kStateGame) {
+      host_transitioned = true;
+      host_transition_frame = hc->CurrentFrame();
     }
-    if (clientInWs && cc->gameState() == StateGame) {
-      clientTransitioned = true;
-      clientTransitionFrame = cc->currentFrame();
+    if (client_in_ws && cc->State() == kStateGame) {
+      client_transitioned = true;
+      client_transition_frame = cc->CurrentFrame();
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
 
   // Drive WS to completion.
-  for (uint8_t b : wsScript) runTick(b);
-  for (int i = 0; i < 200 && !(hostTransitioned && clientTransitioned); ++i) {
-    runTick(0);
+  for (uint8_t b : ws_script) run_tick(b);
+  for (int i = 0; i < 200 && !(host_transitioned && client_transitioned); ++i) {
+    run_tick(0);
   }
-  REQUIRE(hostTransitioned);
-  REQUIRE(clientTransitioned);
+  REQUIRE(host_transitioned);
+  REQUIRE(client_transitioned);
   // Both peers enter game phase at simFrame=0 (post-WS reset).
-  REQUIRE(hostTransitionFrame == 0);
-  REQUIRE(clientTransitionFrame == 0);
+  REQUIRE(host_transition_frame == 0);
+  REQUIRE(client_transition_frame == 0);
 
   // Drive 5 seconds of game-phase ticks (~350 frames at 70 Hz). Use
   // 400 ticks for headroom — even if one peer stalls a few frames via
@@ -299,9 +299,9 @@ TEST_CASE("Rollback session runs ≥5s game-phase post-WS without desync", "[ses
     // input doesn't matter — both peers run the same script, so any
     // mismatch must come from the sim path, not divergent inputs.
     uint8_t in = 0;
-    if ((i / 20) % 3 == 0) in |= BIT_FIRE;
-    if ((i / 10) % 5 == 0) in |= (uint8_t{1} << Worm::Right);
-    runTick(in);
+    if ((i / 20) % 3 == 0) in |= kBitFire;
+    if ((i / 10) % 5 == 0) in |= (uint8_t{1} << Worm::kRight);
+    run_tick(in);
   }
 
   // Idle drain so both peers' confirmation chains catch up. With the
@@ -309,32 +309,32 @@ TEST_CASE("Rollback session runs ≥5s game-phase post-WS without desync", "[ses
   // overlap window between the two rings should hold several confirmed
   // frames after the drain.
   for (int i = 0; i < 64; ++i) {
-    runTick(0);
+    run_tick(0);
   }
 
-  REQUIRE(hc->currentFrame() > 0);
-  REQUIRE(cc->currentFrame() > 0);
+  REQUIRE(hc->CurrentFrame() > 0);
+  REQUIRE(cc->CurrentFrame() > 0);
 
-  int32_t gap = static_cast<int32_t>(hc->currentFrame()) - static_cast<int32_t>(cc->currentFrame());
+  int32_t gap = static_cast<int32_t>(hc->CurrentFrame()) - static_cast<int32_t>(cc->CurrentFrame());
   REQUIRE(std::abs(gap) <= RollbackController::kFrameAdvantage);
 
   // Headline: the desync detector did NOT fire across the run.
-  REQUIRE(!host.desyncDetected());
-  REQUIRE(!client.desyncDetected());
+  REQUIRE(!host.DesyncDetected());
+  REQUIRE(!client.DesyncDetected());
 
   // Slot-level checksum agreement at a frame both peers have fully
   // confirmed. Pick the most recent frame that's resident in both
   // rings; under loopback both should comfortably hold the last
   // kMaxRollback+1 confirmed frames.
-  rollback::RollbackBuffer const& bufH = hc->rollbackBuffer();
-  rollback::RollbackBuffer const& bufC = cc->rollbackBuffer();
-  int compareFrame = std::min(bufH.newestFrame(), bufC.newestFrame());
-  REQUIRE(compareFrame > 0);
-  auto* slotH = const_cast<rollback::RollbackBuffer&>(bufH).find(compareFrame);
-  auto* slotC = const_cast<rollback::RollbackBuffer&>(bufC).find(compareFrame);
-  REQUIRE(slotH != nullptr);
-  REQUIRE(slotC != nullptr);
-  REQUIRE(slotH->checksum == slotC->checksum);
+  rollback::RollbackBuffer const& buf_h = hc->RollbackBuffer();
+  rollback::RollbackBuffer const& buf_c = cc->RollbackBuffer();
+  int compare_frame = std::min(buf_h.NewestFrame(), buf_c.NewestFrame());
+  REQUIRE(compare_frame > 0);
+  auto* slot_h = const_cast<rollback::RollbackBuffer&>(buf_h).Find(compare_frame);
+  auto* slot_c = const_cast<rollback::RollbackBuffer&>(buf_c).Find(compare_frame);
+  REQUIRE(slot_h != nullptr);
+  REQUIRE(slot_c != nullptr);
+  REQUIRE(slot_h->checksum == slot_c->checksum);
 }
 
 TEST_CASE("Per-worm stats hooks fire on the shadow on both peers", "[session][rollback][stats]") {
@@ -344,89 +344,89 @@ TEST_CASE("Per-worm stats hooks fire on the shadow on both peers", "[session][ro
   // unconditionally non-speculative, so firing weapons through the
   // pipeline should bump shot counts on both peers.
   Env e;
-  e.settings->inputDelay = 1;
+  e.settings->input_delay = 1;
 
-  auto clientSettings = std::make_shared<Settings>(*e.settings);
-  for (auto& ws : clientSettings->wormSettings) {
+  auto client_settings = std::make_shared<Settings>(*e.settings);
+  for (auto& ws : client_settings->worm_settings) {
     if (ws) ws = std::make_shared<WormSettings>(*ws);
   }
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, clientSettings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, client_settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  auto* hc = host.rollbackController();
-  auto* cc = client.rollbackController();
+  auto* hc = host.Rollback();
+  auto* cc = client.Rollback();
   REQUIRE(hc);
   REQUIRE(cc);
-  hc->focus();
-  cc->focus();
+  hc->Focus();
+  cc->Focus();
 
-  constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-  constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+  constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+  constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
-  auto runTick = [&](uint8_t inA, uint8_t inB) {
-    hc->setLocalControlState(inA);
-    cc->setLocalControlState(inB);
-    host.update();
-    client.update();
-    hc->process();
-    cc->process();
+  auto run_tick = [&](uint8_t in_a, uint8_t in_b) {
+    hc->SetLocalControlState(in_a);
+    cc->SetLocalControlState(in_b);
+    host.Update();
+    client.Update();
+    hc->Process();
+    cc->Process();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
 
   // Drive WS to completion.
   for (int i = 0; i < 6; ++i) {
-    runTick(BIT_DOWN, BIT_DOWN);
-    runTick(0, 0);
+    run_tick(kBitDown, kBitDown);
+    run_tick(0, 0);
   }
-  runTick(0, 0);
-  runTick(BIT_FIRE, BIT_FIRE);
-  runTick(0, 0);
-  for (int i = 0; i < 200 && !(hc->gameState() == StateGame && cc->gameState() == StateGame); ++i) {
-    runTick(0, 0);
+  run_tick(0, 0);
+  run_tick(kBitFire, kBitFire);
+  run_tick(0, 0);
+  for (int i = 0; i < 200 && !(hc->State() == kStateGame && cc->State() == kStateGame); ++i) {
+    run_tick(0, 0);
   }
-  REQUIRE(hc->gameState() == StateGame);
-  REQUIRE(cc->gameState() == StateGame);
+  REQUIRE(hc->State() == kStateGame);
+  REQUIRE(cc->State() == kStateGame);
 
   // First ready up both worms with a single Fire press (rising edge
   // sets ready=true for doRespawning), then let them spawn.
-  runTick(BIT_FIRE, BIT_FIRE);
-  for (int i = 0; i < 5; ++i) runTick(0, 0);
+  run_tick(kBitFire, kBitFire);
+  for (int i = 0; i < 5; ++i) run_tick(0, 0);
 
   // Pulse Fire so the rising edge fires every other tick. Held-Fire
   // wouldn't work — edge detection only counts the press.
   for (int i = 0; i < 400; ++i) {
-    runTick((i & 1) ? BIT_FIRE : 0, (i & 1) ? BIT_FIRE : 0);
+    run_tick((i & 1) ? kBitFire : 0, (i & 1) ? kBitFire : 0);
   }
   // Idle drain.
-  for (int i = 0; i < 30; ++i) runTick(0, 0);
+  for (int i = 0; i < 30; ++i) run_tick(0, 0);
 
-  auto* hostStats = dynamic_cast<NormalStatsRecorder*>(hc->statsGame()->statsRecorder.get());
-  auto* clientStats = dynamic_cast<NormalStatsRecorder*>(cc->statsGame()->statsRecorder.get());
-  REQUIRE(hostStats);
-  REQUIRE(clientStats);
+  auto* host_stats = dynamic_cast<NormalStatsRecorder*>(hc->StatsGame()->stats_recorder.get());
+  auto* client_stats = dynamic_cast<NormalStatsRecorder*>(cc->StatsGame()->stats_recorder.get());
+  REQUIRE(host_stats);
+  REQUIRE(client_stats);
 
-  auto totalShots = [](NormalStatsRecorder* s) {
+  auto total_shots = [](NormalStatsRecorder* s) {
     int total = 0;
     for (int w = 0; w < 2; ++w)
       for (int wp = 0; wp < 40; ++wp)
-        total += s->worms[w].weapons[wp].potentialHits + s->worms[w].weapons[wp].actualHits;
+        total += s->worms[w].weapons[wp].potential_hits + s->worms[w].weapons[wp].actual_hits;
     return total;
   };
 
   // Shadow recorded shots on both peers, not just the host.
-  REQUIRE(totalShots(hostStats) > 0);
-  REQUIRE(totalShots(clientStats) > 0);
+  REQUIRE(total_shots(host_stats) > 0);
+  REQUIRE(total_shots(client_stats) > 0);
 }
 
 TEST_CASE("Stats accumulate on both peers across a rollback game", "[session][rollback][stats]") {
@@ -438,192 +438,192 @@ TEST_CASE("Stats accumulate on both peers across a rollback game", "[session][ro
   // sets `gameTime` after finish(), and works symmetrically on host AND
   // client.
   Env e;
-  e.settings->inputDelay = 1;
+  e.settings->input_delay = 1;
 
-  auto clientSettings = std::make_shared<Settings>(*e.settings);
-  for (auto& ws : clientSettings->wormSettings) {
+  auto client_settings = std::make_shared<Settings>(*e.settings);
+  for (auto& ws : client_settings->worm_settings) {
     if (ws) ws = std::make_shared<WormSettings>(*ws);
   }
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, clientSettings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, client_settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  auto* hc = host.rollbackController();
-  auto* cc = client.rollbackController();
+  auto* hc = host.Rollback();
+  auto* cc = client.Rollback();
   REQUIRE(hc != nullptr);
   REQUIRE(cc != nullptr);
 
-  hc->focus();
-  cc->focus();
+  hc->Focus();
+  cc->Focus();
 
-  constexpr uint8_t BIT_DOWN = uint8_t{1} << Worm::Down;
-  constexpr uint8_t BIT_FIRE = uint8_t{1} << Worm::Fire;
+  constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+  constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
 
-  auto runTick = [&](uint8_t inByte) {
-    hc->setLocalControlState(inByte);
-    cc->setLocalControlState(inByte);
-    host.update();
-    client.update();
-    hc->process();
-    cc->process();
+  auto run_tick = [&](uint8_t in_byte) {
+    hc->SetLocalControlState(in_byte);
+    cc->SetLocalControlState(in_byte);
+    host.Update();
+    client.Update();
+    hc->Process();
+    cc->Process();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
 
   // Drive both peers through WS into the game phase.
-  std::vector<uint8_t> wsScript;
+  std::vector<uint8_t> ws_script;
   for (int i = 0; i < 6; ++i) {
-    wsScript.push_back(BIT_DOWN);
-    wsScript.push_back(0);
+    ws_script.push_back(kBitDown);
+    ws_script.push_back(0);
   }
-  wsScript.push_back(0);
-  wsScript.push_back(BIT_FIRE);
-  wsScript.push_back(0);
-  for (uint8_t b : wsScript) runTick(b);
-  for (int i = 0; i < 200 && !(hc->gameState() == StateGame && cc->gameState() == StateGame); ++i) {
-    runTick(0);
+  ws_script.push_back(0);
+  ws_script.push_back(kBitFire);
+  ws_script.push_back(0);
+  for (uint8_t b : ws_script) run_tick(b);
+  for (int i = 0; i < 200 && !(hc->State() == kStateGame && cc->State() == kStateGame); ++i) {
+    run_tick(0);
   }
-  REQUIRE(hc->gameState() == StateGame);
-  REQUIRE(cc->gameState() == StateGame);
+  REQUIRE(hc->State() == kStateGame);
+  REQUIRE(cc->State() == kStateGame);
 
   // Play out a bit of game phase.
-  for (int i = 0; i < 200; ++i) runTick(0);
+  for (int i = 0; i < 200; ++i) run_tick(0);
 
   // The shadow Game (statsGame()) is where stats live now. The live
   // game's recorder is the base no-op class — the dynamic_cast below
   // would fail on it, which is the *intended* contract.
-  auto* hostStats = dynamic_cast<NormalStatsRecorder*>(hc->statsGame()->statsRecorder.get());
-  auto* clientStats = dynamic_cast<NormalStatsRecorder*>(cc->statsGame()->statsRecorder.get());
-  REQUIRE(hostStats != nullptr);
-  REQUIRE(clientStats != nullptr);
-  REQUIRE(hc->statsGame() != hc->currentGame());  // shadow, not live
-  REQUIRE(cc->statsGame() != cc->currentGame());
+  auto* host_stats = dynamic_cast<NormalStatsRecorder*>(hc->StatsGame()->stats_recorder.get());
+  auto* client_stats = dynamic_cast<NormalStatsRecorder*>(cc->StatsGame()->stats_recorder.get());
+  REQUIRE(host_stats != nullptr);
+  REQUIRE(client_stats != nullptr);
+  REQUIRE(hc->StatsGame() != hc->CurrentGame());  // shadow, not live
+  REQUIRE(cc->StatsGame() != cc->CurrentGame());
 
   // Live recorders are the no-op base class — dynamic_cast fails.
-  REQUIRE(dynamic_cast<NormalStatsRecorder*>(hc->currentGame()->statsRecorder.get()) == nullptr);
-  REQUIRE(dynamic_cast<NormalStatsRecorder*>(cc->currentGame()->statsRecorder.get()) == nullptr);
+  REQUIRE(dynamic_cast<NormalStatsRecorder*>(hc->CurrentGame()->stats_recorder.get()) == nullptr);
+  REQUIRE(dynamic_cast<NormalStatsRecorder*>(cc->CurrentGame()->stats_recorder.get()) == nullptr);
 
   // Both shadows should have ticked far past 0 — the shadow runs once
   // per confirmed frame and confirmation tracks within a few frames of
   // simFrame under loopback.
-  REQUIRE(hostStats->frame > 100);
-  REQUIRE(clientStats->frame > 100);
+  REQUIRE(host_stats->frame > 100);
+  REQUIRE(client_stats->frame > 100);
 
   // Host and client should agree closely on frame count — the shadow's
   // counter is keyed to confirmedSimFrame_ which is the same on both
   // peers within a few-frame window.
-  int frameGap = std::abs(hostStats->frame - clientStats->frame);
-  REQUIRE(frameGap <= 10);
+  int frame_gap = std::abs(host_stats->frame - client_stats->frame);
+  REQUIRE(frame_gap <= 10);
 
   // Pause + EndMatch flow: host pauses, picks END MATCH.
-  host.sendPause();
-  for (int i = 0; i < 10; ++i) runTick(0);
-  REQUIRE(cc->isPaused());
+  host.SendPause();
+  for (int i = 0; i < 10; ++i) run_tick(0);
+  REQUIRE(cc->IsPaused());
 
-  host.sendResume();
-  host.transport().sendEndMatch();
-  hc->endMatch();
+  host.SendResume();
+  host.Transport().SendEndMatch();
+  hc->EndMatch();
 
-  bool hostDone = false, clientDone = false;
-  for (int i = 0; i < 200 && !(hostDone && clientDone); ++i) {
-    hc->setLocalControlState(0);
-    cc->setLocalControlState(0);
-    if (!hostDone && !hc->process()) hostDone = true;
-    if (!clientDone && !cc->process()) clientDone = true;
-    host.update();
-    client.update();
+  bool host_done = false, client_done = false;
+  for (int i = 0; i < 200 && !(host_done && client_done); ++i) {
+    hc->SetLocalControlState(0);
+    cc->SetLocalControlState(0);
+    if (!host_done && !hc->Process()) host_done = true;
+    if (!client_done && !cc->Process()) client_done = true;
+    host.Update();
+    client.Update();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(hostDone);
-  REQUIRE(clientDone);
+  REQUIRE(host_done);
+  REQUIRE(client_done);
 
   // Both peers landed in StateGameEnded → finish() called on shadow →
   // gameTime now reflects the confirmed frame count.
-  REQUIRE(hc->gameState() == StateGameEnded);
-  REQUIRE(cc->gameState() == StateGameEnded);
-  REQUIRE(hostStats->gameTime > 0);
-  REQUIRE(clientStats->gameTime > 0);
+  REQUIRE(hc->State() == kStateGameEnded);
+  REQUIRE(cc->State() == kStateGameEnded);
+  REQUIRE(host_stats->game_time > 0);
+  REQUIRE(client_stats->game_time > 0);
   // gameTime is what gamePlayState checks to decide stats-vs-menu —
   // gating the symptom the user reported.
-  int gtGap = std::abs(hostStats->gameTime - clientStats->gameTime);
-  REQUIRE(gtGap <= 10);
+  int gt_gap = std::abs(host_stats->game_time - client_stats->game_time);
+  REQUIRE(gt_gap <= 10);
 }
 
 TEST_CASE("Host's inputDelay syncs to the client over MatchSettings", "[session][rollback]") {
   Env e;
-  e.settings->inputDelay = 2;
+  e.settings->input_delay = 2;
 
   // Client starts with a different inputDelay; host's value must
   // overwrite it via MatchSettings before tryStartGame builds the
   // controller.
-  auto clientSettings = std::make_shared<Settings>(*e.settings);
-  clientSettings->inputDelay = 5;
+  auto client_settings = std::make_shared<Settings>(*e.settings);
+  client_settings->input_delay = 5;
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, clientSettings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, client_settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  bool ready = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool ready = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
-  REQUIRE(clientSettings->inputDelay == 2);
-  REQUIRE(client.rollbackController() != nullptr);
+  REQUIRE(client_settings->input_delay == 2);
+  REQUIRE(client.Rollback() != nullptr);
 }
 
 TEST_CASE("Input batches received pre-Playing reach controller post-Playing",
           "[session][rollback][regression]") {
   Env e;
-  e.settings->inputDelay = 1;
+  e.settings->input_delay = 1;
 
-  NetSession host(e.common, e.settings, e.tcRoot);
-  NetSession client(e.common, e.settings, e.tcRoot);
+  NetSession host(e.common, e.settings, e.tc_root);
+  NetSession client(e.common, e.settings, e.tc_root);
 
-  REQUIRE(host.hostGame(0));
-  uint16_t port = host.transport().listeningPort();
-  REQUIRE(client.joinGame("127.0.0.1", port));
+  REQUIRE(host.HostGame(0));
+  uint16_t port = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", port));
 
-  REQUIRE(client.sessionState() != NetSession::Playing);
-  REQUIRE(client.rollbackController() == nullptr);
+  REQUIRE(client.State() != NetSession::kPlaying);
+  REQUIRE(client.Rollback() == nullptr);
 
   // Same entry point a real ENet packet would hit, while
   // client.rollbackPtr_ is still null.
-  uint8_t earlyInputs[8] = {0};
-  client.transport().onRemoteInputBatch(
-      /*generation=*/0, /*baseFrame=*/0, /*count=*/8, earlyInputs,
+  uint8_t early_inputs[8] = {0};
+  client.Transport().on_remote_input_batch(
+      /*generation=*/0, /*baseFrame=*/0, /*count=*/8, early_inputs,
       /*remoteLocalFrame=*/7);
 
-  bool reached = pollUntil(host, client, [&]() {
-    return host.sessionState() == NetSession::Playing &&
-           client.sessionState() == NetSession::Playing;
+  bool reached = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying &&
+           client.State() == NetSession::kPlaying;
   });
   REQUIRE(reached);
-  REQUIRE(client.rollbackController() != nullptr);
+  REQUIRE(client.Rollback() != nullptr);
 
   // No rollback.process() on either side during the handshake, so the
   // only remote input the client's confirm chain can see is the
   // pre-Playing injection above.
-  auto* rb = client.rollbackController();
-  rb->focus();
+  auto* rb = client.Rollback();
+  rb->Focus();
   for (int i = 0; i < 16; ++i) {
-    rb->setLocalControlState(0);
-    rb->process();
+    rb->SetLocalControlState(0);
+    rb->Process();
   }
 
-  INFO("client simFrame=" << rb->currentFrame() << " confirmedFrame=" << rb->confirmedFrame());
-  REQUIRE(rb->confirmedFrame() >= 7);
+  INFO("client simFrame=" << rb->CurrentFrame() << " confirmedFrame=" << rb->ConfirmedFrame());
+  REQUIRE(rb->ConfirmedFrame() >= 7);
 }

--- a/src/tests/test_session_rollback.cpp
+++ b/src/tests/test_session_rollback.cpp
@@ -65,8 +65,7 @@ TEST_CASE("NetSession reaches Playing and runs ticks", "[session][rollback]") {
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -133,8 +132,7 @@ TEST_CASE("Rollback weapon select transitions to game over a real session",
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -230,8 +228,7 @@ TEST_CASE("Rollback session runs ≥5s game-phase post-WS without desync", "[ses
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -359,8 +356,7 @@ TEST_CASE("Per-worm stats hooks fire on the shadow on both peers", "[session][ro
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -453,8 +449,7 @@ TEST_CASE("Stats accumulate on both peers across a rollback game", "[session][ro
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -576,8 +571,7 @@ TEST_CASE("Host's inputDelay syncs to the client over MatchSettings", "[session]
   REQUIRE(client.JoinGame("127.0.0.1", port));
 
   bool ready = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(ready);
 
@@ -608,8 +602,7 @@ TEST_CASE("Input batches received pre-Playing reach controller post-Playing",
       /*remoteLocalFrame=*/7);
 
   bool reached = PollUntil(host, client, [&]() {
-    return host.State() == NetSession::kPlaying &&
-           client.State() == NetSession::kPlaying;
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
   });
   REQUIRE(reached);
   REQUIRE(client.Rollback() != nullptr);

--- a/src/tests/test_settings.cpp
+++ b/src/tests/test_settings.cpp
@@ -173,7 +173,8 @@ TEST_CASE("Settings round-trip via TOML") {
   CHECK(loaded.worm_settings[2]->input_device == original.worm_settings[2]->input_device);
   CHECK(loaded.worm_settings[2]->gamepad_name == original.worm_settings[2]->gamepad_name);
   CHECK(loaded.worm_settings[2]->gamepad_serial == original.worm_settings[2]->gamepad_serial);
-  CHECK(loaded.worm_settings[2]->gamepad_controls[0] == original.worm_settings[2]->gamepad_controls[0]);
+  CHECK(loaded.worm_settings[2]->gamepad_controls[0] ==
+        original.worm_settings[2]->gamepad_controls[0]);
 
   // Cleanup
   std::filesystem::remove(tmp_path);

--- a/src/tests/test_settings.cpp
+++ b/src/tests/test_settings.cpp
@@ -11,90 +11,90 @@
 
 TEST_CASE("Settings round-trip via TOML") {
   Rand rand;
-  rand.seed(42);
+  rand.Seed(42);
 
   // Create settings with non-default values
   Settings original;
-  original.maxBonuses = 7;
+  original.max_bonuses = 7;
   original.blood = 200;
-  original.timeToLose = 300;
-  original.flagsToWin = 10;
-  original.gameMode = 2;
+  original.time_to_lose = 300;
+  original.flags_to_win = 10;
+  original.game_mode = 2;
   original.shadow = false;
-  original.loadChange = false;
-  original.namesOnBonuses = true;
-  original.regenerateLevel = true;
+  original.load_change = false;
+  original.names_on_bonuses = true;
+  original.regenerate_level = true;
   original.lives = 25;
-  original.loadingTime = 50;
-  original.randomLevel = false;
-  original.levelFile = "testlevel.lev";
+  original.loading_time = 50;
+  original.random_level = false;
+  original.level_file = "testlevel.lev";
   original.map = false;
-  original.screenSync = false;
+  original.screen_sync = false;
 
   // Extension fields
-  original.recordReplays = false;
-  original.loadPowerlevelPalette = false;
-  original.bloodParticleMax = 500;
-  original.aiFrames = 200;
-  original.aiMutations = 5;
-  original.aiTraces = true;
-  original.aiParallels = 8;
+  original.record_replays = false;
+  original.load_powerlevel_palette = false;
+  original.blood_particle_max = 500;
+  original.ai_frames = 200;
+  original.ai_mutations = 5;
+  original.ai_traces = true;
+  original.ai_parallels = 8;
   original.fullscreen = true;
-  original.zoneTimeout = 60;
-  original.selectBotWeapons = 2;
-  original.allowViewingSpawnPoint = true;
-  original.singleScreenReplay = true;
-  original.spectatorWindow = true;
+  original.zone_timeout = 60;
+  original.select_bot_weapons = 2;
+  original.allow_viewing_spawn_point = true;
+  original.single_screen_replay = true;
+  original.spectator_window = true;
   original.tc = "customtc";
 
   // Weapon table
-  for (int i = 0; i < 40; ++i) original.weapTable[i] = i % 3;
+  for (int i = 0; i < 40; ++i) original.weap_table[i] = i % 3;
 
   // Worm settings (player 0)
-  original.wormSettings[0]->controller = 1;
-  original.wormSettings[0]->health = 150;
-  original.wormSettings[0]->name = "TestWorm1";
-  original.wormSettings[0]->randomName = false;
-  original.wormSettings[0]->rgb[0] = 10;
-  original.wormSettings[0]->rgb[1] = 20;
-  original.wormSettings[0]->rgb[2] = 30;
-  original.wormSettings[0]->controlsEx[0] = 100;
-  original.wormSettings[0]->controlsEx[1] = 101;
-  original.wormSettings[0]->weapons[0] = 5;
-  original.wormSettings[0]->weapons[1] = 10;
-  original.wormSettings[0]->inputDevice = 1;
-  original.wormSettings[0]->gamepadName = "Xbox Controller";
+  original.worm_settings[0]->controller = 1;
+  original.worm_settings[0]->health = 150;
+  original.worm_settings[0]->name = "TestWorm1";
+  original.worm_settings[0]->random_name = false;
+  original.worm_settings[0]->rgb[0] = 10;
+  original.worm_settings[0]->rgb[1] = 20;
+  original.worm_settings[0]->rgb[2] = 30;
+  original.worm_settings[0]->controls_ex[0] = 100;
+  original.worm_settings[0]->controls_ex[1] = 101;
+  original.worm_settings[0]->weapons[0] = 5;
+  original.worm_settings[0]->weapons[1] = 10;
+  original.worm_settings[0]->input_device = 1;
+  original.worm_settings[0]->gamepad_name = "Xbox Controller";
 
   // Worm settings (player 1)
-  original.wormSettings[1]->controller = 2;
-  original.wormSettings[1]->health = 200;
-  original.wormSettings[1]->name = "TestWorm2";
-  original.wormSettings[1]->randomName = false;
-  original.wormSettings[1]->rgb[0] = 40;
-  original.wormSettings[1]->rgb[1] = 50;
-  original.wormSettings[1]->rgb[2] = 60;
-  original.wormSettings[1]->controlsEx[2] = 200;
+  original.worm_settings[1]->controller = 2;
+  original.worm_settings[1]->health = 200;
+  original.worm_settings[1]->name = "TestWorm2";
+  original.worm_settings[1]->random_name = false;
+  original.worm_settings[1]->rgb[0] = 40;
+  original.worm_settings[1]->rgb[1] = 50;
+  original.worm_settings[1]->rgb[2] = 60;
+  original.worm_settings[1]->controls_ex[2] = 200;
 
   // Network player (player 2)
-  original.wormSettings[2]->controller = 1;
-  original.wormSettings[2]->health = 175;
-  original.wormSettings[2]->name = "NetPlayer";
-  original.wormSettings[2]->randomName = false;
-  original.wormSettings[2]->rgb[0] = 5;
-  original.wormSettings[2]->rgb[1] = 15;
-  original.wormSettings[2]->rgb[2] = 25;
-  original.wormSettings[2]->controlsEx[0] = 50;
-  original.wormSettings[2]->controlsEx[3] = 77;
-  original.wormSettings[2]->weapons[0] = 3;
-  original.wormSettings[2]->weapons[2] = 7;
-  original.wormSettings[2]->inputDevice = 2;
-  original.wormSettings[2]->gamepadName = "PS5 Controller";
-  original.wormSettings[2]->gamepadSerial = "ABC123";
-  original.wormSettings[2]->gamepadControls[0] = 10;
+  original.worm_settings[2]->controller = 1;
+  original.worm_settings[2]->health = 175;
+  original.worm_settings[2]->name = "NetPlayer";
+  original.worm_settings[2]->random_name = false;
+  original.worm_settings[2]->rgb[0] = 5;
+  original.worm_settings[2]->rgb[1] = 15;
+  original.worm_settings[2]->rgb[2] = 25;
+  original.worm_settings[2]->controls_ex[0] = 50;
+  original.worm_settings[2]->controls_ex[3] = 77;
+  original.worm_settings[2]->weapons[0] = 3;
+  original.worm_settings[2]->weapons[2] = 7;
+  original.worm_settings[2]->input_device = 2;
+  original.worm_settings[2]->gamepad_name = "PS5 Controller";
+  original.worm_settings[2]->gamepad_serial = "ABC123";
+  original.worm_settings[2]->gamepad_controls[0] = 10;
 
   // Save to temp file
-  auto tmpPath = std::filesystem::temp_directory_path() / "openliero_test_settings.cfg";
-  FsNode node(tmpPath.string());
+  auto tmp_path = std::filesystem::temp_directory_path() / "openliero_test_settings.cfg";
+  FsNode node(tmp_path.string());
 
   original.save(node, rand);
 
@@ -103,85 +103,85 @@ TEST_CASE("Settings round-trip via TOML") {
   REQUIRE(loaded.load(node, rand));
 
   // Verify base settings
-  CHECK(loaded.maxBonuses == original.maxBonuses);
+  CHECK(loaded.max_bonuses == original.max_bonuses);
   CHECK(loaded.blood == original.blood);
-  CHECK(loaded.timeToLose == original.timeToLose);
-  CHECK(loaded.flagsToWin == original.flagsToWin);
-  CHECK(loaded.gameMode == original.gameMode);
+  CHECK(loaded.time_to_lose == original.time_to_lose);
+  CHECK(loaded.flags_to_win == original.flags_to_win);
+  CHECK(loaded.game_mode == original.game_mode);
   CHECK(loaded.shadow == original.shadow);
-  CHECK(loaded.loadChange == original.loadChange);
-  CHECK(loaded.namesOnBonuses == original.namesOnBonuses);
-  CHECK(loaded.regenerateLevel == original.regenerateLevel);
+  CHECK(loaded.load_change == original.load_change);
+  CHECK(loaded.names_on_bonuses == original.names_on_bonuses);
+  CHECK(loaded.regenerate_level == original.regenerate_level);
   CHECK(loaded.lives == original.lives);
-  CHECK(loaded.loadingTime == original.loadingTime);
-  CHECK(loaded.randomLevel == original.randomLevel);
-  CHECK(loaded.levelFile == original.levelFile);
+  CHECK(loaded.loading_time == original.loading_time);
+  CHECK(loaded.random_level == original.random_level);
+  CHECK(loaded.level_file == original.level_file);
   CHECK(loaded.map == original.map);
-  CHECK(loaded.screenSync == original.screenSync);
+  CHECK(loaded.screen_sync == original.screen_sync);
 
   // Extension fields
-  CHECK(loaded.recordReplays == original.recordReplays);
-  CHECK(loaded.loadPowerlevelPalette == original.loadPowerlevelPalette);
-  CHECK(loaded.bloodParticleMax == original.bloodParticleMax);
-  CHECK(loaded.aiFrames == original.aiFrames);
-  CHECK(loaded.aiMutations == original.aiMutations);
-  CHECK(loaded.aiTraces == original.aiTraces);
-  CHECK(loaded.aiParallels == original.aiParallels);
+  CHECK(loaded.record_replays == original.record_replays);
+  CHECK(loaded.load_powerlevel_palette == original.load_powerlevel_palette);
+  CHECK(loaded.blood_particle_max == original.blood_particle_max);
+  CHECK(loaded.ai_frames == original.ai_frames);
+  CHECK(loaded.ai_mutations == original.ai_mutations);
+  CHECK(loaded.ai_traces == original.ai_traces);
+  CHECK(loaded.ai_parallels == original.ai_parallels);
   CHECK(loaded.fullscreen == original.fullscreen);
-  CHECK(loaded.zoneTimeout == original.zoneTimeout);
-  CHECK(loaded.selectBotWeapons == original.selectBotWeapons);
-  CHECK(loaded.allowViewingSpawnPoint == original.allowViewingSpawnPoint);
-  CHECK(loaded.singleScreenReplay == original.singleScreenReplay);
-  CHECK(loaded.spectatorWindow == original.spectatorWindow);
+  CHECK(loaded.zone_timeout == original.zone_timeout);
+  CHECK(loaded.select_bot_weapons == original.select_bot_weapons);
+  CHECK(loaded.allow_viewing_spawn_point == original.allow_viewing_spawn_point);
+  CHECK(loaded.single_screen_replay == original.single_screen_replay);
+  CHECK(loaded.spectator_window == original.spectator_window);
   CHECK(loaded.tc == original.tc);
 
   // Weapon table
-  for (int i = 0; i < 40; ++i) CHECK(loaded.weapTable[i] == original.weapTable[i]);
+  for (int i = 0; i < 40; ++i) CHECK(loaded.weap_table[i] == original.weap_table[i]);
 
   // Player 0
-  CHECK(loaded.wormSettings[0]->controller == original.wormSettings[0]->controller);
-  CHECK(loaded.wormSettings[0]->health == original.wormSettings[0]->health);
-  CHECK(loaded.wormSettings[0]->name == original.wormSettings[0]->name);
-  CHECK(loaded.wormSettings[0]->rgb[0] == original.wormSettings[0]->rgb[0]);
-  CHECK(loaded.wormSettings[0]->rgb[1] == original.wormSettings[0]->rgb[1]);
-  CHECK(loaded.wormSettings[0]->rgb[2] == original.wormSettings[0]->rgb[2]);
-  CHECK(loaded.wormSettings[0]->controlsEx[0] == original.wormSettings[0]->controlsEx[0]);
-  CHECK(loaded.wormSettings[0]->controlsEx[1] == original.wormSettings[0]->controlsEx[1]);
-  CHECK(loaded.wormSettings[0]->weapons[0] == original.wormSettings[0]->weapons[0]);
-  CHECK(loaded.wormSettings[0]->weapons[1] == original.wormSettings[0]->weapons[1]);
-  CHECK(loaded.wormSettings[0]->inputDevice == original.wormSettings[0]->inputDevice);
-  CHECK(loaded.wormSettings[0]->gamepadName == original.wormSettings[0]->gamepadName);
+  CHECK(loaded.worm_settings[0]->controller == original.worm_settings[0]->controller);
+  CHECK(loaded.worm_settings[0]->health == original.worm_settings[0]->health);
+  CHECK(loaded.worm_settings[0]->name == original.worm_settings[0]->name);
+  CHECK(loaded.worm_settings[0]->rgb[0] == original.worm_settings[0]->rgb[0]);
+  CHECK(loaded.worm_settings[0]->rgb[1] == original.worm_settings[0]->rgb[1]);
+  CHECK(loaded.worm_settings[0]->rgb[2] == original.worm_settings[0]->rgb[2]);
+  CHECK(loaded.worm_settings[0]->controls_ex[0] == original.worm_settings[0]->controls_ex[0]);
+  CHECK(loaded.worm_settings[0]->controls_ex[1] == original.worm_settings[0]->controls_ex[1]);
+  CHECK(loaded.worm_settings[0]->weapons[0] == original.worm_settings[0]->weapons[0]);
+  CHECK(loaded.worm_settings[0]->weapons[1] == original.worm_settings[0]->weapons[1]);
+  CHECK(loaded.worm_settings[0]->input_device == original.worm_settings[0]->input_device);
+  CHECK(loaded.worm_settings[0]->gamepad_name == original.worm_settings[0]->gamepad_name);
 
   // Player 1
-  CHECK(loaded.wormSettings[1]->controller == original.wormSettings[1]->controller);
-  CHECK(loaded.wormSettings[1]->health == original.wormSettings[1]->health);
-  CHECK(loaded.wormSettings[1]->name == original.wormSettings[1]->name);
-  CHECK(loaded.wormSettings[1]->rgb[0] == original.wormSettings[1]->rgb[0]);
-  CHECK(loaded.wormSettings[1]->controlsEx[2] == original.wormSettings[1]->controlsEx[2]);
+  CHECK(loaded.worm_settings[1]->controller == original.worm_settings[1]->controller);
+  CHECK(loaded.worm_settings[1]->health == original.worm_settings[1]->health);
+  CHECK(loaded.worm_settings[1]->name == original.worm_settings[1]->name);
+  CHECK(loaded.worm_settings[1]->rgb[0] == original.worm_settings[1]->rgb[0]);
+  CHECK(loaded.worm_settings[1]->controls_ex[2] == original.worm_settings[1]->controls_ex[2]);
 
   // Network player (the critical one that was broken)
-  CHECK(loaded.wormSettings[2]->controller == original.wormSettings[2]->controller);
-  CHECK(loaded.wormSettings[2]->health == original.wormSettings[2]->health);
-  CHECK(loaded.wormSettings[2]->name == original.wormSettings[2]->name);
-  CHECK(loaded.wormSettings[2]->rgb[0] == original.wormSettings[2]->rgb[0]);
-  CHECK(loaded.wormSettings[2]->rgb[1] == original.wormSettings[2]->rgb[1]);
-  CHECK(loaded.wormSettings[2]->rgb[2] == original.wormSettings[2]->rgb[2]);
-  CHECK(loaded.wormSettings[2]->controlsEx[0] == original.wormSettings[2]->controlsEx[0]);
-  CHECK(loaded.wormSettings[2]->controlsEx[3] == original.wormSettings[2]->controlsEx[3]);
-  CHECK(loaded.wormSettings[2]->weapons[0] == original.wormSettings[2]->weapons[0]);
-  CHECK(loaded.wormSettings[2]->weapons[2] == original.wormSettings[2]->weapons[2]);
-  CHECK(loaded.wormSettings[2]->inputDevice == original.wormSettings[2]->inputDevice);
-  CHECK(loaded.wormSettings[2]->gamepadName == original.wormSettings[2]->gamepadName);
-  CHECK(loaded.wormSettings[2]->gamepadSerial == original.wormSettings[2]->gamepadSerial);
-  CHECK(loaded.wormSettings[2]->gamepadControls[0] == original.wormSettings[2]->gamepadControls[0]);
+  CHECK(loaded.worm_settings[2]->controller == original.worm_settings[2]->controller);
+  CHECK(loaded.worm_settings[2]->health == original.worm_settings[2]->health);
+  CHECK(loaded.worm_settings[2]->name == original.worm_settings[2]->name);
+  CHECK(loaded.worm_settings[2]->rgb[0] == original.worm_settings[2]->rgb[0]);
+  CHECK(loaded.worm_settings[2]->rgb[1] == original.worm_settings[2]->rgb[1]);
+  CHECK(loaded.worm_settings[2]->rgb[2] == original.worm_settings[2]->rgb[2]);
+  CHECK(loaded.worm_settings[2]->controls_ex[0] == original.worm_settings[2]->controls_ex[0]);
+  CHECK(loaded.worm_settings[2]->controls_ex[3] == original.worm_settings[2]->controls_ex[3]);
+  CHECK(loaded.worm_settings[2]->weapons[0] == original.worm_settings[2]->weapons[0]);
+  CHECK(loaded.worm_settings[2]->weapons[2] == original.worm_settings[2]->weapons[2]);
+  CHECK(loaded.worm_settings[2]->input_device == original.worm_settings[2]->input_device);
+  CHECK(loaded.worm_settings[2]->gamepad_name == original.worm_settings[2]->gamepad_name);
+  CHECK(loaded.worm_settings[2]->gamepad_serial == original.worm_settings[2]->gamepad_serial);
+  CHECK(loaded.worm_settings[2]->gamepad_controls[0] == original.worm_settings[2]->gamepad_controls[0]);
 
   // Cleanup
-  std::filesystem::remove(tmpPath);
+  std::filesystem::remove(tmp_path);
 }
 
 TEST_CASE("Settings load handles missing file gracefully") {
   Rand rand;
-  rand.seed(1);
+  rand.Seed(1);
 
   Settings settings;
   FsNode node("/tmp/nonexistent_openliero_settings.cfg");
@@ -190,27 +190,27 @@ TEST_CASE("Settings load handles missing file gracefully") {
 
 TEST_CASE("Settings TOML with comments") {
   Rand rand;
-  rand.seed(42);
+  rand.Seed(42);
 
   // Write using toToml(), then verify it can be re-loaded
   Settings original;
-  original.maxBonuses = 12;
+  original.max_bonuses = 12;
   original.blood = 50;
 
-  auto tmpPath = std::filesystem::temp_directory_path() / "openliero_test_comments.cfg";
+  auto tmp_path = std::filesystem::temp_directory_path() / "openliero_test_comments.cfg";
 
   {
-    std::ofstream f(tmpPath);
+    std::ofstream f(tmp_path);
     f << "# This is a comment\n";
-    f << original.toToml();
+    f << original.ToToml();
   }
 
-  FsNode node(tmpPath.string());
+  FsNode node(tmp_path.string());
   Settings loaded;
   REQUIRE(loaded.load(node, rand));
-  std::filesystem::remove(tmpPath);
+  std::filesystem::remove(tmp_path);
 
-  CHECK(loaded.maxBonuses == 12);
+  CHECK(loaded.max_bonuses == 12);
   CHECK(loaded.blood == 50);
 }
 
@@ -219,33 +219,33 @@ TEST_CASE("Settings hash only includes gameplay fields") {
   Settings s2;
 
   // Both should have the same hash initially
-  auto hash1 = s1.updateHash();
-  auto hash2 = s2.updateHash();
+  auto hash1 = s1.UpdateHash();
+  auto hash2 = s2.UpdateHash();
   CHECK(hash1 == hash2);
 
   // Changing an app-only field should NOT change the hash
   s2.fullscreen = !s2.fullscreen;
-  s2.singleScreenReplay = !s2.singleScreenReplay;
-  s2.spectatorWindow = !s2.spectatorWindow;
-  s2.bloodParticleMax = 9999;
-  auto hash3 = s2.updateHash();
+  s2.single_screen_replay = !s2.single_screen_replay;
+  s2.spectator_window = !s2.spectator_window;
+  s2.blood_particle_max = 9999;
+  auto hash3 = s2.UpdateHash();
   CHECK(hash1 == hash3);
 
   // Changing a gameplay field SHOULD change the hash
   s2.lives = 99;
-  auto hash4 = s2.updateHash();
+  auto hash4 = s2.UpdateHash();
   CHECK(hash1 != hash4);
 
   // Changing another gameplay field
   Settings s3;
-  s3.zoneTimeout = 999;
-  auto hash5 = s3.updateHash();
+  s3.zone_timeout = 999;
+  auto hash5 = s3.UpdateHash();
   CHECK(hash1 != hash5);
 
   // Changing TC should change hash
   Settings s4;
   s4.tc = "different_tc";
-  auto hash6 = s4.updateHash();
+  auto hash6 = s4.UpdateHash();
   CHECK(hash1 != hash6);
 }
 
@@ -253,7 +253,7 @@ TEST_CASE("WormSettings profile round-trip") {
   // Set up a worm profile with non-default values
   WormSettings original;
   original.name = "TestWorm";
-  original.randomName = false;
+  original.random_name = false;
   original.controller = 1;
   original.health = 200;
   original.rgb[0] = 10;
@@ -261,25 +261,25 @@ TEST_CASE("WormSettings profile round-trip") {
   original.rgb[2] = 30;
   original.weapons[0] = 3;
   original.weapons[1] = 2;
-  original.controlsEx[0] = 42;
-  original.controlsEx[1] = 99;
-  original.inputDevice = 1;
-  original.gamepadName = "TestPad";
-  original.gamepadSerial = "SERIAL123";
-  original.gamepadControls[0] = 7;
+  original.controls_ex[0] = 42;
+  original.controls_ex[1] = 99;
+  original.input_device = 1;
+  original.gamepad_name = "TestPad";
+  original.gamepad_serial = "SERIAL123";
+  original.gamepad_controls[0] = 7;
 
-  auto tmpPath = std::filesystem::temp_directory_path() / "openliero_test_profile.toml";
+  auto tmp_path = std::filesystem::temp_directory_path() / "openliero_test_profile.toml";
 
   // Save
-  original.saveProfile(FsNode(tmpPath.string()));
+  original.SaveProfile(FsNode(tmp_path.string()));
 
   // Load into a fresh WormSettings
   WormSettings loaded;
   loaded.color = 55;  // Should be preserved
-  loaded.loadProfile(FsNode(tmpPath.string()));
+  loaded.LoadProfile(FsNode(tmp_path.string()));
 
   CHECK(loaded.name == "TestWorm");
-  CHECK(loaded.randomName == false);
+  CHECK(loaded.random_name == false);
   CHECK(loaded.controller == 1);
   CHECK(loaded.health == 200);
   CHECK(loaded.rgb[0] == 10);
@@ -287,57 +287,57 @@ TEST_CASE("WormSettings profile round-trip") {
   CHECK(loaded.rgb[2] == 30);
   CHECK(loaded.weapons[0] == 3);
   CHECK(loaded.weapons[1] == 2);
-  CHECK(loaded.controlsEx[0] == 42);
-  CHECK(loaded.controlsEx[1] == 99);
-  CHECK(loaded.inputDevice == 1);
-  CHECK(loaded.gamepadName == "TestPad");
-  CHECK(loaded.gamepadSerial == "SERIAL123");
-  CHECK(loaded.gamepadControls[0] == 7);
+  CHECK(loaded.controls_ex[0] == 42);
+  CHECK(loaded.controls_ex[1] == 99);
+  CHECK(loaded.input_device == 1);
+  CHECK(loaded.gamepad_name == "TestPad");
+  CHECK(loaded.gamepad_serial == "SERIAL123");
+  CHECK(loaded.gamepad_controls[0] == 7);
   CHECK(loaded.color == 55);  // Color is preserved across profile load
 
-  std::filesystem::remove(tmpPath);
+  std::filesystem::remove(tmp_path);
 }
 
 TEST_CASE("Settings toToml/fromToml round-trip") {
   Settings original;
-  original.maxBonuses = 8;
+  original.max_bonuses = 8;
   original.blood = 150;
   original.lives = 30;
   original.fullscreen = true;
   original.tc = "custom_tc";
-  original.wormSettings[0]->name = "Player1";
-  original.wormSettings[0]->randomName = false;
+  original.worm_settings[0]->name = "Player1";
+  original.worm_settings[0]->random_name = false;
 
-  std::string toml = original.toToml();
+  std::string toml = original.ToToml();
   REQUIRE(!toml.empty());
 
   Settings loaded;
-  loaded.fromToml(toml);
+  loaded.FromToml(toml);
 
-  CHECK(loaded.maxBonuses == 8);
+  CHECK(loaded.max_bonuses == 8);
   CHECK(loaded.blood == 150);
   CHECK(loaded.lives == 30);
   CHECK(loaded.fullscreen == true);
   CHECK(loaded.tc == "custom_tc");
-  CHECK(loaded.wormSettings[0]->name == "Player1");
+  CHECK(loaded.worm_settings[0]->name == "Player1");
 }
 
 TEST_CASE("WormSettings toToml/fromToml round-trip") {
   WormSettings original;
   original.name = "TestWorm";
-  original.randomName = false;
+  original.random_name = false;
   original.health = 250;
   original.controller = 2;
-  original.controlsEx[0] = 77;
+  original.controls_ex[0] = 77;
 
-  std::string toml = original.toToml();
+  std::string toml = original.ToToml();
   REQUIRE(!toml.empty());
 
   WormSettings loaded;
-  loaded.fromToml(toml);
+  loaded.FromToml(toml);
 
   CHECK(loaded.name == "TestWorm");
   CHECK(loaded.health == 250);
   CHECK(loaded.controller == 2);
-  CHECK(loaded.controlsEx[0] == 77);
+  CHECK(loaded.controls_ex[0] == 77);
 }

--- a/src/tests/test_sfx_loader.cpp
+++ b/src/tests/test_sfx_loader.cpp
@@ -11,19 +11,19 @@
 
 namespace {
 
-void put_u16le(std::vector<uint8_t>& buf, uint16_t v) {
+void PutU16le(std::vector<uint8_t>& buf, uint16_t v) {
   buf.push_back(v & 0xff);
   buf.push_back((v >> 8) & 0xff);
 }
 
-void put_u32le(std::vector<uint8_t>& buf, uint32_t v) {
+void PutU32le(std::vector<uint8_t>& buf, uint32_t v) {
   buf.push_back(v & 0xff);
   buf.push_back((v >> 8) & 0xff);
   buf.push_back((v >> 16) & 0xff);
   buf.push_back((v >> 24) & 0xff);
 }
 
-void put_name8(std::vector<uint8_t>& buf, char const* name) {
+void PutName8(std::vector<uint8_t>& buf, char const* name) {
   uint8_t pad[8] = {0};
   std::size_t n = std::strlen(name);
   if (n > 8) n = 8;
@@ -39,32 +39,32 @@ TEST_CASE("loadSfx preserves disabled middle slots", "[sfx_loader]") {
   // Three samples: "first" (4 bytes), "middle" (disabled, length 0),
   // "last" (4 bytes). Header is 2 + 3*16 = 50 bytes; audio data follows.
   std::vector<uint8_t> blob;
-  put_u16le(blob, 3);
+  PutU16le(blob, 3);
 
-  uint32_t const headerEnd = 2 + 3 * 16;
+  uint32_t const kHeaderEnd = 2 + 3 * 16;
 
-  put_name8(blob, "first");
-  put_u32le(blob, headerEnd);
-  put_u32le(blob, 4);
+  PutName8(blob, "first");
+  PutU32le(blob, kHeaderEnd);
+  PutU32le(blob, 4);
 
-  put_name8(blob, "middle");
-  put_u32le(blob, 0);
-  put_u32le(blob, 0);
+  PutName8(blob, "middle");
+  PutU32le(blob, 0);
+  PutU32le(blob, 0);
 
-  put_name8(blob, "last");
-  put_u32le(blob, headerEnd + 4);
-  put_u32le(blob, 4);
+  PutName8(blob, "last");
+  PutU32le(blob, kHeaderEnd + 4);
+  PutU32le(blob, 4);
 
-  uint8_t firstData[4] = {1, 2, 3, 4};
-  uint8_t lastData[4] = {5, 6, 7, 8};
-  blob.insert(blob.end(), firstData, firstData + 4);
-  blob.insert(blob.end(), lastData, lastData + 4);
+  uint8_t first_data[4] = {1, 2, 3, 4};
+  uint8_t last_data[4] = {5, 6, 7, 8};
+  blob.insert(blob.end(), first_data, first_data + 4);
+  blob.insert(blob.end(), last_data, last_data + 4);
 
   io::MemReader mem(blob);
   ReaderFile rf(mem);
 
   std::vector<SfxSample> sounds;
-  REQUIRE_NOTHROW(loadSfx(sounds, rf));
+  REQUIRE_NOTHROW(LoadSfx(sounds, rf));
 
   REQUIRE(sounds.size() == 3);
 

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -32,51 +32,51 @@ struct GameRunner {
   std::unique_ptr<Game> game;
 
   GameRunner(uint32_t seed) {
-    precomputeTables();
+    PrecomputeTables();
 
     common = std::make_shared<Common>();
-    FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-    common->load(std::move(tcRoot));
+    FsNode tc_root(FsNode("data") / "TC" / "openliero");
+    common->load(std::move(tc_root));
 
     settings = std::make_shared<Settings>();
     settings->lives = 50;
-    settings->loadingTime = 0;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
     settings->blood = 100;
 
     sp = std::make_shared<NullSoundPlayer>();
     game = std::make_unique<Game>(common, settings, sp);
-    game->rand.seed(seed);
+    game->rand.Seed(seed);
 
     for (int idx = 0; idx < 2; ++idx) {
       auto w = std::make_shared<Worm>();
-      w->settings = settings->wormSettings[idx];
+      w->settings = settings->worm_settings[idx];
       w->health = 25;
       w->index = idx;
-      w->statsX = idx == 0 ? 0 : 218;
-      game->addWorm(w);
+      w->stats_x = idx == 0 ? 0 : 218;
+      game->AddWorm(w);
     }
 
-    game->addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-    game->level.generateFromSettings(*common, *settings, game->rand);
-    for (auto const& w : game->worms) w->initWeapons(*game);
+    game->level.GenerateFromSettings(*common, *settings, game->rand);
+    for (auto const& w : game->worms) w->InitWeapons(*game);
 
     game->paused = false;
-    game->startGame();
-    game->resetWorms();
+    game->StartGame();
+    game->ResetWorms();
   }
 
-  void step(Rand& inputRng) {
+  void Step(Rand& input_rng) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = inputRng() & 0x7f;
-      if ((inputRng() % 10) < 6) input |= (1 << 4);
-      if ((inputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
-      game->worms[idx]->controlStates.unpack(input);
+      uint32_t input = input_rng() & 0x7f;
+      if ((input_rng() % 10) < 6) input |= (1 << 4);
+      if ((input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
+      game->worms[idx]->control_states.Unpack(input);
     }
-    game->processFrame();
+    game->ProcessFrame();
   }
 };
 
@@ -86,59 +86,59 @@ TEST_CASE("Fast snapshot round-trip preserves frame-by-frame state", "[snapshot]
   constexpr uint32_t kSeed = 0xC0FFEE;
   constexpr int kPhase = 200;
 
-  std::vector<uint32_t> controlHashes;
-  controlHashes.reserve(3 * kPhase);
+  std::vector<uint32_t> control_hashes;
+  control_hashes.reserve(3 * kPhase);
   {
     GameRunner ctl(kSeed);
-    Rand inputRng(kSeed ^ 0xDEAD);
+    Rand input_rng(kSeed ^ 0xDEAD);
     for (int f = 0; f < 3 * kPhase; ++f) {
-      ctl.step(inputRng);
-      controlHashes.push_back(hashGameState(*ctl.game));
+      ctl.Step(input_rng);
+      control_hashes.push_back(HashGameState(*ctl.game));
     }
   }
 
   GameRunner sub(kSeed);
-  Rand inputRng(kSeed ^ 0xDEAD);
+  Rand input_rng(kSeed ^ 0xDEAD);
 
   GameSnapshot snap;
-  snap.prepare(*sub.game);
+  snap.Prepare(*sub.game);
 
   for (int f = 0; f < kPhase; ++f) {
-    sub.step(inputRng);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    sub.Step(input_rng);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 
-  sub.game->saveSnapshotFast(snap);
-  uint32_t hashAtSnap = hashGameState(*sub.game);
+  sub.game->SaveSnapshotFast(snap);
+  uint32_t hash_at_snap = HashGameState(*sub.game);
 
   for (int f = kPhase; f < 2 * kPhase; ++f) {
-    sub.step(inputRng);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    sub.Step(input_rng);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 
-  sub.game->loadSnapshotFast(snap);
-  REQUIRE(hashGameState(*sub.game) == hashAtSnap);
+  sub.game->LoadSnapshotFast(snap);
+  REQUIRE(HashGameState(*sub.game) == hash_at_snap);
 
   // Replay phase-2 inputs from the restored state — same scheme as the
   // cereal round-trip test.
-  Rand postSnapInputRng(kSeed ^ 0xDEAD);
+  Rand post_snap_input_rng(kSeed ^ 0xDEAD);
   for (int f = 0; f < kPhase; ++f) {
     for (int idx = 0; idx < 2; ++idx) {
-      (void)postSnapInputRng();
-      (void)postSnapInputRng();
-      (void)postSnapInputRng();
+      (void)post_snap_input_rng();
+      (void)post_snap_input_rng();
+      (void)post_snap_input_rng();
     }
   }
   for (int f = kPhase; f < 2 * kPhase; ++f) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = postSnapInputRng() & 0x7f;
-      if ((postSnapInputRng() % 10) < 6) input |= (1 << 4);
-      if ((postSnapInputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
-      sub.game->worms[idx]->controlStates.unpack(input);
+      uint32_t input = post_snap_input_rng() & 0x7f;
+      if ((post_snap_input_rng() % 10) < 6) input |= (1 << 4);
+      if ((post_snap_input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
+      sub.game->worms[idx]->control_states.Unpack(input);
     }
-    sub.game->processFrame();
+    sub.game->ProcessFrame();
     INFO("Mismatch at post-restore frame " << f);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 }
 
@@ -152,35 +152,35 @@ TEST_CASE("Fast snapshot matches cereal oracle across a fuzz run", "[snapshot][r
 
   GameRunner a(kSeed);
   GameRunner b(kSeed);
-  Rand inputRngA(kSeed ^ 0xBEEF), inputRngB(kSeed ^ 0xBEEF);
+  Rand input_rng_a(kSeed ^ 0xBEEF), input_rng_b(kSeed ^ 0xBEEF);
 
-  GameSnapshot fastSnap;
-  fastSnap.prepare(*a.game);
-  std::vector<uint8_t> cerealSnap;
+  GameSnapshot fast_snap;
+  fast_snap.Prepare(*a.game);
+  std::vector<uint8_t> cereal_snap;
 
-  std::size_t snapIdx = 0;
+  std::size_t snap_idx = 0;
   for (int f = 0; f < kTotal; ++f) {
-    a.step(inputRngA);
-    b.step(inputRngB);
-    REQUIRE(hashGameState(*a.game) == hashGameState(*b.game));
+    a.Step(input_rng_a);
+    b.Step(input_rng_b);
+    REQUIRE(HashGameState(*a.game) == HashGameState(*b.game));
 
-    if (snapIdx < std::size(kSnapAt) && f == kSnapAt[snapIdx]) {
-      a.game->saveSnapshotFast(fastSnap);
-      b.game->saveSnapshot(cerealSnap);
+    if (snap_idx < std::size(kSnapAt) && f == kSnapAt[snap_idx]) {
+      a.game->SaveSnapshotFast(fast_snap);
+      b.game->SaveSnapshot(cereal_snap);
 
       // Run ~30 more frames on each so the live state diverges from the
       // snapshot, then restore.
-      Rand mutateA = inputRngA, mutateB = inputRngB;
+      Rand mutate_a = input_rng_a, mutate_b = input_rng_b;
       for (int k = 0; k < 30; ++k) {
-        a.step(mutateA);
-        b.step(mutateB);
+        a.Step(mutate_a);
+        b.Step(mutate_b);
       }
-      a.game->loadSnapshotFast(fastSnap);
-      b.game->loadSnapshot(cerealSnap);
+      a.game->LoadSnapshotFast(fast_snap);
+      b.game->LoadSnapshot(cereal_snap);
 
       INFO("Cereal/fast restore divergence after snapshot at frame " << f);
-      REQUIRE(hashGameState(*a.game) == hashGameState(*b.game));
-      ++snapIdx;
+      REQUIRE(HashGameState(*a.game) == HashGameState(*b.game));
+      ++snap_idx;
     }
   }
 }
@@ -192,25 +192,25 @@ TEST_CASE("Fast snapshot save/restore microbenchmark", "[snapshot][rollback][!be
   using clock = std::chrono::steady_clock;
 
   GameRunner r(0x12345);
-  Rand inputRng(0xABCDEF);
-  for (int f = 0; f < 500; ++f) r.step(inputRng);
+  Rand input_rng(0xABCDEF);
+  for (int f = 0; f < 500; ++f) r.Step(input_rng);
 
   GameSnapshot snap;
-  snap.prepare(*r.game);
+  snap.Prepare(*r.game);
 
   constexpr int kIters = 200;
 
   auto t0 = clock::now();
-  for (int i = 0; i < kIters; ++i) r.game->saveSnapshotFast(snap);
+  for (int i = 0; i < kIters; ++i) r.game->SaveSnapshotFast(snap);
   auto t1 = clock::now();
-  for (int i = 0; i < kIters; ++i) r.game->loadSnapshotFast(snap);
+  for (int i = 0; i < kIters; ++i) r.game->LoadSnapshotFast(snap);
   auto t2 = clock::now();
 
-  double saveUs = std::chrono::duration<double, std::micro>(t1 - t0).count() / kIters;
-  double loadUs = std::chrono::duration<double, std::micro>(t2 - t1).count() / kIters;
+  double save_us = std::chrono::duration<double, std::micro>(t1 - t0).count() / kIters;
+  double load_us = std::chrono::duration<double, std::micro>(t2 - t1).count() / kIters;
 
-  std::cout << "[fast snapshot] save=" << saveUs << " us, load=" << loadUs << " us\n";
+  std::cout << "[fast snapshot] save=" << save_us << " us, load=" << load_us << " us\n";
 
-  REQUIRE(saveUs < 2000.0);
-  REQUIRE(loadUs < 2000.0);
+  REQUIRE(save_us < 2000.0);
+  REQUIRE(load_us < 2000.0);
 }

--- a/src/tests/test_snapshot_roundtrip.cpp
+++ b/src/tests/test_snapshot_roundtrip.cpp
@@ -29,51 +29,51 @@ struct GameRunner {
   std::unique_ptr<Game> game;
 
   GameRunner(uint32_t seed) {
-    precomputeTables();
+    PrecomputeTables();
 
     common = std::make_shared<Common>();
-    FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-    common->load(std::move(tcRoot));
+    FsNode tc_root(FsNode("data") / "TC" / "openliero");
+    common->load(std::move(tc_root));
 
     settings = std::make_shared<Settings>();
     settings->lives = 50;
-    settings->loadingTime = 0;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
     settings->blood = 100;
 
     sp = std::make_shared<NullSoundPlayer>();
     game = std::make_unique<Game>(common, settings, sp);
-    game->rand.seed(seed);
+    game->rand.Seed(seed);
 
     for (int idx = 0; idx < 2; ++idx) {
       auto w = std::make_shared<Worm>();
-      w->settings = settings->wormSettings[idx];
+      w->settings = settings->worm_settings[idx];
       w->health = 25;
       w->index = idx;
-      w->statsX = idx == 0 ? 0 : 218;
-      game->addWorm(w);
+      w->stats_x = idx == 0 ? 0 : 218;
+      game->AddWorm(w);
     }
 
-    game->addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-    game->level.generateFromSettings(*common, *settings, game->rand);
-    for (auto const& w : game->worms) w->initWeapons(*game);
+    game->level.GenerateFromSettings(*common, *settings, game->rand);
+    for (auto const& w : game->worms) w->InitWeapons(*game);
 
     game->paused = false;
-    game->startGame();
-    game->resetWorms();
+    game->StartGame();
+    game->ResetWorms();
   }
 
-  void step(Rand& inputRng) {
+  void Step(Rand& input_rng) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = inputRng() & 0x7f;
-      if ((inputRng() % 10) < 6) input |= (1 << 4);  // fire
-      if ((inputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
-      game->worms[idx]->controlStates.unpack(input);
+      uint32_t input = input_rng() & 0x7f;
+      if ((input_rng() % 10) < 6) input |= (1 << 4);  // fire
+      if ((input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
+      game->worms[idx]->control_states.Unpack(input);
     }
-    game->processFrame();
+    game->ProcessFrame();
   }
 };
 
@@ -84,63 +84,63 @@ TEST_CASE("Snapshot round-trip preserves frame-by-frame state", "[snapshot][roll
   constexpr int kPhase = 200;
 
   // Control: run 3*kPhase frames straight, recording per-frame hashes.
-  std::vector<uint32_t> controlHashes;
-  controlHashes.reserve(3 * kPhase);
+  std::vector<uint32_t> control_hashes;
+  control_hashes.reserve(3 * kPhase);
   {
     GameRunner ctl(kSeed);
-    Rand inputRng(kSeed ^ 0xDEAD);
+    Rand input_rng(kSeed ^ 0xDEAD);
     for (int f = 0; f < 3 * kPhase; ++f) {
-      ctl.step(inputRng);
-      controlHashes.push_back(hashGameState(*ctl.game));
+      ctl.Step(input_rng);
+      control_hashes.push_back(HashGameState(*ctl.game));
     }
   }
 
   // Subject: same seed and inputs, but with a snapshot/restore in the middle.
   GameRunner sub(kSeed);
-  Rand inputRng(kSeed ^ 0xDEAD);
+  Rand input_rng(kSeed ^ 0xDEAD);
 
   // Phase 1: frames [0, kPhase) — verify match against control.
   for (int f = 0; f < kPhase; ++f) {
-    sub.step(inputRng);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    sub.Step(input_rng);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 
   // Snapshot at frame kPhase.
   std::vector<uint8_t> snap;
-  sub.game->saveSnapshot(snap);
-  uint32_t hashAtSnap = hashGameState(*sub.game);
+  sub.game->SaveSnapshot(snap);
+  uint32_t hash_at_snap = HashGameState(*sub.game);
 
   // Phase 2: frames [kPhase, 2*kPhase) — advance, ignore final hash.
   for (int f = kPhase; f < 2 * kPhase; ++f) {
-    sub.step(inputRng);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    sub.Step(input_rng);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 
   // Restore the snapshot — state must match exactly what we saved.
-  sub.game->loadSnapshot(snap);
-  REQUIRE(hashGameState(*sub.game) == hashAtSnap);
+  sub.game->LoadSnapshot(snap);
+  REQUIRE(HashGameState(*sub.game) == hash_at_snap);
 
   // Phase 3: replay phase-2 inputs from the restored state. Rebuild an
   // input PRNG and skip phase-1's draws so it lines up with the control
   // at frame kPhase.
-  Rand postSnapInputRng(kSeed ^ 0xDEAD);
+  Rand post_snap_input_rng(kSeed ^ 0xDEAD);
   for (int f = 0; f < kPhase; ++f) {
     for (int idx = 0; idx < 2; ++idx) {
-      (void)postSnapInputRng();  // input bits
-      (void)postSnapInputRng();  // fire roll
-      (void)postSnapInputRng();  // movement roll
+      (void)post_snap_input_rng();  // input bits
+      (void)post_snap_input_rng();  // fire roll
+      (void)post_snap_input_rng();  // movement roll
     }
   }
   for (int f = kPhase; f < 2 * kPhase; ++f) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = postSnapInputRng() & 0x7f;
-      if ((postSnapInputRng() % 10) < 6) input |= (1 << 4);
-      if ((postSnapInputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
-      sub.game->worms[idx]->controlStates.unpack(input);
+      uint32_t input = post_snap_input_rng() & 0x7f;
+      if ((post_snap_input_rng() % 10) < 6) input |= (1 << 4);
+      if ((post_snap_input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
+      sub.game->worms[idx]->control_states.Unpack(input);
     }
-    sub.game->processFrame();
+    sub.game->ProcessFrame();
     INFO("Mismatch at post-restore frame " << f);
-    REQUIRE(hashGameState(*sub.game) == controlHashes[f]);
+    REQUIRE(HashGameState(*sub.game) == control_hashes[f]);
   }
 }
 
@@ -152,8 +152,8 @@ TEST_CASE("Snapshot save/restore microbenchmark", "[snapshot][rollback][!benchma
   using clock = std::chrono::steady_clock;
 
   GameRunner r(0x12345);
-  Rand inputRng(0xABCDEF);
-  for (int f = 0; f < 500; ++f) r.step(inputRng);
+  Rand input_rng(0xABCDEF);
+  for (int f = 0; f < 500; ++f) r.Step(input_rng);
 
   constexpr int kIters = 50;
   std::vector<uint8_t> snap;
@@ -161,21 +161,21 @@ TEST_CASE("Snapshot save/restore microbenchmark", "[snapshot][rollback][!benchma
   auto t0 = clock::now();
   for (int i = 0; i < kIters; ++i) {
     snap.clear();
-    r.game->saveSnapshot(snap);
+    r.game->SaveSnapshot(snap);
   }
   auto t1 = clock::now();
   for (int i = 0; i < kIters; ++i) {
-    r.game->loadSnapshot(snap);
+    r.game->LoadSnapshot(snap);
   }
   auto t2 = clock::now();
 
-  double saveUs = std::chrono::duration<double, std::micro>(t1 - t0).count() / kIters;
-  double loadUs = std::chrono::duration<double, std::micro>(t2 - t1).count() / kIters;
+  double save_us = std::chrono::duration<double, std::micro>(t1 - t0).count() / kIters;
+  double load_us = std::chrono::duration<double, std::micro>(t2 - t1).count() / kIters;
 
-  std::cout << "[snapshot bench] save=" << saveUs << " us, load=" << loadUs
+  std::cout << "[snapshot bench] save=" << save_us << " us, load=" << load_us
             << " us, size=" << snap.size() << " bytes\n";
 
   // Generous bound: 10 ms.
-  REQUIRE(saveUs < 10000.0);
-  REQUIRE(loadUs < 10000.0);
+  REQUIRE(save_us < 10000.0);
+  REQUIRE(load_us < 10000.0);
 }

--- a/src/tests/test_sound_player.cpp
+++ b/src/tests/test_sound_player.cpp
@@ -11,7 +11,7 @@
 #include "mixer/player.hpp"
 #include "settings.hpp"
 
-static std::string getTcPath() {
+static std::string GetTcPath() {
   if (auto* p = std::getenv("TC_PATH")) return p;
   return "data/TC/openliero";
 }
@@ -19,30 +19,30 @@ static std::string getTcPath() {
 namespace {
 
 struct RecordingPlayer : SoundPlayer {
-  RecordingPlayer() : m_common(nullptr) {}
-  explicit RecordingPlayer(Common& c) : m_common(&c) {}
+  RecordingPlayer() : m_common_(nullptr) {}
+  explicit RecordingPlayer(struct Common& c) : m_common_(&c) {}
 
   std::vector<int> played;
 
-  bool isPlaying(void* /*id*/) override { return false; }
-  void stop(void* /*id*/) override {}
+  bool IsPlaying(void* /*id*/) override { return false; }
+  void Stop(void* /*id*/) override {}
 
  protected:
-  void playImpl(int sound, void* /*id*/, int /*loops*/) override { played.push_back(sound); }
-  Common* common() override { return m_common; }
+  void PlayImpl(int sound, void* /*id*/, int /*loops*/) override { played.push_back(sound); }
+  struct Common* Common() { return m_common_; }
 
  private:
-  Common* m_common;
+  struct Common* m_common_;
 };
 
 }  // namespace
 
 TEST_CASE("SoundPlayer guards negative indices", "[sound_player]") {
   RecordingPlayer p;
-  p.play(-1);
-  p.play(3);
-  p.play(-5);
-  p.play(0);
+  p.Play(-1);
+  p.Play(3);
+  p.Play(-5);
+  p.Play(0);
 
   REQUIRE(p.played.size() == 2);
   REQUIRE(p.played[0] == 3);
@@ -51,41 +51,41 @@ TEST_CASE("SoundPlayer guards negative indices", "[sound_player]") {
 
 TEST_CASE("SoundPlayer SOUND_DEF_T overload resolves via Common::soundHook", "[sound_player]") {
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  common->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  common->load(std::move(tc_root));
 
   RecordingPlayer p(*common);
-  p.play(SoundMenuSelect);
+  p.Play(SoundMenuSelect);
 
   REQUIRE(p.played.size() == 1);
-  REQUIRE(p.played[0] == common->soundHook[SoundMenuSelect]);
-  REQUIRE(p.played[0] == common->soundIndex("select"));
+  REQUIRE(p.played[0] == common->sound_hook[SoundMenuSelect]);
+  REQUIRE(p.played[0] == common->SoundIndex("select"));
 }
 
 TEST_CASE("SoundPlayer SOUND_DEF_T overload is a no-op when common() returns null",
           "[sound_player]") {
   RecordingPlayer p;  // no Common attached
-  p.play(SoundMenuSelect);
+  p.Play(SoundMenuSelect);
   REQUIRE(p.played.empty());
 }
 
 TEST_CASE("Game ctor installs g_soundPlayer and dtor restores it", "[sound_player]") {
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  common->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  common->load(std::move(tc_root));
   auto settings = std::make_shared<Settings>();
 
-  SoundPlayer* originalGlobal = g_soundPlayer;
+  SoundPlayer* original_global = g_sound_player;
   auto sentinel = std::make_shared<NullSoundPlayer>();
-  g_soundPlayer = sentinel.get();
+  g_sound_player = sentinel.get();
 
   {
     auto sp = std::make_shared<RecordingPlayer>(*common);
     Game game(common, settings, sp);
-    REQUIRE(g_soundPlayer == sp.get());
+    REQUIRE(g_sound_player == sp.get());
   }
 
-  REQUIRE(g_soundPlayer == sentinel.get());
+  REQUIRE(g_sound_player == sentinel.get());
 
-  g_soundPlayer = originalGlobal;
+  g_sound_player = original_global;
 }

--- a/src/tests/test_sound_player.cpp
+++ b/src/tests/test_sound_player.cpp
@@ -20,7 +20,7 @@ namespace {
 
 struct RecordingPlayer : SoundPlayer {
   RecordingPlayer() : m_common_(nullptr) {}
-  explicit RecordingPlayer(struct Common& c) : m_common_(&c) {}
+  explicit RecordingPlayer(Common& c) : m_common_(&c) {}
 
   std::vector<int> played;
 
@@ -29,10 +29,10 @@ struct RecordingPlayer : SoundPlayer {
 
  protected:
   void PlayImpl(int sound, void* /*id*/, int /*loops*/) override { played.push_back(sound); }
-  struct Common* Common() { return m_common_; }
+  Common* GetCommonPtr() override { return m_common_; }
 
  private:
-  struct Common* m_common_;
+  Common* m_common_;
 };
 
 }  // namespace

--- a/src/tests/test_speculative_suppression.cpp
+++ b/src/tests/test_speculative_suppression.cpp
@@ -27,19 +27,19 @@ namespace {
 struct CountingSoundPlayer : SoundPlayer {
   int plays = 0;
   int stops = 0;
-  int isPlayingCalls = 0;
+  int is_playing_calls = 0;
 
-  bool isPlaying(void* /*id*/) override {
-    ++isPlayingCalls;
+  bool IsPlaying(void* /*id*/) override {
+    ++is_playing_calls;
     return false;
   }
-  void stop(void* /*id*/) override {
+  void Stop(void* /*id*/) override {
     if (speculative) return;
     ++stops;
   }
 
  protected:
-  void playImpl(int /*sound*/, void* /*id*/, int /*loops*/) override { ++plays; }
+  void PlayImpl(int /*sound*/, void* /*id*/, int /*loops*/) override { ++plays; }
 };
 
 struct CountingStatsRecorder : StatsRecorder {
@@ -50,16 +50,16 @@ struct CountingStatsRecorder : StatsRecorder {
     if (speculative) return; \
     ++events;                \
   } while (0)
-  void damagePotential(Worm*, WormWeapon*, int) override { EVT(); }
-  void damageDealt(Worm*, WormWeapon*, Worm*, int, bool) override { EVT(); }
-  void shot(Worm*, WormWeapon*) override { EVT(); }
-  void hit(Worm*, WormWeapon*, Worm*) override { EVT(); }
-  void afterSpawn(Worm*) override { EVT(); }
-  void afterDeath(Worm*) override { EVT(); }
-  void preTick(Game&) override { EVT(); }
-  void tick(Game&) override { EVT(); }
-  void finish(Game&) override { EVT(); }
-  void aiProcessTime(Worm*, std::chrono::nanoseconds) override { EVT(); }
+  void DamagePotential(Worm*, WormWeapon*, int) override { EVT(); }
+  void DamageDealt(Worm*, WormWeapon*, Worm*, int, bool) override { EVT(); }
+  void Shot(Worm*, WormWeapon*) override { EVT(); }
+  void Hit(Worm*, WormWeapon*, Worm*) override { EVT(); }
+  void AfterSpawn(Worm*) override { EVT(); }
+  void AfterDeath(Worm*) override { EVT(); }
+  void PreTick(Game&) override { EVT(); }
+  void Tick(Game&) override { EVT(); }
+  void Finish(Game&) override { EVT(); }
+  void AiProcessTime(Worm*, std::chrono::nanoseconds) override { EVT(); }
 #undef EVT
 };
 
@@ -70,54 +70,54 @@ struct Runner {
   std::unique_ptr<Game> game;
 
   Runner(uint32_t seed) {
-    precomputeTables();
+    PrecomputeTables();
     common = std::make_shared<Common>();
-    FsNode tcRoot(FsNode("data") / "TC" / "openliero");
-    common->load(std::move(tcRoot));
+    FsNode tc_root(FsNode("data") / "TC" / "openliero");
+    common->load(std::move(tc_root));
 
     settings = std::make_shared<Settings>();
     settings->lives = 50;
-    settings->loadingTime = 0;
-    settings->randomLevel = true;
-    settings->gameMode = Settings::GMKillEmAll;
+    settings->loading_time = 0;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
     settings->blood = 100;
 
     sp = std::make_shared<CountingSoundPlayer>();
     game = std::make_unique<Game>(common, settings, sp);
-    game->statsRecorder.reset(new CountingStatsRecorder);
-    game->rand.seed(seed);
+    game->stats_recorder.reset(new CountingStatsRecorder);
+    game->rand.Seed(seed);
 
     for (int idx = 0; idx < 2; ++idx) {
       auto w = std::make_shared<Worm>();
-      w->settings = settings->wormSettings[idx];
+      w->settings = settings->worm_settings[idx];
       w->health = 25;
       w->index = idx;
-      w->statsX = idx == 0 ? 0 : 218;
-      game->addWorm(w);
+      w->stats_x = idx == 0 ? 0 : 218;
+      game->AddWorm(w);
     }
-    game->addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-    game->level.generateFromSettings(*common, *settings, game->rand);
-    for (auto const& w : game->worms) w->initWeapons(*game);
+    game->level.GenerateFromSettings(*common, *settings, game->rand);
+    for (auto const& w : game->worms) w->InitWeapons(*game);
 
     game->paused = false;
-    game->startGame();
-    game->resetWorms();
+    game->StartGame();
+    game->ResetWorms();
   }
 
-  void step(Rand& inputRng) {
+  void Step(Rand& input_rng) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = inputRng() & 0x7f;
-      if ((inputRng() % 10) < 6) input |= (1 << 4);
-      if ((inputRng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
-      game->worms[idx]->controlStates.unpack(input);
+      uint32_t input = input_rng() & 0x7f;
+      if ((input_rng() % 10) < 6) input |= (1 << 4);
+      if ((input_rng() % 10) < 4) input |= (1 << (idx == 0 ? 1 : 0));
+      game->worms[idx]->control_states.Unpack(input);
     }
-    game->processFrame();
+    game->ProcessFrame();
   }
 
-  CountingStatsRecorder& stats() {
-    return static_cast<CountingStatsRecorder&>(*game->statsRecorder);
+  CountingStatsRecorder& Stats() {
+    return static_cast<CountingStatsRecorder&>(*game->stats_recorder);
   }
 };
 
@@ -129,67 +129,67 @@ TEST_CASE("Speculative frames suppress sound and stats", "[rollback]") {
 
   // Control: 2 * kPhase frames with no speculation.
   Runner ctl(kSeed);
-  Rand ctlInputs(kSeed ^ 0xDEAD);
-  for (int f = 0; f < 2 * kPhase; ++f) ctl.step(ctlInputs);
-  int controlPlays = ctl.sp->plays;
-  int controlStops = ctl.sp->stops;
-  int controlEvents = ctl.stats().events;
+  Rand ctl_inputs(kSeed ^ 0xDEAD);
+  for (int f = 0; f < 2 * kPhase; ++f) ctl.Step(ctl_inputs);
+  int control_plays = ctl.sp->plays;
+  int control_stops = ctl.sp->stops;
+  int control_events = ctl.Stats().events;
 
   // Subject: run kPhase normally, save snapshot, run kPhase speculatively,
   // restore, run kPhase more normally. Final counts must match the control.
   Runner sub(kSeed);
-  Rand subInputs(kSeed ^ 0xDEAD);
+  Rand sub_inputs(kSeed ^ 0xDEAD);
 
   GameSnapshot snap;
-  snap.prepare(*sub.game);
+  snap.Prepare(*sub.game);
 
-  for (int f = 0; f < kPhase; ++f) sub.step(subInputs);
-  int playsAtSnap = sub.sp->plays;
-  int stopsAtSnap = sub.sp->stops;
-  int eventsAtSnap = sub.stats().events;
+  for (int f = 0; f < kPhase; ++f) sub.Step(sub_inputs);
+  int plays_at_snap = sub.sp->plays;
+  int stops_at_snap = sub.sp->stops;
+  int events_at_snap = sub.Stats().events;
 
-  sub.game->saveSnapshotFast(snap);
-  sub.game->setSpeculative(true);
+  sub.game->SaveSnapshotFast(snap);
+  sub.game->SetSpeculative(true);
 
   // Speculative run uses the *same* inputs the post-restore segment will
   // use, so the underlying sim work is comparable. Counters must not move.
-  Rand specInputs = subInputs;
-  for (int f = 0; f < kPhase; ++f) sub.step(specInputs);
+  Rand spec_inputs = sub_inputs;
+  for (int f = 0; f < kPhase; ++f) sub.Step(spec_inputs);
 
-  REQUIRE(sub.sp->plays == playsAtSnap);
-  REQUIRE(sub.sp->stops == stopsAtSnap);
-  REQUIRE(sub.stats().events == eventsAtSnap);
+  REQUIRE(sub.sp->plays == plays_at_snap);
+  REQUIRE(sub.sp->stops == stops_at_snap);
+  REQUIRE(sub.Stats().events == events_at_snap);
 
   // isPlaying should have been called at least once and always passes
   // through — its count is allowed to grow during speculation.
-  int isPlayingDuringSpec = sub.sp->isPlayingCalls;
+  int is_playing_during_spec = sub.sp->is_playing_calls;
 
-  sub.game->loadSnapshotFast(snap);
-  sub.game->setSpeculative(false);
+  sub.game->LoadSnapshotFast(snap);
+  sub.game->SetSpeculative(false);
 
-  for (int f = 0; f < kPhase; ++f) sub.step(subInputs);
+  for (int f = 0; f < kPhase; ++f) sub.Step(sub_inputs);
 
-  REQUIRE(sub.sp->plays == controlPlays);
-  REQUIRE(sub.sp->stops == controlStops);
-  REQUIRE(sub.stats().events == controlEvents);
+  REQUIRE(sub.sp->plays == control_plays);
+  REQUIRE(sub.sp->stops == control_stops);
+  REQUIRE(sub.Stats().events == control_events);
 
   // Sanity: isPlaying did pass through during speculation (not gated).
-  REQUIRE(sub.sp->isPlayingCalls >= isPlayingDuringSpec);
+  REQUIRE(sub.sp->is_playing_calls >= is_playing_during_spec);
 }
 
 TEST_CASE("setSpeculative propagates to soundPlayer and statsRecorder", "[rollback]") {
   Runner r(0x1234);
   REQUIRE(r.game->speculative == false);
-  REQUIRE(r.game->soundPlayer->speculative == false);
-  REQUIRE(r.game->statsRecorder->speculative == false);
+  REQUIRE(r.game->sound_player->speculative == false);
+  REQUIRE(r.game->stats_recorder->speculative == false);
 
-  r.game->setSpeculative(true);
+  r.game->SetSpeculative(true);
   REQUIRE(r.game->speculative == true);
-  REQUIRE(r.game->soundPlayer->speculative == true);
-  REQUIRE(r.game->statsRecorder->speculative == true);
+  REQUIRE(r.game->sound_player->speculative == true);
+  REQUIRE(r.game->stats_recorder->speculative == true);
 
-  r.game->setSpeculative(false);
+  r.game->SetSpeculative(false);
   REQUIRE(r.game->speculative == false);
-  REQUIRE(r.game->soundPlayer->speculative == false);
-  REQUIRE(r.game->statsRecorder->speculative == false);
+  REQUIRE(r.game->sound_player->speculative == false);
+  REQUIRE(r.game->stats_recorder->speculative == false);
 }

--- a/src/tests/test_stun.cpp
+++ b/src/tests/test_stun.cpp
@@ -14,16 +14,16 @@
 #include "net/stun.hpp"
 
 // Helper to build a STUN Binding Response with XOR-MAPPED-ADDRESS (IPv4)
-static std::vector<uint8_t> buildIPv4Response(const stun::Header& req, const char* ip,
+static std::vector<uint8_t> BuildIPv4Response(const stun::Header& req, const char* ip,
                                               uint16_t port) {
   // Parse IP into network-order bytes
-  uint32_t ipNet;
-  inet_pton(AF_INET, ip, &ipNet);
-  uint32_t ipHost = ntohl(ipNet);
+  uint32_t ip_net;
+  inet_pton(AF_INET, ip, &ip_net);
+  uint32_t ip_host = ntohl(ip_net);
 
   // XOR the address and port
-  uint32_t xorAddr = htonl(ipHost ^ stun::MAGIC_COOKIE);
-  uint16_t xorPort = port ^ (uint16_t)(stun::MAGIC_COOKIE >> 16);
+  uint32_t xor_addr = htonl(ip_host ^ stun::kMagicCookie);
+  uint16_t xor_port = port ^ (uint16_t)(stun::kMagicCookie >> 16);
 
   // Build response
   std::vector<uint8_t> pkt;
@@ -38,36 +38,36 @@ static std::vector<uint8_t> buildIPv4Response(const stun::Header& req, const cha
   attr[3] = 0x08;  // length = 8
   attr[4] = 0x00;  // reserved
   attr[5] = 0x01;  // family = IPv4
-  attr[6] = (uint8_t)(xorPort >> 8);
-  attr[7] = (uint8_t)(xorPort & 0xFF);
-  std::memcpy(attr + 8, &xorAddr, 4);
+  attr[6] = (uint8_t)(xor_port >> 8);
+  attr[7] = (uint8_t)(xor_port & 0xFF);
+  std::memcpy(attr + 8, &xor_addr, 4);
 
   pkt.insert(pkt.end(), attr, attr + 12);
 
   // Fill header
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(12);  // attribute total length
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
   return pkt;
 }
 
 // Helper to build a STUN Binding Response with XOR-MAPPED-ADDRESS (IPv6)
-static std::vector<uint8_t> buildIPv6Response(const stun::Header& req, const char* ip,
+static std::vector<uint8_t> BuildIPv6Response(const stun::Header& req, const char* ip,
                                               uint16_t port) {
-  uint8_t ipBytes[16];
-  inet_pton(AF_INET6, ip, ipBytes);
+  uint8_t ip_bytes[16];
+  inet_pton(AF_INET6, ip, ip_bytes);
 
   // XOR with magic cookie (4 bytes) + transaction ID (12 bytes)
-  uint32_t cookie = htonl(stun::MAGIC_COOKIE);
-  uint8_t xorAddr[16];
-  std::memcpy(xorAddr, ipBytes, 16);
-  for (int i = 0; i < 4; i++) xorAddr[i] ^= ((uint8_t*)&cookie)[i];
-  for (int i = 0; i < 12; i++) xorAddr[4 + i] ^= req.transactionId[i];
+  uint32_t cookie = htonl(stun::kMagicCookie);
+  uint8_t xor_addr[16];
+  std::memcpy(xor_addr, ip_bytes, 16);
+  for (int i = 0; i < 4; i++) xor_addr[i] ^= ((uint8_t*)&cookie)[i];
+  for (int i = 0; i < 12; i++) xor_addr[4 + i] ^= req.transaction_id[i];
 
-  uint16_t xorPort = port ^ (uint16_t)(stun::MAGIC_COOKIE >> 16);
+  uint16_t xor_port = port ^ (uint16_t)(stun::kMagicCookie >> 16);
 
   // Build response
   std::vector<uint8_t> pkt;
@@ -82,27 +82,27 @@ static std::vector<uint8_t> buildIPv6Response(const stun::Header& req, const cha
   attr[3] = 20;    // length = 20
   attr[4] = 0x00;  // reserved
   attr[5] = 0x02;  // family = IPv6
-  attr[6] = (uint8_t)(xorPort >> 8);
-  attr[7] = (uint8_t)(xorPort & 0xFF);
-  std::memcpy(attr + 8, xorAddr, 16);
+  attr[6] = (uint8_t)(xor_port >> 8);
+  attr[7] = (uint8_t)(xor_port & 0xFF);
+  std::memcpy(attr + 8, xor_addr, 16);
 
   pkt.insert(pkt.end(), attr, attr + 24);
 
   // Fill header
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(24);
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
   return pkt;
 }
 
 // Helper to build a STUN Binding Response with MAPPED-ADDRESS (non-XOR, fallback)
-static std::vector<uint8_t> buildMappedAddressResponse(const stun::Header& req, const char* ip,
+static std::vector<uint8_t> BuildMappedAddressResponse(const stun::Header& req, const char* ip,
                                                        uint16_t port) {
-  uint32_t ipNet;
-  inet_pton(AF_INET, ip, &ipNet);
+  uint32_t ip_net;
+  inet_pton(AF_INET, ip, &ip_net);
 
   std::vector<uint8_t> pkt;
   pkt.resize(sizeof(stun::Header));
@@ -117,104 +117,104 @@ static std::vector<uint8_t> buildMappedAddressResponse(const stun::Header& req, 
   attr[5] = 0x01;  // family = IPv4
   attr[6] = (uint8_t)(port >> 8);
   attr[7] = (uint8_t)(port & 0xFF);
-  std::memcpy(attr + 8, &ipNet, 4);  // network byte order
+  std::memcpy(attr + 8, &ip_net, 4);  // network byte order
 
   pkt.insert(pkt.end(), attr, attr + 12);
 
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(12);
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
   return pkt;
 }
 
-static stun::Header makeRequest() {
+static stun::Header MakeRequest() {
   stun::Header req = {};
-  req.type = htons(stun::BINDING_REQUEST);
+  req.type = htons(stun::kBindingRequest);
   req.length = 0;
-  req.magicCookie = htonl(stun::MAGIC_COOKIE);
+  req.magic_cookie = htonl(stun::kMagicCookie);
   // Use a known transaction ID for reproducibility
-  for (int i = 0; i < 12; i++) req.transactionId[i] = (uint8_t)(0x10 + i);
+  for (int i = 0; i < 12; i++) req.transaction_id[i] = (uint8_t)(0x10 + i);
   return req;
 }
 
 TEST_CASE("parseResponse extracts IPv4 XOR-MAPPED-ADDRESS", "[stun]") {
-  auto req = makeRequest();
-  auto pkt = buildIPv4Response(req, "203.0.113.42", 54321);
+  auto req = MakeRequest();
+  auto pkt = BuildIPv4Response(req, "203.0.113.42", 54321);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip == "203.0.113.42");
   REQUIRE(result.port == 54321);
 }
 
 TEST_CASE("parseResponse extracts IPv6 XOR-MAPPED-ADDRESS", "[stun]") {
-  auto req = makeRequest();
-  auto pkt = buildIPv6Response(req, "2001:db8::1", 12345);
+  auto req = MakeRequest();
+  auto pkt = BuildIPv6Response(req, "2001:db8::1", 12345);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip == "2001:db8::1");
   REQUIRE(result.port == 12345);
 }
 
 TEST_CASE("parseResponse falls back to MAPPED-ADDRESS", "[stun]") {
-  auto req = makeRequest();
-  auto pkt = buildMappedAddressResponse(req, "198.51.100.7", 9999);
+  auto req = MakeRequest();
+  auto pkt = BuildMappedAddressResponse(req, "198.51.100.7", 9999);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip == "198.51.100.7");
   REQUIRE(result.port == 9999);
 }
 
 TEST_CASE("parseResponse prefers XOR-MAPPED-ADDRESS over MAPPED-ADDRESS", "[stun]") {
-  auto req = makeRequest();
+  auto req = MakeRequest();
 
   // Build a response with MAPPED-ADDRESS first, then XOR-MAPPED-ADDRESS
   std::vector<uint8_t> pkt;
   pkt.resize(sizeof(stun::Header));
 
   // MAPPED-ADDRESS with wrong IP (should be ignored if XOR-MAPPED follows)
-  uint8_t mappedAttr[12] = {};
-  mappedAttr[0] = 0x00;
-  mappedAttr[1] = 0x01;  // MAPPED-ADDRESS
-  mappedAttr[2] = 0x00;
-  mappedAttr[3] = 0x08;
-  mappedAttr[4] = 0x00;
-  mappedAttr[5] = 0x01;  // IPv4
-  mappedAttr[6] = 0x00;
-  mappedAttr[7] = 0x50;  // port 80
-  uint32_t wrongIP;
-  inet_pton(AF_INET, "10.0.0.1", &wrongIP);
-  std::memcpy(mappedAttr + 8, &wrongIP, 4);
-  pkt.insert(pkt.end(), mappedAttr, mappedAttr + 12);
+  uint8_t mapped_attr[12] = {};
+  mapped_attr[0] = 0x00;
+  mapped_attr[1] = 0x01;  // MAPPED-ADDRESS
+  mapped_attr[2] = 0x00;
+  mapped_attr[3] = 0x08;
+  mapped_attr[4] = 0x00;
+  mapped_attr[5] = 0x01;  // IPv4
+  mapped_attr[6] = 0x00;
+  mapped_attr[7] = 0x50;  // port 80
+  uint32_t wrong_ip;
+  inet_pton(AF_INET, "10.0.0.1", &wrong_ip);
+  std::memcpy(mapped_attr + 8, &wrong_ip, 4);
+  pkt.insert(pkt.end(), mapped_attr, mapped_attr + 12);
 
   // XOR-MAPPED-ADDRESS with correct IP
-  uint32_t ipNet;
-  inet_pton(AF_INET, "203.0.113.42", &ipNet);
-  uint32_t ipHost = ntohl(ipNet);
-  uint32_t xorAddr = htonl(ipHost ^ stun::MAGIC_COOKIE);
-  uint16_t xorPort = 54321 ^ (uint16_t)(stun::MAGIC_COOKIE >> 16);
+  uint32_t ip_net;
+  inet_pton(AF_INET, "203.0.113.42", &ip_net);
+  uint32_t ip_host = ntohl(ip_net);
+  uint32_t xor_addr = htonl(ip_host ^ stun::kMagicCookie);
+  uint16_t xor_port = 54321 ^ (uint16_t)(stun::kMagicCookie >> 16);
 
-  uint8_t xorAttr[12] = {};
-  xorAttr[0] = 0x00;
-  xorAttr[1] = 0x20;  // XOR-MAPPED-ADDRESS
-  xorAttr[2] = 0x00;
-  xorAttr[3] = 0x08;
-  xorAttr[4] = 0x00;
-  xorAttr[5] = 0x01;  // IPv4
-  xorAttr[6] = (uint8_t)(xorPort >> 8);
-  xorAttr[7] = (uint8_t)(xorPort & 0xFF);
-  std::memcpy(xorAttr + 8, &xorAddr, 4);
-  pkt.insert(pkt.end(), xorAttr, xorAttr + 12);
+  uint8_t xor_attr[12] = {};
+  xor_attr[0] = 0x00;
+  xor_attr[1] = 0x20;  // XOR-MAPPED-ADDRESS
+  xor_attr[2] = 0x00;
+  xor_attr[3] = 0x08;
+  xor_attr[4] = 0x00;
+  xor_attr[5] = 0x01;  // IPv4
+  xor_attr[6] = (uint8_t)(xor_port >> 8);
+  xor_attr[7] = (uint8_t)(xor_port & 0xFF);
+  std::memcpy(xor_attr + 8, &xor_addr, 4);
+  pkt.insert(pkt.end(), xor_attr, xor_attr + 12);
 
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(24);  // 12 + 12
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
 
   // RFC 5389: XOR-MAPPED-ADDRESS is preferred over MAPPED-ADDRESS.
   // Even though MAPPED-ADDRESS comes first, we should get the XOR result.
@@ -223,114 +223,114 @@ TEST_CASE("parseResponse prefers XOR-MAPPED-ADDRESS over MAPPED-ADDRESS", "[stun
 }
 
 TEST_CASE("parseResponse rejects wrong transaction ID", "[stun]") {
-  auto req = makeRequest();
-  auto pkt = buildIPv4Response(req, "203.0.113.42", 54321);
+  auto req = MakeRequest();
+  auto pkt = BuildIPv4Response(req, "203.0.113.42", 54321);
 
   // Corrupt the transaction ID in the request we pass to parseResponse
-  stun::Header wrongReq = req;
-  wrongReq.transactionId[0] = 0xFF;
+  stun::Header wrong_req = req;
+  wrong_req.transaction_id[0] = 0xFF;
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), wrongReq);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), wrong_req);
   REQUIRE(result.ip.empty());
   REQUIRE(result.port == 0);
 }
 
 TEST_CASE("parseResponse rejects non-binding-response", "[stun]") {
-  auto req = makeRequest();
-  auto pkt = buildIPv4Response(req, "203.0.113.42", 54321);
+  auto req = MakeRequest();
+  auto pkt = BuildIPv4Response(req, "203.0.113.42", 54321);
 
   // Change type to something else
   auto* hdr = (stun::Header*)pkt.data();
   hdr->type = htons(0x0111);  // Binding Error Response
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip.empty());
 }
 
 TEST_CASE("parseResponse rejects truncated packet", "[stun]") {
-  auto req = makeRequest();
+  auto req = MakeRequest();
 
   // Too short — less than header size
   uint8_t tiny[10] = {};
-  auto result = stun::parseResponse(tiny, sizeof(tiny), req);
+  auto result = stun::ParseResponse(tiny, sizeof(tiny), req);
   REQUIRE(result.ip.empty());
 }
 
 TEST_CASE("parseResponse handles empty attributes", "[stun]") {
-  auto req = makeRequest();
+  auto req = MakeRequest();
 
   // Valid header but no attributes
   std::vector<uint8_t> pkt(sizeof(stun::Header));
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(0);
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip.empty());
   REQUIRE(result.port == 0);
 }
 
 TEST_CASE("parseResponse handles padded attributes", "[stun]") {
-  auto req = makeRequest();
+  auto req = MakeRequest();
 
   // Build a response with a 5-byte unknown attribute (padded to 8) followed by XOR-MAPPED-ADDRESS
   std::vector<uint8_t> pkt;
   pkt.resize(sizeof(stun::Header));
 
   // Unknown attribute: type=0x8000, length=5 (padded to 8 bytes)
-  uint8_t unknownAttr[4 + 8] = {};  // 4 header + 8 padded data
-  unknownAttr[0] = 0x80;
-  unknownAttr[1] = 0x00;  // unknown type
-  unknownAttr[2] = 0x00;
-  unknownAttr[3] = 0x05;  // length = 5
+  uint8_t unknown_attr[4 + 8] = {};  // 4 header + 8 padded data
+  unknown_attr[0] = 0x80;
+  unknown_attr[1] = 0x00;  // unknown type
+  unknown_attr[2] = 0x00;
+  unknown_attr[3] = 0x05;  // length = 5
   // 5 bytes data + 3 bytes padding = 8 bytes
-  pkt.insert(pkt.end(), unknownAttr, unknownAttr + 12);
+  pkt.insert(pkt.end(), unknown_attr, unknown_attr + 12);
 
   // XOR-MAPPED-ADDRESS
-  uint32_t ipNet;
-  inet_pton(AF_INET, "192.0.2.1", &ipNet);
-  uint32_t ipHost = ntohl(ipNet);
-  uint32_t xorAddr = htonl(ipHost ^ stun::MAGIC_COOKIE);
-  uint16_t xorPort = 8080 ^ (uint16_t)(stun::MAGIC_COOKIE >> 16);
+  uint32_t ip_net;
+  inet_pton(AF_INET, "192.0.2.1", &ip_net);
+  uint32_t ip_host = ntohl(ip_net);
+  uint32_t xor_addr = htonl(ip_host ^ stun::kMagicCookie);
+  uint16_t xor_port = 8080 ^ (uint16_t)(stun::kMagicCookie >> 16);
 
-  uint8_t xorAttr[12] = {};
-  xorAttr[0] = 0x00;
-  xorAttr[1] = 0x20;
-  xorAttr[2] = 0x00;
-  xorAttr[3] = 0x08;
-  xorAttr[4] = 0x00;
-  xorAttr[5] = 0x01;
-  xorAttr[6] = (uint8_t)(xorPort >> 8);
-  xorAttr[7] = (uint8_t)(xorPort & 0xFF);
-  std::memcpy(xorAttr + 8, &xorAddr, 4);
-  pkt.insert(pkt.end(), xorAttr, xorAttr + 12);
+  uint8_t xor_attr[12] = {};
+  xor_attr[0] = 0x00;
+  xor_attr[1] = 0x20;
+  xor_attr[2] = 0x00;
+  xor_attr[3] = 0x08;
+  xor_attr[4] = 0x00;
+  xor_attr[5] = 0x01;
+  xor_attr[6] = (uint8_t)(xor_port >> 8);
+  xor_attr[7] = (uint8_t)(xor_port & 0xFF);
+  std::memcpy(xor_attr + 8, &xor_addr, 4);
+  pkt.insert(pkt.end(), xor_attr, xor_attr + 12);
 
   auto* hdr = (stun::Header*)pkt.data();
-  hdr->type = htons(stun::BINDING_RESPONSE);
+  hdr->type = htons(stun::kBindingResponse);
   hdr->length = htons(24);  // 12 (unknown padded) + 12 (xor-mapped)
-  hdr->magicCookie = htonl(stun::MAGIC_COOKIE);
-  std::memcpy(hdr->transactionId, req.transactionId, 12);
+  hdr->magic_cookie = htonl(stun::kMagicCookie);
+  std::memcpy(hdr->transaction_id, req.transaction_id, 12);
 
-  auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+  auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
   REQUIRE(result.ip == "192.0.2.1");
   REQUIRE(result.port == 8080);
 }
 
 TEST_CASE("parseResponse handles port 0 and port 65535", "[stun]") {
-  auto req = makeRequest();
+  auto req = MakeRequest();
 
   SECTION("port 0") {
-    auto pkt = buildIPv4Response(req, "10.0.0.1", 0);
-    auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+    auto pkt = BuildIPv4Response(req, "10.0.0.1", 0);
+    auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
     REQUIRE(result.ip == "10.0.0.1");
     REQUIRE(result.port == 0);
   }
 
   SECTION("port 65535") {
-    auto pkt = buildIPv4Response(req, "10.0.0.1", 65535);
-    auto result = stun::parseResponse(pkt.data(), pkt.size(), req);
+    auto pkt = BuildIPv4Response(req, "10.0.0.1", 65535);
+    auto result = stun::ParseResponse(pkt.data(), pkt.size(), req);
     REQUIRE(result.ip == "10.0.0.1");
     REQUIRE(result.port == 65535);
   }
@@ -340,20 +340,20 @@ TEST_CASE("StunQuery completes with done flag", "[stun][integration]") {
   // This test requires network access to Google's STUN server.
   // It will gracefully fail (empty results) if network is unavailable.
   StunQuery query;
-  query.start();
+  query.Start();
 
   // Wait up to 6 seconds for completion
-  for (int i = 0; i < 60 && !query.done(); i++)
+  for (int i = 0; i < 60 && !query.Done(); i++)
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  REQUIRE(query.done());
+  REQUIRE(query.Done());
 
-  auto result = query.result();
+  auto result = query.Result();
   // We can't guarantee STUN succeeds in all test environments,
   // but the query must complete without crashing.
   // If network is available, we should get at least an IPv4 result.
   if (!result.ipv4.empty()) {
-    REQUIRE(result.ipv4Port != 0);
+    REQUIRE(result.ipv4_port != 0);
     // Sanity check: IP should have dots
     REQUIRE(result.ipv4.find('.') != std::string::npos);
   }

--- a/src/tests/test_tc_load.cpp
+++ b/src/tests/test_tc_load.cpp
@@ -51,13 +51,13 @@ TEST_CASE("TC loads without errors", "[tc_load]") {
   REQUIRE(common->SoundIndex("does_not_exist") == -1);
 
   // [sounds] hooks resolve via the loaded sound table.
-  REQUIRE(common->soundHook[SoundMenuSelect] == common->SoundIndex("select"));
-  REQUIRE(common->soundHook[SoundMenuMoveUp] == common->SoundIndex("moveup"));
-  REQUIRE(common->soundHook[SoundMenuMoveDown] == common->SoundIndex("movedown"));
-  REQUIRE(common->soundHook[SoundBump] == common->SoundIndex("bump"));
-  REQUIRE(common->soundHook[SoundBegin] == common->SoundIndex("begin"));
-  REQUIRE(common->soundHook[SoundReloaded] == common->SoundIndex("reloaded"));
-  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(common->soundHook[i] >= 0);
+  REQUIRE(common->sound_hook[SoundMenuSelect] == common->SoundIndex("select"));
+  REQUIRE(common->sound_hook[SoundMenuMoveUp] == common->SoundIndex("moveup"));
+  REQUIRE(common->sound_hook[SoundMenuMoveDown] == common->SoundIndex("movedown"));
+  REQUIRE(common->sound_hook[SoundBump] == common->SoundIndex("bump"));
+  REQUIRE(common->sound_hook[SoundBegin] == common->SoundIndex("begin"));
+  REQUIRE(common->sound_hook[SoundReloaded] == common->SoundIndex("reloaded"));
+  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(common->sound_hook[i] >= 0);
 
   // Step 5: sound fields in weapon / sobject configs are now name-typed.
   // Anchor a couple of known values so regressions in soundRefFromStr
@@ -141,7 +141,7 @@ TEST_CASE("tc.cfg [sounds] round-trips through save/load", "[tc_load]") {
   // populated from [types].sounds, which loadTcConfig does first.
   LoadTcConfig(dst, ss);
 
-  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(dst.soundHook[i] == src->soundHook[i]);
+  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(dst.sound_hook[i] == src->sound_hook[i]);
 }
 
 TEST_CASE("[sounds] unknown name resolves to -1", "[tc_load]") {
@@ -162,10 +162,10 @@ TEST_CASE("[sounds] unknown name resolves to -1", "[tc_load]") {
   std::stringstream ss(cfg);
   Common c;
   LoadTcConfig(c, ss);
-  REQUIRE(c.soundHook[SoundMenuSelect] == -1);
-  REQUIRE(c.soundHook[SoundMenuMoveUp] == c.SoundIndex("alpha"));
+  REQUIRE(c.sound_hook[SoundMenuSelect] == -1);
+  REQUIRE(c.sound_hook[SoundMenuMoveUp] == c.SoundIndex("alpha"));
   // Unset entries default to -1.
-  REQUIRE(c.soundHook[SoundBump] == -1);
+  REQUIRE(c.sound_hook[SoundBump] == -1);
 }
 
 // Regression for issue #44: a TC whose [types].sounds lists a sound whose

--- a/src/tests/test_tc_load.cpp
+++ b/src/tests/test_tc_load.cpp
@@ -16,105 +16,105 @@
 #include "worm.hpp"
 
 // TC path can be overridden via TC_PATH env var (default: data/TC/openliero)
-static std::string getTcPath() {
+static std::string GetTcPath() {
   if (auto* p = std::getenv("TC_PATH")) return p;
   return "data/TC/openliero";
 }
 
 TEST_CASE("TC loads without errors", "[tc_load]") {
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
+  FsNode tc_root(GetTcPath());
 
-  REQUIRE_NOTHROW(common->load(std::move(tcRoot)));
+  REQUIRE_NOTHROW(common->load(std::move(tc_root)));
 
   // Basic sanity checks on loaded data
   REQUIRE(common->weapons.size() > 0);
-  REQUIRE(common->nobjectTypes.size() > 0);
-  REQUIRE(common->sobjectTypes.size() > 0);
-  REQUIRE(common->weapOrder.size() == common->weapons.size());
+  REQUIRE(common->nobject_types.size() > 0);
+  REQUIRE(common->sobject_types.size() > 0);
+  REQUIRE(common->weap_order.size() == common->weapons.size());
 
   // Strings from tc.cfg should arrive as UTF-8. The Copyright string contains
   // 'ä' (U+00E4) which is two bytes in UTF-8 (0xC3 0xA4); historically tc.cfg
   // stored these as  (a control char), which the parser then yielded as
   // 0xC2 0x84 — neither of which decode to 'ä'. Anchor that here.
-  std::string const& copy2 = common->S[SCopyright2];
+  std::string const& copy2 = common->s[SCopyright2];
   REQUIRE(copy2.find("Liero v1.33") == 0);
   REQUIRE(copy2.find("\xC3\xA4") != std::string::npos);  // 'ä' UTF-8
   REQUIRE(copy2.find("\xC2\x84") == std::string::npos);  // bogus old form
-  REQUIRE(common->guessName() == "Liero v1.33");
+  REQUIRE(common->GuessName() == "Liero v1.33");
 
   // Sound name lookup: known names resolve to a valid index that
   // round-trips back to the same name, unknown names yield -1.
-  int selectIdx = common->soundIndex("select");
-  REQUIRE(selectIdx >= 0);
-  REQUIRE(common->sounds[selectIdx].name == "select");
-  REQUIRE(common->soundIndex("does_not_exist") == -1);
+  int select_idx = common->SoundIndex("select");
+  REQUIRE(select_idx >= 0);
+  REQUIRE(common->sounds[select_idx].name == "select");
+  REQUIRE(common->SoundIndex("does_not_exist") == -1);
 
   // [sounds] hooks resolve via the loaded sound table.
-  REQUIRE(common->soundHook[SoundMenuSelect] == common->soundIndex("select"));
-  REQUIRE(common->soundHook[SoundMenuMoveUp] == common->soundIndex("moveup"));
-  REQUIRE(common->soundHook[SoundMenuMoveDown] == common->soundIndex("movedown"));
-  REQUIRE(common->soundHook[SoundBump] == common->soundIndex("bump"));
-  REQUIRE(common->soundHook[SoundBegin] == common->soundIndex("begin"));
-  REQUIRE(common->soundHook[SoundReloaded] == common->soundIndex("reloaded"));
-  for (int i = 0; i < SOUND_DEF_T::MaxSound; ++i) REQUIRE(common->soundHook[i] >= 0);
+  REQUIRE(common->soundHook[SoundMenuSelect] == common->SoundIndex("select"));
+  REQUIRE(common->soundHook[SoundMenuMoveUp] == common->SoundIndex("moveup"));
+  REQUIRE(common->soundHook[SoundMenuMoveDown] == common->SoundIndex("movedown"));
+  REQUIRE(common->soundHook[SoundBump] == common->SoundIndex("bump"));
+  REQUIRE(common->soundHook[SoundBegin] == common->SoundIndex("begin"));
+  REQUIRE(common->soundHook[SoundReloaded] == common->SoundIndex("reloaded"));
+  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(common->soundHook[i] >= 0);
 
   // Step 5: sound fields in weapon / sobject configs are now name-typed.
   // Anchor a couple of known values so regressions in soundRefFromStr
   // (e.g. unknown-name returning 0 instead of -1) get caught.
-  auto findWeapon = [&](std::string const& id) -> Weapon const& {
+  auto find_weapon = [&](std::string const& id) -> Weapon const& {
     for (auto& w : common->weapons)
-      if (w.idStr == id) return w;
+      if (w.id_str == id) return w;
     FAIL("weapon not found: " + id);
     return common->weapons.front();
   };
-  auto findSObject = [&](std::string const& id) -> SObjectType const& {
-    for (auto& s : common->sobjectTypes)
-      if (s.idStr == id) return s;
+  auto find_s_object = [&](std::string const& id) -> SObjectType const& {
+    for (auto& s : common->sobject_types)
+      if (s.id_str == id) return s;
     FAIL("sobject not found: " + id);
-    return common->sobjectTypes.front();
+    return common->sobject_types.front();
   };
-  REQUIRE(findWeapon("bazooka").launchSound == common->soundIndex("bazooka"));
-  REQUIRE(findWeapon("bazooka").exploSound == -1);
-  REQUIRE(findSObject("large_explosion").startSound == common->soundIndex("exp2"));
-  REQUIRE(findSObject("flashing_pixel").startSound == -1);
+  REQUIRE(find_weapon("bazooka").launch_sound == common->SoundIndex("bazooka"));
+  REQUIRE(find_weapon("bazooka").explo_sound == -1);
+  REQUIRE(find_s_object("large_explosion").start_sound == common->SoundIndex("exp2"));
+  REQUIRE(find_s_object("flashing_pixel").start_sound == -1);
 }
 
 TEST_CASE("weapon / sobject sound refs round-trip via save/load", "[tc_load]") {
   auto src = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  src->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  src->load(std::move(tc_root));
 
   for (auto const& w : src->weapons) {
     std::stringstream ss;
-    saveWeaponConfig(*src, w, ss);
+    SaveWeaponConfig(*src, w, ss);
     Weapon copy = w;
-    copy.launchSound = copy.loopSound = copy.exploSound = -999;
-    loadWeaponConfig(*src, copy, ss);
-    REQUIRE(copy.launchSound == w.launchSound);
-    REQUIRE(copy.loopSound == w.loopSound);
-    REQUIRE(copy.exploSound == w.exploSound);
+    copy.launch_sound = copy.loop_sound = copy.explo_sound = -999;
+    LoadWeaponConfig(*src, copy, ss);
+    REQUIRE(copy.launch_sound == w.launch_sound);
+    REQUIRE(copy.loop_sound == w.loop_sound);
+    REQUIRE(copy.explo_sound == w.explo_sound);
   }
-  for (auto const& s : src->sobjectTypes) {
+  for (auto const& s : src->sobject_types) {
     std::stringstream ss;
-    saveSObjectConfig(*src, s, ss);
+    SaveSObjectConfig(*src, s, ss);
     SObjectType copy = s;
-    copy.startSound = -999;
-    loadSObjectConfig(*src, copy, ss);
-    REQUIRE(copy.startSound == s.startSound);
+    copy.start_sound = -999;
+    LoadSObjectConfig(*src, copy, ss);
+    REQUIRE(copy.start_sound == s.start_sound);
   }
 }
 
 TEST_CASE("weapon cfg with unknown sound name resolves to -1, not 0", "[tc_load]") {
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  common->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  common->load(std::move(tc_root));
 
   // Round-trip a weapon, but rewrite exploSound to a bogus name. Must
   // resolve to -1 (no sound), NOT 0 (would spuriously play the first sound).
   Weapon const& src = common->weapons.front();
   std::stringstream out;
-  saveWeaponConfig(*common, src, out);
+  SaveWeaponConfig(*common, src, out);
   std::string text = out.str();
   // Inject an unknown name into exploSound.
   auto pos = text.find("exploSound = ");
@@ -124,24 +124,24 @@ TEST_CASE("weapon cfg with unknown sound name resolves to -1, not 0", "[tc_load]
 
   std::stringstream in(text);
   Weapon dst = src;
-  loadWeaponConfig(*common, dst, in);
-  REQUIRE(dst.exploSound == -1);
+  LoadWeaponConfig(*common, dst, in);
+  REQUIRE(dst.explo_sound == -1);
 }
 
 TEST_CASE("tc.cfg [sounds] round-trips through save/load", "[tc_load]") {
   auto src = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  src->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  src->load(std::move(tc_root));
 
   std::stringstream ss;
-  saveTcConfig(*src, ss);
+  SaveTcConfig(*src, ss);
 
   Common dst;
   // soundIndex resolution during load relies on `dst.sounds` being
   // populated from [types].sounds, which loadTcConfig does first.
-  loadTcConfig(dst, ss);
+  LoadTcConfig(dst, ss);
 
-  for (int i = 0; i < SOUND_DEF_T::MaxSound; ++i) REQUIRE(dst.soundHook[i] == src->soundHook[i]);
+  for (int i = 0; i < SoundDefT::kMaxSound; ++i) REQUIRE(dst.soundHook[i] == src->soundHook[i]);
 }
 
 TEST_CASE("[sounds] unknown name resolves to -1", "[tc_load]") {
@@ -161,9 +161,9 @@ TEST_CASE("[sounds] unknown name resolves to -1", "[tc_load]") {
       "MenuMoveUp = \"alpha\"\n";
   std::stringstream ss(cfg);
   Common c;
-  loadTcConfig(c, ss);
+  LoadTcConfig(c, ss);
   REQUIRE(c.soundHook[SoundMenuSelect] == -1);
-  REQUIRE(c.soundHook[SoundMenuMoveUp] == c.soundIndex("alpha"));
+  REQUIRE(c.soundHook[SoundMenuMoveUp] == c.SoundIndex("alpha"));
   // Unset entries default to -1.
   REQUIRE(c.soundHook[SoundBump] == -1);
 }
@@ -174,106 +174,106 @@ TEST_CASE("[sounds] unknown name resolves to -1", "[tc_load]") {
 // missing slot is a silent no-op (not a crash, not the wrong sound).
 TEST_CASE("TC with a missing sound WAV loads and keeps indices stable", "[tc_load][issue44]") {
   namespace fs = std::filesystem;
-  fs::path const tempTc = fs::temp_directory_path() / "openliero_test_missing_sound_tc";
-  fs::remove_all(tempTc);
-  fs::copy(getTcPath(), tempTc, fs::copy_options::recursive | fs::copy_options::copy_symlinks);
+  fs::path const kTempTc = fs::temp_directory_path() / "openliero_test_missing_sound_tc";
+  fs::remove_all(kTempTc);
+  fs::copy(GetTcPath(), kTempTc, fs::copy_options::recursive | fs::copy_options::copy_symlinks);
 
   // Pick a sound that is NOT the last entry so we can verify later
   // indices don't shift. "shotgun" is sounds[0] in the shipped TC, and
   // "exp2" lives further down the array, referenced by the
   // "large_explosion" sobject.
-  fs::path const victim = tempTc / "sounds" / "shotgun.wav";
-  REQUIRE(fs::exists(victim));
-  fs::remove(victim);
+  fs::path const kVictim = kTempTc / "sounds" / "shotgun.wav";
+  REQUIRE(fs::exists(kVictim));
+  fs::remove(kVictim);
 
   auto common = std::make_shared<Common>();
-  REQUIRE_NOTHROW(common->load(FsNode(tempTc.string())));
+  REQUIRE_NOTHROW(common->load(FsNode(kTempTc.string())));
 
-  int const shotgunIdx = common->soundIndex("shotgun");
-  REQUIRE(shotgunIdx >= 0);
-  REQUIRE(common->sounds[shotgunIdx].name == "shotgun");
-  REQUIRE(common->sounds[shotgunIdx].sound == nullptr);
+  int const kShotgunIdx = common->SoundIndex("shotgun");
+  REQUIRE(kShotgunIdx >= 0);
+  REQUIRE(common->sounds[kShotgunIdx].name == "shotgun");
+  REQUIRE(common->sounds[kShotgunIdx].sound == nullptr);
 
   // Later entries must still resolve to the same (named) slot — the
   // shifting bug from issue #44 would have moved them up by one.
-  int const exp2Idx = common->soundIndex("exp2");
-  REQUIRE(exp2Idx > shotgunIdx);
-  REQUIRE(common->sounds[exp2Idx].name == "exp2");
-  REQUIRE(common->sounds[exp2Idx].sound != nullptr);
+  int const kExp2Idx = common->SoundIndex("exp2");
+  REQUIRE(kExp2Idx > kShotgunIdx);
+  REQUIRE(common->sounds[kExp2Idx].name == "exp2");
+  REQUIRE(common->sounds[kExp2Idx].sound != nullptr);
 
   // The sobject that plays "exp2" must point at the slot that's still
   // named "exp2", not at whatever happens to live at the shifted index.
-  SObjectType const* largeExp = nullptr;
-  for (auto const& s : common->sobjectTypes)
-    if (s.idStr == "large_explosion") largeExp = &s;
-  REQUIRE(largeExp != nullptr);
-  REQUIRE(largeExp->startSound == exp2Idx);
+  SObjectType const* large_exp = nullptr;
+  for (auto const& s : common->sobject_types)
+    if (s.id_str == "large_explosion") large_exp = &s;
+  REQUIRE(large_exp != nullptr);
+  REQUIRE(large_exp->start_sound == kExp2Idx);
 
   // Playing the missing slot must be a silent no-op, not a crash. Run
   // through the production play wrapper (NullSoundPlayer dispatches to
   // playImpl, which does nothing — but the wrapper still touches
   // Common::sounds[idx] on the SOUND_DEF_T overload path).
   NullSoundPlayer p;
-  REQUIRE_NOTHROW(p.play(shotgunIdx));
+  REQUIRE_NOTHROW(p.Play(kShotgunIdx));
 
-  fs::remove_all(tempTc);
+  fs::remove_all(kTempTc);
 }
 
 TEST_CASE("TC supports game initialization", "[tc_load]") {
-  precomputeTables();
+  PrecomputeTables();
 
   auto common = std::make_shared<Common>();
-  FsNode tcRoot(getTcPath());
-  common->load(std::move(tcRoot));
+  FsNode tc_root(GetTcPath());
+  common->load(std::move(tc_root));
 
   auto settings = std::make_shared<Settings>();
   settings->lives = 5;
-  settings->loadingTime = 0;
-  settings->randomLevel = true;
-  settings->gameMode = Settings::GMKillEmAll;
+  settings->loading_time = 0;
+  settings->random_level = true;
+  settings->game_mode = Settings::kGmKillEmAll;
 
   // Clamp weapon selections to valid range for this TC
-  int numWeapons = (int)common->weapons.size();
+  int num_weapons = (int)common->weapons.size();
   for (int p = 0; p < 3; ++p) {
-    for (int i = 0; i < Settings::selectableWeapons; ++i) {
-      if ((int)settings->wormSettings[p]->weapons[i] > numWeapons)
-        settings->wormSettings[p]->weapons[i] = 1;
+    for (int i = 0; i < Settings::kSelectableWeapons; ++i) {
+      if ((int)settings->worm_settings[p]->weapons[i] > num_weapons)
+        settings->worm_settings[p]->weapons[i] = 1;
     }
   }
 
   auto sp = std::make_shared<NullSoundPlayer>();
   Game game(common, settings, sp);
-  game.rand.seed(42);
+  game.rand.Seed(42);
 
   for (int idx = 0; idx < 2; ++idx) {
     auto w = std::make_shared<Worm>();
-    w->settings = settings->wormSettings[idx];
+    w->settings = settings->worm_settings[idx];
     w->health = w->settings->health;
     w->index = idx;
-    w->statsX = idx == 0 ? 0 : 218;
-    game.addWorm(w);
+    w->stats_x = idx == 0 ? 0 : 218;
+    game.AddWorm(w);
   }
 
-  game.addViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game.addViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
+  game.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
 
-  REQUIRE_NOTHROW(game.level.generateFromSettings(*common, *settings, game.rand));
+  REQUIRE_NOTHROW(game.level.GenerateFromSettings(*common, *settings, game.rand));
 
-  for (auto const& w : game.worms) REQUIRE_NOTHROW(w->initWeapons(game));
+  for (auto const& w : game.worms) REQUIRE_NOTHROW(w->InitWeapons(game));
 
   game.paused = false;
-  game.startGame();
-  game.resetWorms();
+  game.StartGame();
+  game.ResetWorms();
 
   // Run a short simulation — validates no crashes during gameplay
-  Rand inputRng(12345);
-  constexpr int NUM_FRAMES = 200;
+  Rand input_rng(12345);
+  constexpr int kNumFrames = 200;
 
-  for (int frame = 0; frame < NUM_FRAMES; ++frame) {
+  for (int frame = 0; frame < kNumFrames; ++frame) {
     for (int idx = 0; idx < 2; ++idx) {
-      uint32_t input = inputRng() & 0x7f;
-      game.worms[idx]->controlStates.unpack(input);
+      uint32_t input = input_rng() & 0x7f;
+      game.worms[idx]->control_states.Unpack(input);
     }
-    REQUIRE_NOTHROW(game.processFrame());
+    REQUIRE_NOTHROW(game.ProcessFrame());
   }
 }

--- a/src/tests/test_toml_archive.cpp
+++ b/src/tests/test_toml_archive.cpp
@@ -78,9 +78,9 @@ struct Versioned {
   std::int32_t b = 0;  // added in v2
 
   template <class Archive>
-  void serialize(Archive& ar, std::uint32_t const version) {
+  void serialize(Archive& ar, std::uint32_t const kVersion) {
     ar(CEREAL_NVP(a));
-    if (version >= 2) ar(CEREAL_NVP(b));
+    if (kVersion >= 2) ar(CEREAL_NVP(b));
   }
 };
 

--- a/src/tests/test_transport.cpp
+++ b/src/tests/test_transport.cpp
@@ -5,141 +5,141 @@
 
 #include "net/transport.hpp"
 
-static void pollUntil(NetTransport& t, NetTransport::State target, int maxMs = 2000) {
-  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(maxMs);
-  while (t.state() != target && std::chrono::steady_clock::now() < deadline) {
-    t.poll();
+static void PollUntil(NetTransport& t, NetTransport::State target, int max_ms = 2000) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_ms);
+  while (t.State() != target && std::chrono::steady_clock::now() < deadline) {
+    t.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 
 TEST_CASE("Transport connects host and client", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));  // Bind to any available port
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));  // Bind to any available port
+  uint16_t port = host.ListeningPort();
   REQUIRE(port != 0);
-  REQUIRE(host.state() == NetTransport::Listening);
+  REQUIRE(host.State() == NetTransport::kListening);
 
-  bool hostConnected = false;
-  bool clientConnected = false;
-  host.onConnected = [&]() { hostConnected = true; };
+  bool host_connected = false;
+  bool client_connected = false;
+  host.on_connected = [&]() { host_connected = true; };
 
   NetTransport client;
-  client.onConnected = [&]() { clientConnected = true; };
-  REQUIRE(client.connect("127.0.0.1", port));
+  client.on_connected = [&]() { client_connected = true; };
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Poll both until connected
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((!hostConnected || !clientConnected) && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+  while ((!host_connected || !client_connected) && std::chrono::steady_clock::now() < deadline) {
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(hostConnected);
-  REQUIRE(clientConnected);
-  REQUIRE(host.state() == NetTransport::Connected);
-  REQUIRE(client.state() == NetTransport::Connected);
+  REQUIRE(host_connected);
+  REQUIRE(client_connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(client.State() == NetTransport::kConnected);
 }
 
 TEST_CASE("Transport delivers input packets", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
   // Client sends inputs, host receives them
-  uint32_t receivedFrame = 0xFFFFFFFF;
-  uint8_t receivedInput = 0xFF;
-  host.onRemoteInput = [&](uint32_t f, uint8_t i) {
-    receivedFrame = f;
-    receivedInput = i;
+  uint32_t received_frame = 0xFFFFFFFF;
+  uint8_t received_input = 0xFF;
+  host.on_remote_input = [&](uint32_t f, uint8_t i) {
+    received_frame = f;
+    received_input = i;
   };
 
-  client.sendInput(42, 0x55);
+  client.SendInput(42, 0x55);
 
   // Poll until received
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
-  while (receivedFrame == 0xFFFFFFFF && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+  while (received_frame == 0xFFFFFFFF && std::chrono::steady_clock::now() < deadline) {
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(receivedFrame == 42);
-  REQUIRE(receivedInput == 0x55);
+  REQUIRE(received_frame == 42);
+  REQUIRE(received_input == 0x55);
 }
 
 TEST_CASE("Transport delivers handshake", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
-  uint32_t rxSeed = 0, rxHash = 0;
-  host.onHandshake = [&](uint32_t s, uint32_t h) {
-    rxSeed = s;
-    rxHash = h;
+  uint32_t rx_seed = 0, rx_hash = 0;
+  host.on_handshake = [&](uint32_t s, uint32_t h) {
+    rx_seed = s;
+    rx_hash = h;
   };
 
-  client.sendHandshake(12345, 0xDEADBEEF);
+  client.SendHandshake(12345, 0xDEADBEEF);
 
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
-  while (rxSeed == 0 && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+  while (rx_seed == 0 && std::chrono::steady_clock::now() < deadline) {
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(rxSeed == 12345);
-  REQUIRE(rxHash == 0xDEADBEEF);
+  REQUIRE(rx_seed == 12345);
+  REQUIRE(rx_hash == 0xDEADBEEF);
 }
 
 TEST_CASE("Transport delivers player info", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
   NetTransport::PlayerInfo received{};
   bool got = false;
-  host.onPlayerInfo = [&](const NetTransport::PlayerInfo& info) {
+  host.on_player_info = [&](const NetTransport::PlayerInfo& info) {
     received = info;
     got = true;
   };
@@ -155,12 +155,12 @@ TEST_CASE("Transport delivers player info", "[transport]") {
   sent.rgb[1] = 100;
   sent.rgb[2] = 50;
 
-  client.sendPlayerInfo(sent);
+  client.SendPlayerInfo(sent);
 
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
   while (!got && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
@@ -172,144 +172,144 @@ TEST_CASE("Transport delivers player info", "[transport]") {
 
 TEST_CASE("Transport delivers match settings", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
   NetTransport::MatchSettingsData received{};
   bool got = false;
-  client.onMatchSettings = [&](const NetTransport::MatchSettingsData& data) {
+  client.on_match_settings = [&](const NetTransport::MatchSettingsData& data) {
     received = data;
     got = true;
   };
 
   NetTransport::MatchSettingsData sent{};
   sent.lives = 15;
-  sent.loadingTime = 100;
-  sent.gameMode = 2;
+  sent.loading_time = 100;
+  sent.game_mode = 2;
   sent.blood = 500;
-  sent.maxBonuses = 3;
-  sent.timeToLose = 600;
-  sent.flagsToWin = 5;
-  sent.loadChange = 1;
-  for (int i = 0; i < 40; ++i) sent.weapTable[i] = (i % 4 == 0) ? 1 : 0;
+  sent.max_bonuses = 3;
+  sent.time_to_lose = 600;
+  sent.flags_to_win = 5;
+  sent.load_change = 1;
+  for (int i = 0; i < 40; ++i) sent.weap_table[i] = (i % 4 == 0) ? 1 : 0;
 
-  host.sendMatchSettings(sent);
+  host.SendMatchSettings(sent);
 
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
   while (!got && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
   REQUIRE(got);
   REQUIRE(received.lives == sent.lives);
-  REQUIRE(received.loadingTime == sent.loadingTime);
-  REQUIRE(received.gameMode == sent.gameMode);
+  REQUIRE(received.loading_time == sent.loading_time);
+  REQUIRE(received.game_mode == sent.game_mode);
   REQUIRE(received.blood == sent.blood);
-  REQUIRE(received.maxBonuses == sent.maxBonuses);
-  REQUIRE(received.timeToLose == sent.timeToLose);
-  REQUIRE(received.flagsToWin == sent.flagsToWin);
-  REQUIRE(received.loadChange == sent.loadChange);
-  for (int i = 0; i < 40; ++i) REQUIRE(received.weapTable[i] == sent.weapTable[i]);
+  REQUIRE(received.max_bonuses == sent.max_bonuses);
+  REQUIRE(received.time_to_lose == sent.time_to_lose);
+  REQUIRE(received.flags_to_win == sent.flags_to_win);
+  REQUIRE(received.load_change == sent.load_change);
+  for (int i = 0; i < 40; ++i) REQUIRE(received.weap_table[i] == sent.weap_table[i]);
 }
 
 TEST_CASE("Transport bidirectional input exchange", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
   // Exchange 100 frames of inputs in both directions
-  int hostReceived = 0, clientReceived = 0;
-  host.onRemoteInput = [&](uint32_t, uint8_t) { ++hostReceived; };
-  client.onRemoteInput = [&](uint32_t, uint8_t) { ++clientReceived; };
+  int host_received = 0, client_received = 0;
+  host.on_remote_input = [&](uint32_t, uint8_t) { ++host_received; };
+  client.on_remote_input = [&](uint32_t, uint8_t) { ++client_received; };
 
   for (uint32_t i = 0; i < 100; ++i) {
-    host.sendInput(i, static_cast<uint8_t>(i & 0x7f));
-    client.sendInput(i, static_cast<uint8_t>((i + 1) & 0x7f));
+    host.SendInput(i, static_cast<uint8_t>(i & 0x7f));
+    client.SendInput(i, static_cast<uint8_t>((i + 1) & 0x7f));
   }
 
   // Poll until all received
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((hostReceived < 100 || clientReceived < 100) &&
+  while ((host_received < 100 || client_received < 100) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(hostReceived == 100);
-  REQUIRE(clientReceived == 100);
+  REQUIRE(host_received == 100);
+  REQUIRE(client_received == 100);
 }
 
 TEST_CASE("Transport delivers large map data (100KB+)", "[transport]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
   // Create a 150KB payload with a recognizable pattern
-  const size_t payloadSize = 150 * 1024;
-  std::vector<uint8_t> sendData(payloadSize);
-  for (size_t i = 0; i < payloadSize; ++i) {
-    sendData[i] = static_cast<uint8_t>(i * 7 + i / 256);
+  const size_t kPayloadSize = 150 * 1024;
+  std::vector<uint8_t> send_data(kPayloadSize);
+  for (size_t i = 0; i < kPayloadSize; ++i) {
+    send_data[i] = static_cast<uint8_t>(i * 7 + i / 256);
   }
 
-  std::vector<uint8_t> receivedData;
-  client.onMapData = [&](const void* data, size_t len) {
+  std::vector<uint8_t> received_data;
+  client.on_map_data = [&](const void* data, size_t len) {
     auto* bytes = static_cast<const uint8_t*>(data);
-    receivedData.assign(bytes, bytes + len);
+    received_data.assign(bytes, bytes + len);
   };
 
-  host.sendMapData(sendData.data(), sendData.size());
+  host.SendMapData(send_data.data(), send_data.size());
 
   // Poll until received (may require multiple poll cycles for fragmentation)
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  while (receivedData.empty() && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+  while (received_data.empty() && std::chrono::steady_clock::now() < deadline) {
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(receivedData.size() == payloadSize);
-  REQUIRE(receivedData == sendData);
+  REQUIRE(received_data.size() == kPayloadSize);
+  REQUIRE(received_data == send_data);
 }
 
 // Rollback K-wide input batch round-trip. Verifies the PacketInputBatch
@@ -317,52 +317,52 @@ TEST_CASE("Transport delivers large map data (100KB+)", "[transport]") {
 // (= remoteLocalFrame).
 TEST_CASE("Transport delivers rollback input batches", "[transport][rollback]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
-  uint32_t rxBaseFrame = 0xFFFFFFFF;
-  uint8_t rxCount = 0;
-  uint32_t rxLocalFrame = 0xFFFFFFFF;
-  std::vector<uint8_t> rxInputs;
-  uint8_t rxGen = 0xFF;
-  host.onRemoteInputBatch = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in,
+  uint32_t rx_base_frame = 0xFFFFFFFF;
+  uint8_t rx_count = 0;
+  uint32_t rx_local_frame = 0xFFFFFFFF;
+  std::vector<uint8_t> rx_inputs;
+  uint8_t rx_gen = 0xFF;
+  host.on_remote_input_batch = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in,
                                 uint32_t lf) {
-    rxGen = gen;
-    rxBaseFrame = bf;
-    rxCount = c;
-    rxLocalFrame = lf;
-    rxInputs.assign(in, in + c);
+    rx_gen = gen;
+    rx_base_frame = bf;
+    rx_count = c;
+    rx_local_frame = lf;
+    rx_inputs.assign(in, in + c);
   };
 
   uint8_t inputs[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
   // baseFrame = 100, localDelta = 5, so remoteLocalFrame = 105.
-  client.sendInputBatch(0, 100, 8, 5, inputs);
+  client.SendInputBatch(0, 100, 8, 5, inputs);
 
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
-  while (rxBaseFrame == 0xFFFFFFFF && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+  while (rx_base_frame == 0xFFFFFFFF && std::chrono::steady_clock::now() < deadline) {
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 
-  REQUIRE(rxGen == 0);
-  REQUIRE(rxBaseFrame == 100);
-  REQUIRE(rxCount == 8);
-  REQUIRE(rxLocalFrame == 105);
-  REQUIRE(rxInputs.size() == 8);
-  for (int i = 0; i < 8; ++i) REQUIRE(rxInputs[i] == inputs[i]);
+  REQUIRE(rx_gen == 0);
+  REQUIRE(rx_base_frame == 100);
+  REQUIRE(rx_count == 8);
+  REQUIRE(rx_local_frame == 105);
+  REQUIRE(rx_inputs.size() == 8);
+  for (int i = 0; i < 8; ++i) REQUIRE(rx_inputs[i] == inputs[i]);
 }
 
 // The handshake carries kProtocolVersion. A peer that sends a
@@ -372,30 +372,30 @@ TEST_CASE("Transport delivers rollback input batches", "[transport][rollback]") 
 // connection failure.
 TEST_CASE("Transport rejects handshake with wrong protocol version", "[transport][rollback]") {
   NetTransport host;
-  REQUIRE(host.host(0));
-  uint16_t port = host.listeningPort();
+  REQUIRE(host.Host(0));
+  uint16_t port = host.ListeningPort();
 
   NetTransport client;
-  REQUIRE(client.connect("127.0.0.1", port));
+  REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.state() != NetTransport::Connected || client.state() != NetTransport::Connected) &&
+  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.state() == NetTransport::Connected);
+  REQUIRE(host.State() == NetTransport::kConnected);
 
   bool delivered = false;
-  host.onHandshake = [&](uint32_t, uint32_t) { delivered = true; };
+  host.on_handshake = [&](uint32_t, uint32_t) { delivered = true; };
 
   // Normal handshake (correct version) goes through.
-  client.sendHandshake(7, 0x12345678);
+  client.SendHandshake(7, 0x12345678);
   deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
   while (!delivered && std::chrono::steady_clock::now() < deadline) {
-    host.poll();
-    client.poll();
+    host.Poll();
+    client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   REQUIRE(delivered);

--- a/src/tests/test_transport.cpp
+++ b/src/tests/test_transport.cpp
@@ -52,7 +52,8 @@ TEST_CASE("Transport delivers input packets", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -92,7 +93,8 @@ TEST_CASE("Transport delivers handshake", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -129,7 +131,8 @@ TEST_CASE("Transport delivers player info", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -180,7 +183,8 @@ TEST_CASE("Transport delivers match settings", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -237,7 +241,8 @@ TEST_CASE("Transport bidirectional input exchange", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -277,7 +282,8 @@ TEST_CASE("Transport delivers large map data (100KB+)", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -324,7 +330,8 @@ TEST_CASE("Transport delivers rollback input batches", "[transport][rollback]") 
   REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -338,7 +345,7 @@ TEST_CASE("Transport delivers rollback input batches", "[transport][rollback]") 
   std::vector<uint8_t> rx_inputs;
   uint8_t rx_gen = 0xFF;
   host.on_remote_input_batch = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in,
-                                uint32_t lf) {
+                                   uint32_t lf) {
     rx_gen = gen;
     rx_base_frame = bf;
     rx_count = c;
@@ -379,7 +386,8 @@ TEST_CASE("Transport rejects handshake with wrong protocol version", "[transport
   REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected ||
+          client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();

--- a/src/tests/test_transport.cpp
+++ b/src/tests/test_transport.cpp
@@ -7,7 +7,7 @@
 
 static void PollUntil(NetTransport& t, NetTransport::State target, int max_ms = 2000) {
   auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_ms);
-  while (t.State() != target && std::chrono::steady_clock::now() < deadline) {
+  while (t.CurrentState() != target && std::chrono::steady_clock::now() < deadline) {
     t.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
@@ -18,7 +18,7 @@ TEST_CASE("Transport connects host and client", "[transport]") {
   REQUIRE(host.Host(0));  // Bind to any available port
   uint16_t port = host.ListeningPort();
   REQUIRE(port != 0);
-  REQUIRE(host.State() == NetTransport::kListening);
+  REQUIRE(host.CurrentState() == NetTransport::kListening);
 
   bool host_connected = false;
   bool client_connected = false;
@@ -38,8 +38,8 @@ TEST_CASE("Transport connects host and client", "[transport]") {
 
   REQUIRE(host_connected);
   REQUIRE(client_connected);
-  REQUIRE(host.State() == NetTransport::kConnected);
-  REQUIRE(client.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
+  REQUIRE(client.CurrentState() == NetTransport::kConnected);
 }
 
 TEST_CASE("Transport delivers input packets", "[transport]") {
@@ -52,13 +52,13 @@ TEST_CASE("Transport delivers input packets", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   // Client sends inputs, host receives them
   uint32_t received_frame = 0xFFFFFFFF;
@@ -92,13 +92,13 @@ TEST_CASE("Transport delivers handshake", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   uint32_t rx_seed = 0, rx_hash = 0;
   host.on_handshake = [&](uint32_t s, uint32_t h) {
@@ -129,13 +129,13 @@ TEST_CASE("Transport delivers player info", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   NetTransport::PlayerInfo received{};
   bool got = false;
@@ -180,13 +180,13 @@ TEST_CASE("Transport delivers match settings", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   NetTransport::MatchSettingsData received{};
   bool got = false;
@@ -237,7 +237,7 @@ TEST_CASE("Transport bidirectional input exchange", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
@@ -277,13 +277,13 @@ TEST_CASE("Transport delivers large map data (100KB+)", "[transport]") {
 
   // Wait for connection
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   // Create a 150KB payload with a recognizable pattern
   const size_t kPayloadSize = 150 * 1024;
@@ -324,13 +324,13 @@ TEST_CASE("Transport delivers rollback input batches", "[transport][rollback]") 
   REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   uint32_t rx_base_frame = 0xFFFFFFFF;
   uint8_t rx_count = 0;
@@ -379,13 +379,13 @@ TEST_CASE("Transport rejects handshake with wrong protocol version", "[transport
   REQUIRE(client.Connect("127.0.0.1", port));
 
   auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  while ((host.State() != NetTransport::kConnected || client.State() != NetTransport::kConnected) &&
+  while ((host.CurrentState() != NetTransport::kConnected || client.CurrentState() != NetTransport::kConnected) &&
          std::chrono::steady_clock::now() < deadline) {
     host.Poll();
     client.Poll();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  REQUIRE(host.State() == NetTransport::kConnected);
+  REQUIRE(host.CurrentState() == NetTransport::kConnected);
 
   bool delivered = false;
   host.on_handshake = [&](uint32_t, uint32_t) { delivered = true; };

--- a/src/tests/test_versioning.cpp
+++ b/src/tests/test_versioning.cpp
@@ -234,19 +234,19 @@ zoneTimeout = 30
 // Helpers
 // ---------------------------------------------------------------------------
 
-static Settings makeKnownV2() {
+static Settings MakeKnownV2() {
   Settings s;
-  s.maxBonuses = 7;
+  s.max_bonuses = 7;
   s.lives = 3;
   s.shadow = true;
   s.tc = "openliero";
-  s.weapTable[0] = 2;
-  s.weapTable[39] = 1;
-  s.bonusTimeout = 42;
-  for (int i = 0; i < Settings::NumWormSettings; ++i) {
-    s.wormSettings[i] = std::make_shared<WormSettings>();
-    s.wormSettings[i]->health = 100 + i;
-    s.wormSettings[i]->name = "w" + std::to_string(i);
+  s.weap_table[0] = 2;
+  s.weap_table[39] = 1;
+  s.bonus_timeout = 42;
+  for (int i = 0; i < Settings::kNumWormSettings; ++i) {
+    s.worm_settings[i] = std::make_shared<WormSettings>();
+    s.worm_settings[i]->health = 100 + i;
+    s.worm_settings[i]->name = "w" + std::to_string(i);
   }
   return s;
 }
@@ -256,7 +256,7 @@ static Settings makeKnownV2() {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("versioning: Settings v2 binary round-trip preserves bonusTimeout", "[versioning]") {
-  Settings src = makeKnownV2();
+  Settings src = MakeKnownV2();
   std::stringstream ss;
   {
     cereal::PortableBinaryOutputArchive ar(ss);
@@ -267,15 +267,15 @@ TEST_CASE("versioning: Settings v2 binary round-trip preserves bonusTimeout", "[
     cereal::PortableBinaryInputArchive ar(ss);
     ar(cereal::make_nvp("s", dst));
   }
-  CHECK(dst.maxBonuses == 7);
+  CHECK(dst.max_bonuses == 7);
   CHECK(dst.lives == 3);
-  CHECK(dst.bonusTimeout == 42);
-  CHECK(dst.wormSettings[0]->health == 100);
-  CHECK(dst.wormSettings[2]->name == "w2");
+  CHECK(dst.bonus_timeout == 42);
+  CHECK(dst.worm_settings[0]->health == 100);
+  CHECK(dst.worm_settings[2]->name == "w2");
 }
 
 TEST_CASE("versioning: Settings v2 TOML round-trip preserves bonusTimeout", "[versioning]") {
-  Settings src = makeKnownV2();
+  Settings src = MakeKnownV2();
   std::stringstream ss;
   {
     cereal::TomlOutputArchive ar(ss);
@@ -289,10 +289,10 @@ TEST_CASE("versioning: Settings v2 TOML round-trip preserves bonusTimeout", "[ve
     cereal::TomlInputArchive ar(ss);
     ar(cereal::make_nvp("s", dst));
   }
-  CHECK(dst.maxBonuses == 7);
+  CHECK(dst.max_bonuses == 7);
   CHECK(dst.lives == 3);
-  CHECK(dst.bonusTimeout == 42);
-  CHECK(dst.wormSettings[2]->health == 102);
+  CHECK(dst.bonus_timeout == 42);
+  CHECK(dst.worm_settings[2]->health == 102);
 }
 
 TEST_CASE("versioning: Settings v1 TOML fixture reads as v2 with default bonusTimeout",
@@ -304,23 +304,23 @@ TEST_CASE("versioning: Settings v1 TOML fixture reads as v2 with default bonusTi
     ar(cereal::make_nvp("s", dst));
   }
   // Fields present in v1.
-  CHECK(dst.maxBonuses == 7);
+  CHECK(dst.max_bonuses == 7);
   CHECK(dst.lives == 3);
   CHECK(dst.shadow == true);
   CHECK(dst.tc == "openliero");
-  CHECK(dst.wormSettings[0]->health == 100);
-  CHECK(dst.wormSettings[1]->name == "w1");
+  CHECK(dst.worm_settings[0]->health == 100);
+  CHECK(dst.worm_settings[1]->name == "w1");
   // bonusTimeout absent in v1 TOML — must be the struct default (0).
-  CHECK(dst.bonusTimeout == 0);
+  CHECK(dst.bonus_timeout == 0);
 }
 
 TEST_CASE("versioning: Settings toToml/fromToml produces human-readable config", "[versioning]") {
-  Settings src = makeKnownV2();
-  src.wormSettings[0]->name = "Player1";
-  src.wormSettings[1]->name = "Player2";
-  src.wormSettings[2]->name = "NetPlayer";
+  Settings src = MakeKnownV2();
+  src.worm_settings[0]->name = "Player1";
+  src.worm_settings[1]->name = "Player2";
+  src.worm_settings[2]->name = "NetPlayer";
 
-  std::string toml = src.toToml();
+  std::string toml = src.ToToml();
 
   // Human-readable: uses [settings], [player1], [player2], [network_player]
   CHECK(toml.find("[settings]") != std::string::npos);
@@ -339,13 +339,13 @@ TEST_CASE("versioning: Settings toToml/fromToml produces human-readable config",
 
   // Round-trip
   Settings dst;
-  dst.fromToml(toml);
-  CHECK(dst.maxBonuses == 7);
+  dst.FromToml(toml);
+  CHECK(dst.max_bonuses == 7);
   CHECK(dst.lives == 3);
-  CHECK(dst.bonusTimeout == 42);
-  CHECK(dst.wormSettings[0]->name == "Player1");
-  CHECK(dst.wormSettings[1]->name == "Player2");
-  CHECK(dst.wormSettings[2]->name == "NetPlayer");
-  CHECK(dst.wormSettings[0]->health == 100);
-  CHECK(dst.wormSettings[2]->health == 102);
+  CHECK(dst.bonus_timeout == 42);
+  CHECK(dst.worm_settings[0]->name == "Player1");
+  CHECK(dst.worm_settings[1]->name == "Player2");
+  CHECK(dst.worm_settings[2]->name == "NetPlayer");
+  CHECK(dst.worm_settings[0]->health == 100);
+  CHECK(dst.worm_settings[2]->health == 102);
 }

--- a/src/video_tool/replay_to_video.cpp
+++ b/src/video_tool/replay_to_video.cpp
@@ -25,36 +25,36 @@ void replayToVideo(std::shared_ptr<Common> const& common, bool spectator,
   Renderer renderer;
 
   if (spectator) {
-    renderer.init(640, 400);
-    renderer.loadPalette(*common);
+    renderer.Init(640, 400);
+    renderer.LoadPalette(*common);
   } else {
-    renderer.init(320, 200);
-    renderer.loadPalette(*common);
+    renderer.Init(320, 200);
+    renderer.LoadPalette(*common);
   }
 
-  sfx_mixer* mixer = sfx_mixer_create();
+  sfx_mixer* mixer = SfxMixerCreate();
 
-  std::unique_ptr<Game> game(replayReader.beginPlayback(
+  std::unique_ptr<Game> game(replayReader.BeginPlayback(
       common, std::shared_ptr<SoundPlayer>(new RecordSoundPlayer(*common, mixer))));
 
   // FIXME: the viewports are changed based on the replay for some
   // reason, so we need to restore them here. Probably makes more sense
   // to not save the viewports at all. But that probably breaks save
   // format compatibility?
-  game->clearViewports();
+  game->ClearViewports();
 
   // for backwards compatibility reasons, this is not stored within the
   // replay. Yet.
-  game->worms[0]->statsX = 0;
-  game->worms[1]->statsX = 218;
+  game->worms[0]->stats_x = 0;
+  game->worms[1]->stats_x = 218;
 
   // spectator viewport is always full size
   // +68 on x to align the viewport in the middle
-  game->addSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
-  game->addViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
-  game->addViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
-  game->startGame();
-  game->focus(renderer);
+  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
+  game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
+  game->StartGame();
+  game->Focus(renderer);
 
   int w = 1280, h = 720;
 
@@ -82,16 +82,16 @@ void replayToVideo(std::shared_ptr<Common> const& common, bool spectator,
   frameDebt.den = 1;
 
   int offsetX, offsetY;
-  int mag = fitScreen(640, 400, renderer.bmp.w, renderer.bmp.h, offsetX, offsetY);
+  int mag = FitScreen(640, 400, renderer.bmp.w, renderer.bmp.h, offsetX, offsetY);
 
   int f = 0;
 
-  while (replayReader.playbackFrame(renderer)) {
-    game->processFrame();
-    renderer.clear();
-    game->draw(renderer, StateGame, spectator, true);
+  while (replayReader.PlaybackFrame(renderer)) {
+    game->ProcessFrame();
+    renderer.Clear();
+    game->Draw(renderer, kStateGame, spectator, true);
     ++f;
-    renderer.fadeValue = 33;
+    renderer.fade_value = 33;
 
     sampleDebt.num += 44100;                            // sampleDebt += 44100 / 70
     int mixerFrames = sampleDebt.num / sampleDebt.den;  // floor(sampleDebt)
@@ -100,7 +100,7 @@ void replayToVideo(std::shared_ptr<Common> const& common, bool spectator,
     std::size_t mixerStart = soundBuffer.size();
     soundBuffer.resize(mixerStart + mixerFrames);
 
-    sfx_mixer_mix(mixer, &soundBuffer[mixerStart], mixerFrames);
+    SfxMixerMix(mixer, &soundBuffer[mixerStart], mixerFrames);
 
     {
       int16_t* audioSamples = &soundBuffer[0];
@@ -118,16 +118,16 @@ void replayToVideo(std::shared_ptr<Common> const& common, bool spectator,
         frameDebt = av_sub_q(frameDebt, framerate);
 
         Color realPal[256];
-        renderer.pal.activate(realPal);
+        renderer.pal.Activate(realPal);
         PalIdx* src = renderer.bmp.pixels;
         std::size_t destPitch = vidrec.tmp_picture->linesize[0];
         uint8_t* dest = vidrec.tmp_picture->data[0] + offsetY * destPitch + offsetX * 4;
         std::size_t srcPitch = renderer.bmp.pitch;
 
         uint32_t pal32[256];
-        preparePaletteBgra(realPal, pal32);
+        PreparePaletteBgra(realPal, pal32);
 
-        scaleDraw(src, renderer.renderResX, renderer.renderResY, srcPitch, dest, destPitch, mag,
+        ScaleDraw(src, renderer.render_res_x, renderer.render_res_y, srcPitch, dest, destPitch, mag,
                   pal32);
 
         vidrec_write_video_frame(&vidrec, vidrec.tmp_picture);
@@ -139,7 +139,7 @@ void replayToVideo(std::shared_ptr<Common> const& common, bool spectator,
     }
 
     if ((f % (70 * 5)) == 0) {
-      printf("\r%s", timeToStringFrames(f));
+      printf("\r%s", TimeToStringFrames(f));
       fflush(stdout);
     }
   }

--- a/src/video_tool/tools_main.cpp
+++ b/src/video_tool/tools_main.cpp
@@ -52,14 +52,14 @@ int main(int argc, char* argv[]) try {
     tcName = "openliero";
   }
 
-  precomputeTables();
+  PrecomputeTables();
 
   // Use the same path-resolution logic as the main binary.
-  // paths::resolve ignores single-dash flags, so -d/-s/-r pass through harmlessly.
+  // paths::Resolve ignores single-dash flags, so -d/-s/-r pass through harmlessly.
   // Output videos land next to the replay file; no writes go to any config path.
-  auto r = paths::resolve(argc, argv);
+  auto r = paths::Resolve(argc, argv);
   std::shared_ptr<Common> common(new Common());
-  common->load(r.configNode / "TC" / tcName);
+  common->load(r.config_node / "TC" / tcName);
 
   std::string suffix = "_n";
   if (spectator) {
@@ -67,12 +67,12 @@ int main(int argc, char* argv[]) try {
   }
 
   if (dir) {
-    auto const& root = getRoot(replayPath);
+    auto const& root = GetRoot(replayPath);
     DirectoryListing di(root);
 
     for (auto const& path : di) {
-      if (getExtension(path.name) == "lrp") {
-        auto const& fullPath = joinPath(root, path.name);
+      if (GetExtension(path.name) == "lrp") {
+        auto const& fullPath = JoinPath(root, path.name);
         if (match(fullPath, replayPath)) {
           printf("Converting %s\n", fullPath.c_str());
           replayToVideo(common, spectator, fullPath, fullPath + suffix + ".mp4");
@@ -85,8 +85,6 @@ int main(int argc, char* argv[]) try {
 
   return 0;
 } catch (std::exception& ex) {
-  Console::writeLine(std::string("EXCEPTION: ") + ex.what());
-  // Console::writeLine("Press any key to quit");
-  // Console::waitForAnyKey();
+  console::WriteLine(std::string("EXCEPTION: ") + ex.what());
   return 1;
 }

--- a/tools/cmake/metadata.cpp.in
+++ b/tools/cmake/metadata.cpp.in
@@ -5,18 +5,18 @@
 #define VERSION_GIT_DATE "@VERSION_GIT_DATE@"
 #define VERSION_GIT_TIME "@VERSION_GIT_TIME@"
 
-const char* build_version(void) {
+const char* BuildVersion(void) {
   return VERSION_GIT_TAG;
 }
 
-const char* build_hash(void) {
+const char* BuildHash(void) {
   return VERSION_GIT_HASH;
 }
 
-const char* build_date(void) {
+const char* BuildDate(void) {
   return VERSION_GIT_DATE;
 }
 
-const char* build_time(void) {
+const char* BuildTime(void) {
   return VERSION_GIT_TIME;
 }


### PR DESCRIPTION
## Summary

PR2 of the [clang flag-day plan](../blob/master/docs/clang-flag-day.md): enable `readability-identifier-naming` and apply Google C++ naming conventions across the entire `src/` tree.

- ~12,400 mechanical renames across 192 files via `clang-tidy --fix` (three iterative passes for convergence).
- Hand-fixed every method/type name collision the rename produced (Session::SessionState, IceAgent::State, Level::Rect, FileSelector::Menu, RollbackController::GameState, NetTransport::State, SoundPlayer::Common).
- Carved out names cereal calls via ADL (`serialize`/`save`/`load`/`save_minimal`/`load_minimal`) **plus** the archive-interface methods cereal expects on user archives (`setNextName`, `startNode`, `finishNode`, `saveValue`, `loadValue`, `saveBinaryValue`, `loadBinaryValue`, `sizeTag`, `prologue`, `epilogue`).
- Wrapped the X-macro enum-construction block in `constants.hpp` in `NOLINTBEGIN/END` — tidy rewrote the token-paste arguments and silently broke every `CXxx`/`SXxx`/`HXxx`/`SoundXxx` callsite.
- Restored `_ENetHost` / `_ENetPeer` forward declarations (the leading underscore is load-bearing for tag identity with enet.h's typedef).
- Kept `DirectoryListing::begin`/`end` lower_case so range-for still finds them.
- Tracked the `build_version`/`build_hash`/`build_date`/`build_time` rename in `tools/cmake/metadata.cpp.in` so the generated `metadata.cpp` matches the renamed header after reconfigure.

The on-disk save/snapshot format is unchanged: cereal's `make_nvp(...)` keys are explicit string literals throughout, so renaming the C++ identifiers does not touch the wire format.

## Test plan

- [x] `linux-x64-ci` Release build clean (`cmake --build build/linux-x64-ci`)
- [x] `linux-x64` workflow clean (`cmake --workflow --preset linux-x64`)
- [x] `linux-x64-debug` workflow clean (`cmake --workflow --preset linux-x64-debug`)
- [x] Full test suite: **149/149 passing** (`ctest --test-dir build/linux-x64-ci --build-config Release`)
- [x] Determinism-focused suites pass standalone: `test_determinism`, `test_rollback_correctness`, `test_rollback_desync`
- [x] `scripts/clang-format-all.sh` reports clean
- [x] Cereal hooks confirmed surviving: `grep -rn -E 'void (Serialize|Save|Load)\s*\(' src/game/` returns no matches
- [ ] After merge: append the squash-merge SHA to `.git-blame-ignore-revs`

## Commits

The branch carries four atomic commits (config → renames → hand-fixes → format) for readability; squash-merge so the merge SHA can be added to `.git-blame-ignore-revs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)