### PR TITLE
Fix FileSelector navigation broken by Menu class-name shadowing

### DIFF
--- a/src/game/menu/fileSelector.hpp
+++ b/src/game/menu/fileSelector.hpp
@@ -214,11 +214,11 @@ struct FileSelector {
   }
 
   FileNode* CurSel() const {
-    if (!Menu().IsSelectionValid()) {
+    if (!CurrentMenu().IsSelectionValid()) {
       return nullptr;
     }
 
-    auto* c = current_node->children[Menu().Selection()].get();
+    auto* c = current_node->children[CurrentMenu().Selection()].get();
 
     return c;
   }
@@ -253,7 +253,7 @@ struct FileSelector {
         gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_UP)) {
       g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
-      Menu().Movement(-1);
+      CurrentMenu().Movement(-1);
     }
 
     if (gfx.TestSdlKeyOnce(SDL_SCANCODE_DOWN) ||
@@ -261,19 +261,19 @@ struct FileSelector {
         gfx.TestGamepadDirOnce(SDL_GAMEPAD_BUTTON_DPAD_DOWN)) {
       g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
 
-      Menu().Movement(1);
+      CurrentMenu().Movement(1);
     }
 
     if (gfx.TestSdlKeyOnce(SDL_SCANCODE_PAGEUP)) {
       g_sound_player->Play(common.sound_hook[SoundMenuMoveDown]);
 
-      Menu().MovementPage(-1);
+      CurrentMenu().MovementPage(-1);
     }
 
     if (gfx.TestSdlKeyOnce(SDL_SCANCODE_PAGEDOWN)) {
       g_sound_player->Play(common.sound_hook[SoundMenuMoveUp]);
 
-      Menu().MovementPage(1);
+      CurrentMenu().MovementPage(1);
     }
 
     if (gfx.TestSdlKeyOnce(SDL_SCANCODE_ESCAPE) ||
@@ -294,7 +294,7 @@ struct FileSelector {
       Enter();
     }
 
-    Menu().OnKeys(gfx.key_buf, gfx.key_buf_ptr, /*contains=*/true);
+    CurrentMenu().OnKeys(gfx.key_buf, gfx.key_buf_ptr, /*contains=*/true);
 
     return true;
   }


### PR DESCRIPTION
## Summary

- The Google-naming rename in 1587a2d renamed `FileSelector::menu()` to `CurrentMenu()` but left six call sites inside the class referring to `Menu()`. Because `Menu` is the class name of the enclosing menu type, those calls construct a default `Menu` temporary instead of returning `current_node->GetMenu()`.
- `CurSel()` therefore always returned `nullptr` (empty temporary → `IsSelectionValid()` false), and arrow keys / page keys operated on a throw-away menu. Net effect: Enter, Up, Down, PageUp, PageDown all did nothing in the Profile, Setup, Replay, and Level selectors.
- Fix replaces the six `Menu()` calls with `CurrentMenu()` (the accessor that already exists).

## Test plan

- [x] `cmake --workflow --preset linux-x64` builds clean
- [x] Manual: Load Profile, Load Setup, Load Replay navigate and select correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)