### PR TITLE
Fix netplay sound dying mid-match and muted menus

### DIFF
--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -612,8 +612,13 @@ void RollbackController::SetupShadowGame() {
   // Mirror the live game's construction: same Common/Settings, silent
   // sound player, identical worm+viewport configuration so the
   // snapshot we load below produces an identical processFrame path.
+  // install_global_sound_player=false: the shadow must not replace
+  // g_sound_player with its NullSoundPlayer — that would mute every
+  // menu/UI sound for the rest of the match (and leave a dangling
+  // global after a rematch cycle).
   shadowGame_ =
-      std::make_unique<Game>(game.common, game.settings, std::make_shared<NullSoundPlayer>());
+      std::make_unique<Game>(game.common, game.settings, std::make_shared<NullSoundPlayer>(),
+                             /*install_global_sound_player=*/false);
 
   ConfigureGameSlots(*shadowGame_, {game.worms[0]->settings, game.worms[1]->settings});
 
@@ -935,9 +940,9 @@ void RollbackController::AdvanceWeaponSelection() {
     predicted = true;
   }
 
-  game.SetSpeculative(predicted);
+  // First execution runs audible even when predicted — see the matching
+  // comment in advanceSimulation. Only resim re-executions are speculative.
   bool const kWsDone = WeaponSelectStep(kCurLocal, cur_remote);
-  game.SetSpeculative(/*s=*/false);
   ++simFrame_;
 
   if (!predicted) {
@@ -1148,9 +1153,14 @@ void RollbackController::AdvanceSimulation() {
   localPrevInput_ = kCurLocal;
   remotePrevInput_ = cur_remote;
 
-  game.SetSpeculative(predicted);
+  // First execution of this frame, predicted or not — run it audible.
+  // Under real latency remote input is almost never in by now, so
+  // gating sound on `predicted` would mute the whole match (a frame
+  // whose prediction holds is later promoted without re-execution, so
+  // its sounds would never be heard at all). Only resim re-executions
+  // are speculative; a misprediction can play a sound that "didn't
+  // happen", which is the standard rollback trade-off.
   game.ProcessFrame();
-  game.SetSpeculative(/*s=*/false);
   ++simFrame_;
 
   if (!predicted) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -22,17 +22,20 @@
 #include <utility>
 
 Game::Game(const std::shared_ptr<Common>& common, std::shared_ptr<Settings> settings_init,
-           const std::shared_ptr<SoundPlayer>& sound_player)
+           const std::shared_ptr<SoundPlayer>& sound_player, bool install_global_sound_player)
     : common(common),
       sound_player(sound_player),
       prev_sound_player(g_sound_player),
+      sound_player_installed(install_global_sound_player),
 
       settings(std::move(std::move(settings_init))),
       stats_recorder(new NormalStatsRecorder),
       level(*common)
 
 {
-  g_sound_player = sound_player.get();
+  if (install_global_sound_player) {
+    g_sound_player = sound_player.get();
+  }
 
   rand.Seed(static_cast<uint32_t>(std::time(nullptr)));
 }
@@ -40,6 +43,11 @@ Game::Game(const std::shared_ptr<Common>& common, std::shared_ptr<Settings> sett
 Game::~Game() {
   ClearViewports();
   ClearWorms();
+  // The player may be shared (gfx.soundPlayer); never leave it muted
+  // past this game's lifetime.
+  if (sound_player) {
+    sound_player->speculative = false;
+  }
   if (sound_player_installed && g_sound_player == sound_player.get()) {
     g_sound_player = prev_sound_player;
   }

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -43,8 +43,11 @@ struct Holdazone {
 };
 
 struct Game {
+  // install_global_sound_player: whether this game takes over g_sound_player
+  // for UI code. Pass false for auxiliary games (e.g. the rollback shadow
+  // game) whose sound player must not be heard by menus.
   Game(const std::shared_ptr<Common>& common, std::shared_ptr<Settings> settings_init,
-       const std::shared_ptr<SoundPlayer>& sound_player);
+       const std::shared_ptr<SoundPlayer>& sound_player, bool install_global_sound_player = true);
   ~Game();
 
   void OnKey(uint32_t key, bool state);
@@ -90,8 +93,9 @@ struct Game {
   void SpawnZone();
 
   // While speculative is true, sim-driven side effects
-  // (SoundPlayer::play/stop, StatsRecorder writes) are suppressed.
-  // Set during predicted frames and during rollback resim.
+  // (SoundPlayer::play, StatsRecorder writes) are suppressed.
+  // Set during rollback resim, i.e. re-execution of frames whose side
+  // effects already fired on their first (forward) execution.
   void SetSpeculative(bool s) {
     speculative = s;
     if (sound_player) {
@@ -114,7 +118,7 @@ struct Game {
   std::shared_ptr<Common> common;
   std::shared_ptr<SoundPlayer> sound_player;
   SoundPlayer* prev_sound_player;
-  bool sound_player_installed{true};
+  bool sound_player_installed;
   std::shared_ptr<Settings> settings;
   std::shared_ptr<StatsRecorder> stats_recorder;
 
@@ -146,7 +150,7 @@ struct Game {
 
   bool quick_sim{false};
 
-  // True during predicted/resim frames. Mirrored onto soundPlayer /
+  // True during rollback resim frames. Mirrored onto soundPlayer /
   // statsRecorder via setSpeculative(). Read by Game-internal code
   // that short-circuits a side effect at its source.
   bool speculative = false;

--- a/src/game/mixer/player.cpp
+++ b/src/game/mixer/player.cpp
@@ -88,9 +88,6 @@ bool DefaultSoundPlayer::IsPlaying(void* id) {
 
 void DefaultSoundPlayer::Stop(void* id) {
 #if !DISABLE_SOUND
-  if (speculative) {
-    return;
-  }
   if (!initialized_) {
     return;
   }

--- a/src/game/mixer/player.hpp
+++ b/src/game/mixer/player.hpp
@@ -26,9 +26,13 @@ struct SoundPlayer {
   virtual bool IsPlaying(void* id) = 0;
   virtual void Stop(void* id) = 0;
 
-  // When true, play()/stop() are suppressed but isPlaying() passes
-  // through. Set during predicted/resim frames to avoid duplicate
-  // sound emission.
+  // When true, play() is suppressed but stop()/isPlaying() pass
+  // through. Set during rollback resim to avoid duplicate sound
+  // emission. stop() is deliberately not gated: it is idempotent, a
+  // spurious stop self-heals on the next fire (the isPlaying check
+  // restarts the loop), but a *suppressed* stop leaks a looping
+  // mixer channel forever — and the mixer only has CHANNEL_COUNT of
+  // them, shared with menu sounds.
   bool speculative = false;
 
  protected:
@@ -71,12 +75,7 @@ struct RecordSoundPlayer : SoundPlayer {
 
   bool IsPlaying(void* id) override { return SfxIsPlaying(mixer, id) != 0; }
 
-  void Stop(void* id) override {
-    if (speculative) {
-      return;
-    }
-    SfxMixerStop(mixer, id);
-  }
+  void Stop(void* id) override { SfxMixerStop(mixer, id); }
 
  protected:
   void PlayImpl(int sound, void* id, int loops) override;

--- a/src/tests/test_prediction_no_rollback.cpp
+++ b/src/tests/test_prediction_no_rollback.cpp
@@ -9,16 +9,31 @@
 //      confirmedFrame catches up.
 
 #include <catch2/catch_test_macros.hpp>
+#include <climits>
 #include <cstdint>
 #include <memory>
 
 #include "controller/rollbackController.hpp"
 #include "game.hpp"
+#include "gfx.hpp"
 #include "math.hpp"
 #include "mixer/player.hpp"
 #include "rollback/buffer.hpp"
+#include "weapon.hpp"
 
 namespace {
+
+// IsPlaying always answers false so the sim's sound-dependent branches
+// (loop-sound retrigger checks) behave identically across controllers,
+// keeping play counts comparable between runs.
+struct CountingSoundPlayer : SoundPlayer {
+  int plays = 0;
+  bool IsPlaying(void* /*id*/) override { return false; }
+  void Stop(void* /*id*/) override {}
+
+ protected:
+  void PlayImpl(int /*sound*/, void* /*id*/, int /*loops*/) override { ++plays; }
+};
 
 // Zero-jitter loopback: each peer's batched send fans straight into the
 // other peer's injectRemoteInput. The dedup inside injectRemoteInput
@@ -183,4 +198,129 @@ TEST_CASE("Starvation: predict up to kMaxRollback, then stall, then recover",
 
   REQUIRE(a.ConfirmedFrame() >= static_cast<int32_t>(kSimFrameAtStall) - 1);
   REQUIRE(a.CurrentFrame() > kSimFrameAtStall);
+}
+
+TEST_CASE("Predicted frames emit sound and promote does not re-emit",
+          "[rollback][prediction][sound]") {
+  // Regression for the netplay silence bug: frames first executed as
+  // *predicted* used to run speculatively, so their sounds were never
+  // emitted — and a correct prediction is later promoted without
+  // re-execution, so they never got a second chance. Under real
+  // latency that muted essentially the whole match.
+  //
+  // The remote worm does all the playing: its input is a pure function
+  // of the frame index (so subject and control see identical input
+  // streams), toggling Fire for spawn edges, then holding Fire from
+  // well before the starve window through the end so predictions are
+  // always correct and every frame is executed exactly once. The
+  // subject is starved (frames run predicted, inputs delivered late);
+  // the control gets every input on time. Their final play counts
+  // must match exactly: predicted execution emits, promotion does not
+  // duplicate.
+  auto [common, settings] = MakeEnv();
+
+  constexpr uint8_t kFireBit = (1 << Worm::kFire);
+  // Long enough for the remote worm to spawn and settle into firing:
+  // the respawn camera scroll alone takes up to ~160 frames.
+  constexpr uint32_t kWarm = 500;
+  constexpr uint32_t kHoldFrom = kWarm - 60;
+  constexpr uint32_t kFinal = kWarm + rollback::kMaxRollback + 30;
+
+  auto remote_in = [](uint32_t f) -> uint8_t {
+    if (f >= kHoldFrom) {
+      return kFireBit;  // constant across the prediction window
+    }
+    return (f % 24) < 16 ? kFireBit : 0;  // edges so the worm spawns
+  };
+
+  // Give every worm slot the fastest-firing weapon with a launch sound
+  // so shots land inside the kMaxRollback-frame prediction window.
+  int best_pos = -1;
+  int best_delay = INT_MAX;
+  for (std::size_t p = 0; p < common->weap_order.size(); ++p) {
+    Weapon const& w = common->weapons[common->weap_order[p]];
+    if (w.launch_sound >= 0 && w.ammo >= 10 && w.delay < best_delay) {
+      best_delay = w.delay;
+      best_pos = static_cast<int>(p);
+    }
+  }
+  REQUIRE(best_pos >= 0);
+  REQUIRE(best_delay < rollback::kMaxRollback);
+  for (int ws : {0, 1, Settings::kNetworkPlayerIdx}) {
+    for (uint32_t& w : settings->worm_settings[ws]->weapons) {
+      w = static_cast<uint32_t>(best_pos) + 1;
+    }
+  }
+
+  auto setup = [](RollbackController& c, std::shared_ptr<CountingSoundPlayer> const& sp) {
+    c.SetSkipWeaponSelection(/*skip=*/true);
+    c.game.rand.Seed(0x5EED);
+    c.game.sound_player = sp;
+    c.Focus();
+  };
+
+  auto sp_sub = std::make_shared<CountingSoundPlayer>();
+  RollbackController sub(common, settings, 0);
+  setup(sub, sp_sub);
+
+  // Warm-up: remote input present, frames run confirmed. Inject
+  // per-tick — the input ring is small, injecting the whole range up
+  // front would wrap it.
+  for (uint32_t i = 0; i < kWarm; ++i) {
+    sub.InjectRemoteInput(i, remote_in(i));
+    sub.SetLocalControlState(0);
+    sub.Process();
+  }
+  REQUIRE(sub.CurrentFrame() == kWarm);
+  int const kPlaysWarm = sp_sub->plays;
+  REQUIRE(kPlaysWarm > 1);
+
+  // Starve: every executed frame is predicted. They must still sound.
+  for (int i = 0; i < rollback::kMaxRollback + 5; ++i) {
+    sub.SetLocalControlState(0);
+    sub.Process();
+  }
+  REQUIRE(sub.CurrentFrame() == kWarm + rollback::kMaxRollback);
+  REQUIRE(sp_sub->plays > kPlaysWarm);
+
+  // Late delivery of the (matching) remote inputs lifts the stall via
+  // the promote path; keep feeding inputs and run to kFinal.
+  for (uint32_t f = kWarm; f < kFinal + 8; ++f) {
+    sub.InjectRemoteInput(f, remote_in(f));
+  }
+  for (int guard = 0; sub.CurrentFrame() < kFinal && guard < 1000; ++guard) {
+    sub.SetLocalControlState(0);
+    sub.Process();
+  }
+  REQUIRE(sub.CurrentFrame() == kFinal);
+
+  // Control: identical seed and inputs, never starved.
+  auto sp_ctl = std::make_shared<CountingSoundPlayer>();
+  RollbackController ctl(common, settings, 0);
+  setup(ctl, sp_ctl);
+  for (uint32_t i = 0; i < kFinal; ++i) {
+    ctl.InjectRemoteInput(i, remote_in(i));
+    ctl.SetLocalControlState(0);
+    ctl.Process();
+  }
+  REQUIRE(ctl.CurrentFrame() == kFinal);
+
+  REQUIRE(sp_sub->plays == sp_ctl->plays);
+}
+
+TEST_CASE("Shadow game does not hijack g_soundPlayer", "[rollback][sound]") {
+  // Regression: the shadow game's ctor used to install its
+  // NullSoundPlayer as g_soundPlayer, muting every menu/UI sound for
+  // the rest of the match — and leaving a dangling global after a
+  // rematch cycle.
+  auto [common, settings] = MakeEnv();
+
+  RollbackController a(common, settings, 0);
+  a.SetSkipWeaponSelection(/*skip=*/true);
+  a.game.rand.Seed(0x1234);
+  a.Focus();
+
+  REQUIRE(a.ShadowGameForTest() != nullptr);
+  // The live game's (gfx-shared) player must still be the global one.
+  REQUIRE(g_sound_player == gfx.sound_player.get());
 }

--- a/src/tests/test_prediction_no_rollback.cpp
+++ b/src/tests/test_prediction_no_rollback.cpp
@@ -246,8 +246,8 @@ TEST_CASE("Predicted frames emit sound and promote does not re-emit",
   }
   REQUIRE(best_pos >= 0);
   REQUIRE(best_delay < rollback::kMaxRollback);
-  for (int ws : {0, 1, Settings::kNetworkPlayerIdx}) {
-    for (uint32_t& w : settings->worm_settings[ws]->weapons) {
+  for (int const kWs : {0, 1, Settings::kNetworkPlayerIdx}) {
+    for (uint32_t& w : settings->worm_settings[kWs]->weapons) {
       w = static_cast<uint32_t>(best_pos) + 1;
     }
   }

--- a/src/tests/test_sound_player.cpp
+++ b/src/tests/test_sound_player.cpp
@@ -8,6 +8,7 @@
 #include "constants.hpp"
 #include "filesystem.hpp"
 #include "game.hpp"
+#include "mixer/mixer.hpp"
 #include "mixer/player.hpp"
 #include "settings.hpp"
 
@@ -69,6 +70,58 @@ TEST_CASE("SoundPlayer SOUND_DEF_T overload is a no-op when common() returns nul
   RecordingPlayer p;  // no Common attached
   p.Play(SoundMenuSelect);
   REQUIRE(p.played.empty());
+}
+
+TEST_CASE("Stop passes through while speculative", "[sound_player]") {
+  // Regression: stop() used to be suppressed while speculative. A loop
+  // sound whose stop lands only on speculative frames then plays
+  // forever, permanently occupying one of the CHANNEL_COUNT mixer
+  // channels — leak enough of them and every later play() (game and
+  // menu alike) silently fails.
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(GetTcPath());
+  common->load(kTcRoot);
+
+  int snd = -1;
+  for (std::size_t i = 0; i < common->sounds.size(); ++i) {
+    if (common->sounds[i].sound) {
+      snd = static_cast<int>(i);
+      break;
+    }
+  }
+  REQUIRE(snd >= 0);
+
+  sfx_mixer* mixer = SfxMixerCreate();
+  RecordSoundPlayer p(*common, mixer);
+
+  int channel_id = 0;
+  p.Play(snd, &channel_id, /*loops=*/-1);
+  REQUIRE(p.IsPlaying(&channel_id));
+
+  p.speculative = true;
+  p.Stop(&channel_id);
+  REQUIRE_FALSE(p.IsPlaying(&channel_id));
+}
+
+TEST_CASE("Game ctor can leave g_soundPlayer alone for shadow games", "[sound_player]") {
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(GetTcPath());
+  common->load(kTcRoot);
+  auto settings = std::make_shared<Settings>();
+
+  SoundPlayer* original_global = g_sound_player;
+  auto sentinel = std::make_shared<NullSoundPlayer>();
+  g_sound_player = sentinel.get();
+
+  {
+    auto sp = std::make_shared<RecordingPlayer>(*common);
+    Game const kGame(common, settings, sp, /*install_global_sound_player=*/false);
+    REQUIRE(g_sound_player == sentinel.get());
+  }
+
+  REQUIRE(g_sound_player == sentinel.get());
+
+  g_sound_player = original_global;
 }
 
 TEST_CASE("Game ctor installs g_soundPlayer and dtor restores it", "[sound_player]") {

--- a/src/tests/test_speculative_suppression.cpp
+++ b/src/tests/test_speculative_suppression.cpp
@@ -1,11 +1,13 @@
 // Game::speculative side-effect suppression.
 //
-// Contract: while game.setSpeculative(true), SoundPlayer::play/stop and
-// StatsRecorder writes must not be observable. isPlaying may pass
-// through.
+// Contract: while game.setSpeculative(true), SoundPlayer::play and
+// StatsRecorder writes must not be observable. stop and isPlaying pass
+// through: stop is idempotent and self-healing, while a suppressed
+// stop would leak a looping mixer channel forever.
 //
 // An N-frame run that goes run→snapshot→speculative-run→restore→run
-// must produce the same observable counts as a single 2N-frame run.
+// must produce the same observable play/stats counts as a single
+// 2N-frame run.
 
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
@@ -33,12 +35,7 @@ struct CountingSoundPlayer : SoundPlayer {
     ++is_playing_calls;
     return false;
   }
-  void Stop(void* /*id*/) override {
-    if (speculative) {
-      return;
-    }
-    ++stops;
-  }
+  void Stop(void* /*id*/) override { ++stops; }
 
  protected:
   void PlayImpl(int /*sound*/, void* /*id*/, int /*loops*/) override { ++plays; }
@@ -167,14 +164,16 @@ TEST_CASE("Speculative frames suppress sound and stats", "[rollback]") {
   sub.game->SetSpeculative(/*s=*/true);
 
   // Speculative run uses the *same* inputs the post-restore segment will
-  // use, so the underlying sim work is comparable. Counters must not move.
+  // use, so the underlying sim work is identical. Play/stats counters
+  // must not move; stop passes through, so the speculative segment emits
+  // exactly the stops the control's second phase emits.
   Rand spec_inputs = sub_inputs;
   for (int f = 0; f < kPhase; ++f) {
     sub.Step(spec_inputs);
   }
 
   REQUIRE(sub.sp->plays == kPlaysAtSnap);
-  REQUIRE(sub.sp->stops == kStopsAtSnap);
+  REQUIRE(sub.sp->stops == kControlStops);
   REQUIRE(sub.Stats().events == kEventsAtSnap);
 
   // isPlaying should have been called at least once and always passes
@@ -189,7 +188,9 @@ TEST_CASE("Speculative frames suppress sound and stats", "[rollback]") {
   }
 
   REQUIRE(sub.sp->plays == kControlPlays);
-  REQUIRE(sub.sp->stops == kControlStops);
+  // Second phase ran twice (once speculatively, once for real); its
+  // stop calls were emitted both times.
+  REQUIRE(sub.sp->stops == 2 * kControlStops - kStopsAtSnap);
   REQUIRE(sub.Stats().events == kControlEvents);
 
   // Sanity: isPlaying did pass through during speculation (not gated).


### PR DESCRIPTION
## Symptom

During an online match, sound stopped working for both players and never recovered — menu audio included. Replaying the match's `.lrp` file in a fresh session sounded fine.

## Root causes (three compounding bugs)

**1. Predicted frames were muted, and promotion never gave them a second chance** — the main in-game silence. The forward path ran every first-execution frame with `SetSpeculative(predicted)`, suppressing `SoundPlayer::Play`. A frame whose prediction holds is later *promoted* to confirmed without re-execution, so its sounds were never emitted. With the default 1-frame input delay (~14ms), any real internet latency makes every forward frame predicted, muting essentially the whole match — for both peers simultaneously, since they share the RTT. Forward frames now always run audible; only resim re-executions are speculative. Trade-off (standard for rollback netcode): a misprediction can emit a sound that "didn't happen".

**2. The shadow game hijacked `g_sound_player`** — the menu silence. `Game`'s ctor unconditionally installs its sound player as the global `g_sound_player` used by all menu/UI code; the rollback shadow game installed its `NullSoundPlayer` at match start. After a rematch cycle the ctor/dtor restore chain additionally left `g_sound_player` dangling (pointing at the destroyed first shadow's player), so menus stayed broken after the match. `Game` now takes `install_global_sound_player` (the shadow passes `false`), and `~Game` clears `speculative` on the shared player as a backstop.

**3. Suppressed `Stop()` leaked looping mixer channels.** `Stop` was also gated on `speculative`; a stop landing only on suppressed frames is lost forever, leaving a loop sound permanently occupying one of the mixer's **8** channels (shared with menu sounds). `Stop` now always passes through — it is idempotent, and a spurious stop self-heals via the `IsPlaying` retrigger in `Worm::Fire`, whereas a lost stop never heals.

## Tests

- **Predicted frames emit sound and promote does not re-emit**: a starved controller (frames executed as predicted, inputs delivered late, promoted without resim) must produce play counts exactly equal to a never-starved control with identical frame-indexed inputs. Fails pre-fix (zero plays in the prediction window).
- **Shadow game does not hijack g_soundPlayer**: fails pre-fix (global pointed at the shadow's null player).
- **Stop passes through while speculative**: loop channel must actually stop in the mixer. Fails pre-fix.
- Updated `test_speculative_suppression` to the new contract (play/stats suppressed, stop passes through, with exact stop-count accounting).

## Verification

- All 153 tests pass, including `test_determinism`, `test_rollback_correctness`, `test_rollback_desync` (no sim-state changes — only side-effect emission timing).
- Both new controller-level regression tests verified to fail with the fix stashed.
- Game binary installed and smoke-launched cleanly.
- Tree-wide clang-format (v22) clean.

## Known limitation

Sounds *introduced by a correction* (a resim that changes what happened) are still skipped rather than late-played — fixing that would need a per-frame sound journal. Worth a follow-up only if missing remote shot sounds are noticeable under heavy jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)