### PR TITLE
Fix desync when END MATCH is picked during weapon selection

### DIFF
--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -310,6 +310,7 @@ void RollbackController::Focus() {
       game.StartGame();
       game.ResetWorms();
       state_ = kStateGame;
+      gamePhaseEntered_ = true;
 
       SeedRollbackAndShadow();
     } else {
@@ -392,7 +393,14 @@ bool RollbackController::Process() {
 
   if (state_ == kStateWeaponSelection) {
     AdvanceWeaponSelection();
-  } else if (state_ == kStateGame || state_ == kStateGameEnded) {
+  } else if (state_ == kStateGame || (state_ == kStateGameEnded && gamePhaseEntered_)) {
+    // The gamePhaseEntered_ gate covers END MATCH picked during weapon
+    // selection: that jumps straight to StateGameEnded without ever
+    // running finishWeaponSelect (no startGame, no resetForGamePhase,
+    // no generation bump). Advancing the game sim from there would
+    // exchange same-generation checksums computed from a never-started
+    // Game — the peers end ticks apart, so the values diverge and trip
+    // the desync detector.
     AdvanceSimulation();
   }
 
@@ -574,6 +582,7 @@ void RollbackController::FinishWeaponSelect() {
   game.StartGame();
   game.ResetWorms();
   state_ = kStateGame;
+  gamePhaseEntered_ = true;
 
   // The WS phase can leave peers at different simFrame counters
   // (asymmetric stalls + WS-rollback resims). Carrying that skew into
@@ -1265,8 +1274,14 @@ void RollbackController::EnterGoingToMenu(int fade) {
 
 void RollbackController::EndMatch() {
   if (state_ == kStateGame || state_ == kStateWeaponSelection) {
+    bool const kFromWeaponSelection = state_ == kStateWeaponSelection;
     state_ = kStateGameEnded;
-    EnterGoingToMenu(33);
+    // Ending from weapon selection skips the fade: there is no started
+    // game to keep drawing during it (process() won't advance the sim
+    // either — see the gamePhaseEntered_ gate). Stats finalize with
+    // gameTime 0, so GamePlayState skips the stats screen and routes
+    // straight to the rematch screen via the StateGameEnded check.
+    EnterGoingToMenu(kFromWeaponSelection ? 0 : 33);
     StopReplayRecording();
   }
 }

--- a/src/game/controller/rollbackController.hpp
+++ b/src/game/controller/rollbackController.hpp
@@ -185,6 +185,11 @@ struct RollbackController : CommonController {
   int remoteIdx_;
 
   ::GameState state_{kStateInitial};
+  // True once the game phase actually started (startGame ran). Gates
+  // StateGameEnded ticks in process(): END MATCH during weapon
+  // selection enters StateGameEnded without a started Game, and the
+  // game-phase sim must not run on it.
+  bool gamePhaseEntered_{false};
   int fadeValue_{0};
   bool goingToMenu_{false};
 

--- a/src/game/gamePlayState.cpp
+++ b/src/game/gamePlayState.cpp
@@ -2,10 +2,12 @@
 
 #include <cstdio>
 #include "controller/controller.hpp"
+#include "controller/rollbackController.hpp"
 #include "game.hpp"
 #include "gfx.hpp"
 #include "inputState.hpp"
 #include "net/session.hpp"
+#include "rematchState.hpp"
 #include "statsState.hpp"
 #include "stats_recorder.hpp"
 
@@ -67,6 +69,19 @@ bool GamePlayState::Update() {
             std::make_unique<StatsState>(*stats, *game, kIsMultiplayer));
         return false;
       }
+    }
+
+    // Multiplayer match deliberately ended (END MATCH) but produced no
+    // stats — END MATCH during weapon selection. Keep the session alive
+    // and go straight to the rematch screen so the host can fix the
+    // level pick; there is nothing to show on a stats screen. PeerLeft
+    // and local Disconnect never reach StateGameEnded, so they fall
+    // through to the session teardown below.
+    auto* rollback = dynamic_cast<RollbackController*>(gfx->controller.get());
+    if (gfx->net_session && rollback && rollback->State() == kStateGameEnded && game) {
+      gfx->net_session->EnterRematch();
+      gfx->state_stack.ScheduleReplaceTop(std::make_unique<RematchState>(*game));
+      return false;
     }
 
     // Clear framebuffer so menu doesn't capture stale overlay content

--- a/src/tests/test_rollback_weapsel.cpp
+++ b/src/tests/test_rollback_weapsel.cpp
@@ -353,3 +353,125 @@ TEST_CASE("Weapon select transitions cleanly under jitter", "[rollback][weapsel]
   INFO("a rollbacks=" << a->RollbackCount() << " b rollbacks=" << b->RollbackCount());
   REQUIRE(kAnyRollback);
 }
+
+// Regression: END MATCH picked from the pause menu during weapon
+// selection. endMatch() flips state to StateGameEnded, and process()
+// used to route StateGameEnded into advanceSimulation() — running the
+// game-phase sim on a Game that never went through finishWeaponSelect
+// (no startGame, no resetForGamePhase, no generation bump). The peers
+// reach that state ticks apart (packet latency), so they exchanged
+// same-generation checksums computed from divergent never-started
+// games and tripped the desync detector.
+TEST_CASE("End match during weapon selection exits without running game sim",
+          "[rollback][weapsel]") {
+  constexpr uint32_t kWorldSeed = 0xC0FFEE;
+  auto [common, settings] = MakeEnv();
+  auto a = MakePeer(common, settings, 0, kWorldSeed);
+  auto b = MakePeer(common, settings, 1, kWorldSeed);
+
+  struct Pkt {
+    uint8_t gen;
+    uint32_t base_frame;
+    uint8_t count;
+    std::array<uint8_t, rollback::kMaxRollback + 1> inputs;
+    uint32_t local_frame;
+  };
+  std::vector<Pkt> a_to_b;
+  std::vector<Pkt> b_to_a;
+  auto enqueue = [](std::vector<Pkt>& q, uint8_t g, uint32_t bf, uint8_t c, uint8_t const* in,
+                    uint32_t lf) {
+    Pkt p{};
+    p.gen = g;
+    p.base_frame = bf;
+    p.count = c;
+    p.local_frame = lf;
+    for (uint8_t i = 0; i < c; ++i) {
+      p.inputs[i] = in[i];
+    }
+    q.push_back(p);
+  };
+  a->SetInputCallbacks([&](uint8_t g, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(a_to_b, g, bf, c, in, lf);
+  });
+  b->SetInputCallbacks([&](uint8_t g, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    enqueue(b_to_a, g, bf, c, in, lf);
+  });
+
+  // Record every checksum each peer emits. NetSession compares these
+  // per (generation, frame) — any same-key mismatch is a desync.
+  struct Sum {
+    uint8_t gen;
+    uint32_t frame;
+    uint32_t checksum;
+  };
+  std::vector<Sum> a_sums;
+  std::vector<Sum> b_sums;
+  a->SetChecksumCallback([&](uint8_t g, uint32_t f, uint32_t c) {
+    a_sums.push_back({.gen = g, .frame = f, .checksum = c});
+  });
+  b->SetChecksumCallback([&](uint8_t g, uint32_t f, uint32_t c) {
+    b_sums.push_back({.gen = g, .frame = f, .checksum = c});
+  });
+
+  a->Focus();
+  b->Focus();
+  a->InjectRemoteInput(0, 0);
+  b->InjectRemoteInput(0, 0);
+
+  // A ends the match mid-weapon-select; the (reliable) EndMatch packet
+  // reaches B a few ticks later, so B keeps advancing its WS phase in
+  // between — exactly the skew that produced divergent checksums.
+  constexpr int kEndTickA = 10;
+  constexpr int kEndTickB = kEndTickA + 3;
+
+  bool a_done = false;
+  bool b_done = false;
+  for (int i = 0; i < 100 && !(a_done && b_done); ++i) {
+    if (i == kEndTickA) {
+      a->EndMatch();
+    }
+    if (i == kEndTickB) {
+      b->EndMatch();
+    }
+
+    uint8_t const kIn = (i < 8 && i % 2 == 0) ? kBitDown : 0;
+    if (!a_done) {
+      a->SetLocalControlState(kIn);
+      a_done = !a->Process();
+    }
+    if (!b_done) {
+      b->SetLocalControlState(kIn);
+      b_done = !b->Process();
+    }
+
+    for (auto const& p : a_to_b) {
+      b->InjectRemoteBatch(p.gen, p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    }
+    for (auto const& p : b_to_a) {
+      a->InjectRemoteBatch(p.gen, p.base_frame, p.count, p.inputs.data(), p.local_frame);
+    }
+    a_to_b.clear();
+    b_to_a.clear();
+  }
+
+  REQUIRE(a_done);
+  REQUIRE(b_done);
+  REQUIRE(a->State() == kStateGameEnded);
+  REQUIRE(b->State() == kStateGameEnded);
+
+  // The game-phase simulation must never have run: the Game was never
+  // started, and Game::processFrame is the only place cycles advances.
+  REQUIRE(a->game.cycles == 0);
+  REQUIRE(b->game.cycles == 0);
+
+  // No same-generation frame may carry different checksums on the two
+  // peers — that is exactly NetSession::onChecksum's desync condition.
+  for (auto const& sa : a_sums) {
+    for (auto const& sb : b_sums) {
+      if (sa.gen == sb.gen && sa.frame == sb.frame) {
+        INFO("gen=" << int(sa.gen) << " frame=" << sa.frame);
+        REQUIRE(sa.checksum == sb.checksum);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Selecting END MATCH from the pause menu during weapon selection desynced the game ("DESYNC AT FRAME n" on both peers).

`endMatch()` flips state to `StateGameEnded`, and `process()` routed `StateGameEnded` into `advanceSimulation()` unconditionally — running the game-phase sim on a `Game` that never went through `finishWeaponSelect` (no `startGame`, no `resetForGamePhase`, no generation bump). The peers reach that state ticks apart (END MATCH packet latency plus pause/resume skew), so they exchanged same-generation checksums computed from divergent never-started games and tripped the desync detector.

## Fix

- Gate `StateGameEnded` ticks in `process()` on a new `gamePhaseEntered_` flag, set where the game phase actually starts (`finishWeaponSelect` and the skip-weapon-selection path). Ending from weapon selection no longer simulates or emits checksums.
- Skip the end-of-match fade in that case — there is no started game to draw during it.
- Route both peers to the **rematch screen** instead of the main menu: `GamePlayState` skips the stats screen (`gameTime` is 0, nothing to show) but keeps the session alive and enters `RematchState` directly, so the host can fix the level pick and both players can ready up. The main use case for ending during weapon selection is a wrong map. `PeerLeft`/Disconnect never reach `StateGameEnded` and still tear the session down as before.

## Testing

- New regression test in `test_rollback_weapsel.cpp`: two peers in weapon selection, one ends the match, the other receives it three ticks later; asserts both exit, `game.cycles` stays 0 (game sim never ran), and no same-generation frame carries differing checksums. Fails against the old code with `cycles == 34`.
- Full ctest suite passes (154/154), including `test_determinism`, `test_rollback_correctness`, `test_rollback_desync`.
- Headless smoke-launch of the installed binary runs clean.
- Not covered by automation: the UI routing in `GamePlayState` (host picks new level → ready up → round 2) — worth one manual two-instance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)