### PR TITLE
Arbitrary map sizes PR 1: replace hardcoded 504×350 dims with dynamic reads

### DIFF
--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -1,0 +1,172 @@
+# Plan: Arbitrary Map Sizes + Zooming Spectator Viewport + Configurable Videotool Resolution
+
+**Complexity**: Large (5 sequenced, independently-mergeable PRs)
+
+## Summary
+
+Today the game only supports 504×350 maps and the spectator window assumes the
+whole map fits on screen. This plan adds: (1) arbitrary map sizes up to
+4096×4096 via a new sized on-disk level format (legacy headerless 504×350 still
+loads), (2) a spectator viewport that auto-zooms to keep both worms visible on
+large maps, and (3) a selectable output resolution for the videotool. Work is
+split into 5 PRs, each of which leaves master green and the game playable.
+
+## Decisions
+
+- **D1** — New magic-prefixed on-disk format for sized maps; legacy headerless
+  504×350 files still load.
+- **D2** — Maximum map size **4096×4096** (matches the existing net wire-transfer cap).
+- **D3** — Spectator zoom via **render-to-scratch + area-downscale** (the world
+  pass renders 1:1 into a scratch bitmap, then downscales into the spectator
+  rect; HUD overlays draw on top at native resolution).
+- **D4** — **Sequenced PRs, each independently mergeable.**
+- **D5** — The 4096² test level is **generated on demand** (a tools script +
+  CMake/test fixture), NOT committed to git (~117 MB raw).
+- Random map-size option lives in **MATCH SETUP** (`SettingsMenu`).
+- `docs/modern-level-authoring.md`, the `tools/` level scripts, and a new 4096²
+  test-level generator all get updated.
+
+## Key architecture findings
+
+The **simulation core is already size-agnostic**: `Level` stores layers as
+`std::vector`, `Resize(w,h)` is dynamic, and collision, spawning, blitting
+(`gfx/blit.cpp`), state-hashing, cereal + fast snapshots, replay level capture,
+and the network level transfer (already validates `0 < w,h ≤ 4096` and
+`Resize`s) all read `level.width/height` dynamically. `Viewport` already takes
+`(levwidth, levheight)`.
+
+Blockers (hardcoded 504×350 or fixed-size structures):
+
+| Blocker | Location | Issue |
+|---|---|---|
+| `Resize(504, 350)` | `level.cpp:214` (`load`), `level.cpp:12` (gen) | size baked in |
+| Legacy `.lev` has no size header | `level.cpp:222` reads `w*h` before knowing size | can't encode other sizes on disk |
+| Hardcoded viewport ctor | `localController.cpp:46-53`, `rollbackController.cpp:34-62`, `replayController.cpp:145-154`, `replay_to_video.cpp:60` | literal `504, 350` + `Rect(0,0,504+68,350)` |
+| Fixed AI arrays | `ai/dijkstra.hpp:153-162` (`kFullWidth/Height`, `cells[]`), `ai/predictive_ai.hpp:230-237` (`CellState[17][12]`) | out-of-bounds / overflow on large maps |
+| Fixed stats heatmaps | `stats_recorder.hpp:58-104` (`504/2,350/2,504,350`) | hardcoded dims |
+| No world→buffer downscale | `spectatorviewport.cpp:33-38` maps world→buffer 1:1; `ScaleDraw` (`blit.cpp`) only integer-*upscales* | zoom-out is new capability |
+| Videotool fixed dims | `replay_to_video.cpp:28-34,66-67` (640×400 render, 1280×720 out), `video_recorder.c:327` (sws scaler input hardcoded 640×400 — latent 320×200 bug) | no resolution selection |
+
+**Determinism note:** rendering/zoom never runs in `processFrame`, and the
+spectator view is local display only (not checksummed) — so zoom math may use
+floats freely without touching the fixed-point determinism contract.
+
+## Patterns to mirror (verified in-tree)
+
+| Concern | Source | Pattern |
+|---|---|---|
+| Numeric match-setup setting | `gfx.cpp:1129` | `new IntegerBehavior(common, gfx.settings->field, min, max, step)` |
+| Menu item registration | `gfx.cpp:457` + `gfx.hpp:72-98` enum | `AddItem(MenuItem(...))` + `kSi*` enum + `GetItemBehavior` case |
+| Settings field + persistence | `settings.hpp:71-88`, `cereal_types.hpp:161-189` | field default + `make_nvp` + `kConfigVersion` bump (→ v5) |
+| On-disk format extension | `level.cpp:230-332` | magic-probe blocks (`POWERLEVEL`/`MODERNLV`), `TryGet` tolerant reads |
+| Downscale blit | `blit.cpp` `ScaleDraw` | existing integer-upscale routine to extend with downscale |
+| Videotool CLI args | `tools_main.cpp:42-62` | `argv[i][1]` switch |
+
+## PRs
+
+### PR 1 — Foundation: make hardcoded 504×350 read `level.width/height` (pure refactor)
+No behavior change; level still loads at 504×350. De-risks everything downstream.
+- **Viewport construction**: replace literal `504, 350` in the controllers and
+  `replay_to_video.cpp:60` with `level.width/height`; decouple spectator `Rect`
+  from map size.
+- **AI**: `ai/dijkstra.hpp:153-162` (`kFullWidth/Height` statics + fixed
+  `cells[]`) → dynamic dims + heap buffer; `ai/predictive_ai.hpp:230-237`
+  (`CellState[17][12]`) → dynamic grid.
+- **Stats**: `stats_recorder.hpp:58-104` heatmaps → derive from `level.width/height`.
+- **Mergeable because**: everything still runs at 504×350; identical behavior.
+- **Validate**: full ctest + `test_determinism`/`test_rollback_*`; smoke-launch; clang-format/tidy diff.
+
+### PR 2 — New sized on-disk format + tools + 4096² test level
+- **Format**: file beginning with a distinctive 8-byte magic (e.g. `OLLEVEL2`)
+  + `version:u8` + `width:u16` + `height:u16`, then the **existing body layout**
+  (material bytes → optional `POWERLEVEL` → optional `MODERNLV`…) so
+  encoder/decoder code is shared. No magic ⇒ legacy 504×350 path
+  (`level.cpp:213-344`). Enforce the **D2 4096² cap** with a clear error on load.
+- **`load`**: replace `Resize(504, 350)` (`level.cpp:214`) with header-driven
+  sizing on the new path.
+- **Tools**: parametrize `tools/lev_gen.py` (`LEVEL_W/H`, line 26),
+  `tools/lev_extract.py` (line 33), `tools/gen_stage4_anim.py` (lines 19-20) to
+  read/emit the header and arbitrary sizes.
+- **Test level (D5)**: `tools/gen_large_test.py` produces the 4096² modern level
+  modeled on `modern_test.lev`, **generated on demand** (CMake/test fixture or
+  documented one-liner) — not committed.
+- **Doc**: update `docs/modern-level-authoring.md` — remove the fixed-504×350
+  assumption, document the sized header, the 4096² max, and the larger-level
+  workflow.
+- **Mergeable because**: legacy files unchanged; random gen still 504×350; new
+  files additionally supported.
+- **Validate**: round-trip several sizes through gen/extract; load a stock legacy
+  `.lev` and a new-format file; load the 4096² level and smoke-launch on it
+  (exercises PR1's dynamic AI/stats); `test_level_display`; `test_paths`.
+
+### PR 3 — Random map size in MATCH SETUP
+- **Settings**: add `int32_t random_map_width{504}; int32_t random_map_height{350};`
+  (`settings.hpp`), serialize in `SerializeSettingsScalars`
+  (`cereal_types.hpp:189`), bump `kConfigVersion` **4 → 5** with comment.
+- **Menu**: `kSiRandomMapWidth/Height` enum (`gfx.hpp`), `AddItem` near `kSiLevel`
+  (`gfx.cpp:458`), `IntegerBehavior(common, …, 64, 4096, step)` cases in
+  `GetItemBehavior`. Consider gating visibility on `random_level` (mirror
+  `LevelSelectBehavior` interplay).
+- **Generation**: feed the setting into `GenerateDirtPattern`/`GenerateRandom`
+  (`level.cpp:12`) instead of hardcoded `Resize(504, 350)`.
+- **Mergeable because**: defaults reproduce today's 504×350; older configs
+  missing the fields fall back to defaults (existing v3-comment pattern).
+- **Validate**: generate + smoke-launch a non-default random size; round-trip
+  config; determinism suite.
+
+### PR 4 — Zooming spectator viewport (render-to-scratch + downscale)
+- Split `SpectatorViewport::Draw` (`spectatorviewport.cpp:33`) into a **world
+  pass** (level + objects + worm sprites at 1:1 into a scratch bitmap sized to
+  the visible region) and an **HUD overlay pass** (health bars/names/weapon
+  lists/banner at native res on top, using the existing `kMultiplier` layout).
+- Compute zoom each frame from both worms' bounding box (+ margin), clamp to map
+  bounds and to **1× max** (never zoom in past native). Area-downscale scratch →
+  spectator rect (extend `ScaleDraw`). Keep `Process()` clamp logic; floats are
+  fine (display-only).
+- Make HUD `stats_x`/`+68` offsets resolution-relative.
+- **Mergeable because**: on 504×350 maps the bounding box fits, zoom stays 1×,
+  output is visually unchanged.
+- **Validate**: smoke-launch hotseat on the 4096² level, drive worms far apart,
+  confirm both stay visible and HUD stays crisp at 1×.
+
+### PR 5 — Configurable videotool output resolution
+- **`tools_main.cpp`**: add `-w/-h` (or `--res WxH`) parsing alongside `-d/-s/-r`.
+- **`replay_to_video.{hpp,cpp}`**: thread output dims through; remove hardcoded
+  `kW=1280/kH=720` (lines 66-67); set spectator render resolution from the
+  requested output.
+- **`video_recorder.c:327`**: make `sws_getContext` input size dynamic (also
+  fixes the latent 320×200 bug hardcoded to 640×400).
+- **Mergeable because**: absent the flags it defaults to today's behavior.
+- **Validate**: render a replay at 1280×720 and 1920×1080, spectator + normal
+  mode; confirm output dimensions and no scaler mismatch.
+
+## Validation (every PR)
+
+```bash
+cmake --preset linux-x64 -DOPENLIERO_BUILD_TESTS=ON -DOPENLIERO_BUILD_VIDEOTOOL=ON
+cmake --build build/linux-x64 --config Release
+ctest --test-dir build/linux-x64 --build-config Release --output-on-failure
+./build/linux-x64/Release/test_determinism && ./build/linux-x64/Release/test_rollback_correctness && ./build/linux-x64/Release/test_rollback_desync
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/openliero
+scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
+```
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| 4096² test asset bloats git (~117 MB) | High | D5 — generate on demand |
+| AI/stats overflow on large maps | High pre-PR1 | PR1 makes them dynamic before any large map can load |
+| New magic collides with legacy material bytes | Low | 8-byte distinctive magic at file start; legacy path unchanged |
+| Net play with mismatched sizes | Low | Wire transfer already sends + validates w/h |
+| Memory at 4096² (~117 MB layers + AI) | Medium | D2 cap; fail loudly past 4096; document cost |
+| Determinism regressions from PR1/PR3 sim touch | Medium | `test_determinism`/`test_rollback_*` on every PR |
+
+## Acceptance
+
+- [ ] PR1: all 504×350 hardcodes read `level.width/height`; behavior unchanged; suites green.
+- [ ] PR2: new sized format loads/saves; legacy files still load; 4096² level generates on demand; tools + doc updated.
+- [ ] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
+- [ ] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged.
+- [ ] PR5: videotool output resolution selectable; scaler input dynamic.
+- [ ] Determinism/rollback suites + format checks pass on every PR.

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -64,7 +64,7 @@ floats freely without touching the fixed-point determinism contract.
 
 ## PRs
 
-### PR 1 — Foundation: make hardcoded 504×350 read `level.width/height` (pure refactor)
+### PR 1 — Foundation: make hardcoded 504×350 read `level.width/height` (pure refactor) — **DONE** ([#103](https://github.com/openliero/openliero/pull/103))
 No behavior change; level still loads at 504×350. De-risks everything downstream.
 - **Viewport construction**: replace literal `504, 350` in the controllers and
   `replay_to_video.cpp:60` with `level.width/height`; decouple spectator `Rect`
@@ -164,7 +164,7 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 
 ## Acceptance
 
-- [ ] PR1: all 504×350 hardcodes read `level.width/height`; behavior unchanged; suites green.
+- [x] PR1: all 504×350 hardcodes read `level.width/height`; behavior unchanged; suites green.
 - [ ] PR2: new sized format loads/saves; legacy files still load; 4096² level generates on demand; tools + doc updated.
 - [ ] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
 - [ ] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,13 @@ if(OPENLIERO_BUILD_TESTS)
     DISCOVERY_MODE PRE_TEST
   )
 
+  add_executable(test_map_size_foundation src/tests/test_map_size_foundation.cpp)
+  target_link_libraries(test_map_size_foundation PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_map_size_foundation
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DISCOVERY_MODE PRE_TEST
+  )
+
   # Headless replay frame hasher (not a Catch2 test): prints per-frame
   # hashes of the composed screen so renderer refactors can be verified
   # pixel-identical against a baseline build. See src/tests/framehash_main.cpp.

--- a/src/game/ai/dijkstra.cpp
+++ b/src/game/ai/dijkstra.cpp
@@ -1,12 +1,5 @@
 #include "dijkstra.hpp"
 
-// NOLINTNEXTLINE(cppcoreguidelines-interfaces-global-init) — DijkstraLevel::kPitch is a compile-time constant, no SIOF risk.
-int const kLevelCellOffsets[8] = {-1 * DijkstraLevel::kPitch + 0, 1 * DijkstraLevel::kPitch + 0,
-                                  0 * DijkstraLevel::kPitch - 1,  0 * DijkstraLevel::kPitch + 1,
-
-                                  -1 * DijkstraLevel::kPitch - 1, -1 * DijkstraLevel::kPitch + 1,
-                                  1 * DijkstraLevel::kPitch - 1,  1 * DijkstraLevel::kPitch + 1};
-
 int const kLevelCellCosts[8] = {256, 256, 256, 256,
 
                                 362, 362, 362, 362};

--- a/src/game/ai/dijkstra.hpp
+++ b/src/game/ai/dijkstra.hpp
@@ -117,13 +117,14 @@ struct LevelCell : PathNode {
   int cost;  // 1 = air, 2 = dirt, -1 = rock
 };
 
-extern int const kLevelCellOffsets[8];
 extern int const kLevelCellCosts[8];
 
 struct LevelCellSucc {
-  void Begin(LevelCell* c) {
+  explicit LevelCellSucc(int const* off) : offsets(off) {}
+
+  void Begin(LevelCell* c_init) {
     i = -1;
-    this->c = c;
+    c = c_init;
   }
 
   bool Advance() {
@@ -137,29 +138,27 @@ struct LevelCellSucc {
     return true;
   }
 
-  LevelCell* Node() const { return &c[kLevelCellOffsets[i]]; }
+  LevelCell* Node() const { return c + offsets[i]; }
 
   int Cost() const {
-    LevelCell const* n = c + kLevelCellOffsets[i];
+    LevelCell const* n = c + offsets[i];
     return kLevelCellCosts[i] * n->cost;
   }
 
+  int const* offsets;
   LevelCell* c;
   LevelCell* target;
   int i;
 };
 
 struct DijkstraLevel : DijkstraState<LevelCell*, DijkstraLevel> {
-  static int const kFullWidth = 504;
-  static int const kFullHeight = 350;
-
   static int const kFactor = 4;
 
-  static int const kWidth = kFullWidth / kFactor;
-  static int const kPitch = kWidth + 2;
-  static int const kHeight = kFullHeight / kFactor;
+  int full_width{0}, full_height{0};
+  int width{0}, pitch{0}, height{0};
+  int cell_offsets[8]{};
 
-  LevelCell cells[(kWidth + 2) * (kHeight + 2)];
+  std::vector<LevelCell> cells;
 
   static path_node_t* GetNode(LevelCell* c) { return c; }
 
@@ -168,42 +167,61 @@ struct DijkstraLevel : DijkstraState<LevelCell*, DijkstraLevel> {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
   static LevelCell* GetNodeId(path_node_t* c) { return static_cast<LevelCell*>(c); }
 
-  LevelCell* Cell(int x, int y) { return &cells[(y + 1) * kPitch + x + 1]; }
+  LevelCell* Cell(int x, int y) { return &cells[(y + 1) * pitch + x + 1]; }
 
   IVec2 Coords(LevelCell* c) {
-    int const kOffset = static_cast<int>(c - cells);
-    int const kY = kOffset / kPitch;
-    int const kX = kOffset % kPitch;
+    int const kOffset = static_cast<int>(c - cells.data());
+    int const kY = kOffset / pitch;
+    int const kX = kOffset % pitch;
     return {kX - 1, kY - 1};
   }
 
   IVec2 CoordsLevel(LevelCell* c) { return Coords(c) * kFactor + IVec2(kFactor / 2, kFactor / 2); }
 
   LevelCell* CellFromPx(int x, int y) {
-    x = std::min(std::max(x, 0), kFullWidth - 1);
-    y = std::min(std::max(y, 0), kFullHeight - 1);
+    x = std::min(std::max(x, 0), full_width - 1);
+    y = std::min(std::max(y, 0), full_height - 1);
     x /= kFactor;
     y /= kFactor;
     return Cell(x, y);
   }
 
+  LevelCellSucc MakeSucc() const { return LevelCellSucc(cell_offsets); }
+
   void Build(Level& level, Common& common) {
+    full_width = level.width;
+    full_height = level.height;
+    width = full_width / kFactor;
+    pitch = width + 2;
+    height = full_height / kFactor;
+
+    cell_offsets[0] = -pitch;
+    cell_offsets[1] = pitch;
+    cell_offsets[2] = -1;
+    cell_offsets[3] = 1;
+    cell_offsets[4] = -pitch - 1;
+    cell_offsets[5] = -pitch + 1;
+    cell_offsets[6] = pitch - 1;
+    cell_offsets[7] = pitch + 1;
+
+    cells.assign((width + 2) * (height + 2), LevelCell{});
+
     this->Reset();
 
     Material const* mat = common.materials;
 
-    for (int x = 0; x < kWidth + 2; ++x) {
+    for (int x = 0; x < width + 2; ++x) {
       cells[x].cost = -1;
-      cells[(kHeight + 1) * kPitch + x].cost = -1;
+      cells[(height + 1) * pitch + x].cost = -1;
     }
 
-    for (int y = 0; y < kHeight + 2; ++y) {
-      cells[y * kPitch].cost = -1;
-      cells[y * kPitch + (kWidth + 1)].cost = -1;
+    for (int y = 0; y < height + 2; ++y) {
+      cells[y * pitch].cost = -1;
+      cells[y * pitch + (width + 1)].cost = -1;
     }
 
-    for (int ly = 0; ly < kHeight; ++ly) {
-      for (int lx = 0; lx < kWidth; ++lx) {
+    for (int ly = 0; ly < height; ++ly) {
+      for (int lx = 0; lx < width; ++lx) {
         int cost = 1;
 
         for (int cy = ly * kFactor; cy < (ly + 1) * kFactor; ++cy) {

--- a/src/game/ai/predictive_ai.cpp
+++ b/src/game/ai/predictive_ai.cpp
@@ -256,7 +256,7 @@ static double Psigmoid(double x) { return (Sigmoid(x) - 0.5) * 2.0; }
 
 LevelCell* AiContext::PathFind(int x, int y) {
   auto* cell = dlevel.CellFromPx(x, y);
-  bool const kPath = dlevel.Run([=] { return cell->state == PathNode::kClosed; }, LevelCellSucc());
+  bool const kPath = dlevel.Run([=] { return cell->state == PathNode::kClosed; }, dlevel.MakeSucc());
   return kPath ? cell : nullptr;
 }
 
@@ -289,7 +289,7 @@ static double EvaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& /*
   if (me_org->steerable_count == 1) {
     auto* missile_cell = ai.dlevel.CellFromPx(me->steerable_sum_x, me->steerable_sum_y);
     bool const kMissilePath =
-        ai.dlevel.Run([=] { return missile_cell->state == PathNode::kClosed; }, LevelCellSucc());
+        ai.dlevel.Run([=] { return missile_cell->state == PathNode::kClosed; }, ai.dlevel.MakeSucc());
 
     if (kMissilePath && worm_cell && missile_cell->g < worm_cell->g) {
       double const kCloser = static_cast<double>(worm_cell->g) - missile_cell->g;
@@ -872,6 +872,8 @@ TransModel::TransModel(Weights& weights, bool /*testing*/) {
 }
 
 void AiContext::Update(FollowAI& /*ai*/, Worm& worm) {
+  EnsureState();
+
   double presence = 0;
   double damage = 0;
 
@@ -887,7 +889,7 @@ void AiContext::Update(FollowAI& /*ai*/, Worm& worm) {
 
   IncArea(worm.pos.x, worm.pos.y, presence, damage);
 
-  for (int y = 0; y < kHeight; ++y) {
+  for (int y = 0; y < state_height; ++y) {
     for (auto& x : state) {
       x[y].presence = std::max(x[y].presence - 0.5 / (70.0 * 5.0), 0.0);
     }

--- a/src/game/ai/predictive_ai.cpp
+++ b/src/game/ai/predictive_ai.cpp
@@ -256,7 +256,8 @@ static double Psigmoid(double x) { return (Sigmoid(x) - 0.5) * 2.0; }
 
 LevelCell* AiContext::PathFind(int x, int y) {
   auto* cell = dlevel.CellFromPx(x, y);
-  bool const kPath = dlevel.Run([=] { return cell->state == PathNode::kClosed; }, dlevel.MakeSucc());
+  bool const kPath =
+      dlevel.Run([=] { return cell->state == PathNode::kClosed; }, dlevel.MakeSucc());
   return kPath ? cell : nullptr;
 }
 
@@ -288,8 +289,8 @@ static double EvaluateState(FollowAI& ai, Worm* me, Game& game, InputContext& /*
 
   if (me_org->steerable_count == 1) {
     auto* missile_cell = ai.dlevel.CellFromPx(me->steerable_sum_x, me->steerable_sum_y);
-    bool const kMissilePath =
-        ai.dlevel.Run([=] { return missile_cell->state == PathNode::kClosed; }, ai.dlevel.MakeSucc());
+    bool const kMissilePath = ai.dlevel.Run(
+        [=] { return missile_cell->state == PathNode::kClosed; }, ai.dlevel.MakeSucc());
 
     if (kMissilePath && worm_cell && missile_cell->g < worm_cell->g) {
       double const kCloser = static_cast<double>(worm_cell->g) - missile_cell->g;

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -278,8 +278,8 @@ struct AiContext {
     int wx = Ftoi(fx) >> 5;
     int wy = Ftoi(fy) >> 5;
 
-    wx = std::max(std::min(wx, state_width), 0);
-    wy = std::max(std::min(wy, state_height), 0);
+    wx = std::max(std::min(wx, state_width - 1), 0);
+    wy = std::max(std::min(wy, state_height - 1), 0);
 
     return state[wx][wy];
   }

--- a/src/game/ai/predictive_ai.hpp
+++ b/src/game/ai/predictive_ai.hpp
@@ -227,17 +227,28 @@ struct CellState {
 struct FollowAI;
 
 struct AiContext {
-  static int const kWidth = (504 + 31) >> 5;
-  static int const kHeight = (350 + 31) >> 5;
-
   AiContext() = default;
 
   DijkstraLevel dlevel;
 
-  CellState state[kWidth][kHeight];
+  std::vector<std::vector<CellState>> state;
+  int state_width{0}, state_height{0};
 
   int prev_hp{0};
   double max_damage{0}, max_presence{0};
+
+  void EnsureState() {
+    if (dlevel.full_width == 0 || dlevel.full_height == 0) {
+      return;
+    }
+    int const kW = (dlevel.full_width + 31) >> 5;
+    int const kH = (dlevel.full_height + 31) >> 5;
+    if (state_width != kW || state_height != kH) {
+      state_width = kW;
+      state_height = kH;
+      state.assign(kW, std::vector<CellState>(kH));
+    }
+  }
 
   void IncArea(int fx, int fy, double presence, double damage) {
     int const kWx = Ftoi(fx) >> 5;
@@ -245,7 +256,7 @@ struct AiContext {
 
     for (int y = kWy - 1; y <= kWy + 1; ++y) {
       for (int x = kWx - 1; x <= kWx + 1; ++x) {
-        if (y >= 0 && y < kHeight && x >= 0 && x < kWidth) {
+        if (y >= 0 && y < state_height && x >= 0 && x < state_width) {
           double d = 1.0;
           if (x != kWx) {
             d *= 0.5;
@@ -267,8 +278,8 @@ struct AiContext {
     int wx = Ftoi(fx) >> 5;
     int wy = Ftoi(fy) >> 5;
 
-    wx = std::max(std::min(wx, kWidth), 0);
-    wy = std::max(std::min(wy, kHeight), 0);
+    wx = std::max(std::min(wx, state_width), 0);
+    wy = std::max(std::min(wy, state_height), 0);
 
     return state[wx][wy];
   }

--- a/src/game/controller/localController.cpp
+++ b/src/game/controller/localController.cpp
@@ -43,14 +43,14 @@ LocalController::LocalController(const std::shared_ptr<Common>& common,
   worm2->stats_x = 218;
   worm2->ai = CreateAi(worm2->settings->controller, *worm2, *settings);
 
-  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), worm1->index, 504, 350));
-  game.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), worm2->index, 504, 350));
+  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), worm1->index));
+  game.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), worm2->index));
 
   game.AddWorm(worm1);
   game.AddWorm(worm2);
 
   // +68 on x to align the viewport in the middle
-  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
 }
 
 LocalController::~LocalController() { EndRecord(); }

--- a/src/game/controller/replayController.cpp
+++ b/src/game/controller/replayController.cpp
@@ -142,16 +142,15 @@ void ReplayController::ChangeState(GameState new_state) {
 
     // spectator viewport is always full size
     // +68 on x to align the viewport in the middle
-    game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+    game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
     if (gfx.settings->single_screen_replay) {
       // on single screen replay, use the spectator viewport for the
       // main screen as well
       // we can't use the same object, as the vector's clean function will delete them
-      game->AddViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+      game->AddViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
     } else {
-      game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
-      game->AddViewport(
-          new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
+      game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index));
+      game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index));
     }
     game->StartGame();
     initial_game = std::make_unique<Game>(*game);

--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -31,8 +31,8 @@ static void ConfigureGameSlots(Game& g, std::array<std::shared_ptr<WormSettings>
     worm->stats_x = idx == 0 ? 0 : 218;
     g.AddWorm(worm);
   }
-  g.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  g.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), 1, 504, 350));
+  g.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+  g.AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), 1));
 }
 
 RollbackController::RollbackController(const std::shared_ptr<Common>& common,
@@ -59,7 +59,7 @@ RollbackController::RollbackController(const std::shared_ptr<Common>& common,
                                  : settings->worm_settings[idx];
   }
   ConfigureGameSlots(game, ws);
-  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
 }
 
 RollbackController::~RollbackController() = default;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -510,6 +510,7 @@ void Game::SpawnZone() {
 void Game::StartGame() {
   sound_player->Play(common->sound_hook[SoundBegin]);
   bobjects.Resize(settings->blood_particle_max);
+  stats_recorder->Reset(level.width, level.height);
 
   if (settings->game_mode == Settings::kGmHoldazone) {
     SpawnZone();

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -11,6 +11,9 @@
 #include "text.hpp"
 
 void SpectatorViewport::Process(Game& game) {
+  max_x = game.level.width - rect.Width();
+  max_y = game.level.height - rect.Height();
+
   int const kRealShake = Ftoi(shake);
 
   // FIXME this is a bit broken

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -10,8 +10,7 @@
 struct Renderer;
 
 struct SpectatorViewport : Viewport {
-  SpectatorViewport(Rect rect, int levwidth, int levheight)
-      : Viewport(rect, 0, levwidth, levheight) {}
+  explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 
   void Draw(Game& game, Renderer& renderer, GameState state, bool is_replay) override;
   void Process(Game& game) override;

--- a/src/game/stats_recorder.cpp
+++ b/src/game/stats_recorder.cpp
@@ -26,6 +26,8 @@ void StatsRecorder::Tick(Game& game) {}
 
 void StatsRecorder::AiProcessTime(Worm* worm, std::chrono::nanoseconds time) {}
 
+void StatsRecorder::Reset(int /*lev_w*/, int /*lev_h*/) {}
+
 void NormalStatsRecorder::DamagePotential(Worm* by_worm, WormWeapon* weapon, int hp) {
   if (speculative) {
     return;
@@ -196,4 +198,11 @@ void NormalStatsRecorder::AiProcessTime(Worm* worm, std::chrono::nanoseconds tim
   }
   WormStats& w = worms[worm->index];
   w.ai_process_time += time;
+}
+
+void NormalStatsRecorder::Reset(int lev_w, int lev_h) {
+  presence = Heatmap(lev_w / 2, lev_h / 2, lev_w, lev_h);
+  for (auto& w : worms) {
+    w.Reset(lev_w, lev_h);
+  }
 }

--- a/src/game/stats_recorder.hpp
+++ b/src/game/stats_recorder.hpp
@@ -24,6 +24,8 @@ struct StatsRecorder {
 
   virtual void AiProcessTime(Worm* worm, std::chrono::nanoseconds time);
 
+  virtual void Reset(int lev_w, int lev_h);
+
   // When true, all recording is suppressed. Set during predicted /
   // resim frames to avoid double-counting.
   bool speculative = false;
@@ -62,6 +64,11 @@ struct WormStats {
     for (int i = 0; i < 40; ++i) {
       weapons[i].index = i;
     }
+  }
+
+  void Reset(int lev_w, int lev_h) {
+    damage_hm = Heatmap(lev_w / 2, lev_h / 2, lev_w, lev_h);
+    presence = Heatmap(lev_w / 2, lev_h / 2, lev_w, lev_h);
   }
 
   std::vector<std::pair<int, int> > life_spans;
@@ -128,4 +135,5 @@ struct NormalStatsRecorder : StatsRecorder {
 
   void Finish(Game& game) override;
   void AiProcessTime(Worm* worm, std::chrono::nanoseconds time) override;
+  void Reset(int lev_w, int lev_h) override;
 };

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -20,6 +20,9 @@ struct PreserveClipRect {
 };
 
 void Viewport::Process(Game& game) {
+  max_x = game.level.width - rect.Width();
+  max_y = game.level.height - rect.Height();
+
   Worm const& worm = *game.WormByIdx(worm_idx);
 
   if (worm.killed_timer <= 0) {

--- a/src/game/viewport.hpp
+++ b/src/game/viewport.hpp
@@ -9,9 +9,9 @@
 struct Renderer;
 
 struct Viewport {
-  Viewport(Rect rect, int worm_idx, int levwidth, int levheight)
-      : max_x(levwidth - rect.Width()),
-        max_y(levheight - rect.Height()),
+  Viewport(Rect rect, int worm_idx)
+      : max_x(0),
+        max_y(0),
         center_x(rect.Width() >> 1),
         center_y(rect.Height() >> 1),
         x(0),

--- a/src/tests/framehash_main.cpp
+++ b/src/tests/framehash_main.cpp
@@ -87,12 +87,12 @@ int main(int argc, char* argv[]) try {
     game->worms[0]->stats_x = 0;
     game->worms[1]->stats_x = 218;
   }
-  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
+  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
   if (!game->worms.empty()) {
-    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index));
   }
   if (game->worms.size() >= 2) {
-    game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
+    game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index));
   }
   game->StartGame();
   game->Focus(renderer);

--- a/src/tests/test_determinism.cpp
+++ b/src/tests/test_determinism.cpp
@@ -63,10 +63,10 @@ struct DualGameFixture {
     }
 
     // Add viewports (needed for processFrame's viewport logic)
-    game_a->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game_a->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-    game_b->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game_b->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_a->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game_a->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
+    game_b->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game_b->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
     // Generate levels with the same RNG state
     game_a->level.GenerateFromSettings(*common, *settings, game_a->rand);
@@ -191,10 +191,10 @@ TEST_CASE("Same inputs produce same state regardless of construction order", "[d
     game2.AddWorm(w2);
   }
 
-  game1.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game1.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-  game2.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game2.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+  game1.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+  game1.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
+  game2.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+  game2.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
   game1.level.GenerateFromSettings(*common, *settings, game1.rand);
   game2.level.GenerateFromSettings(*common, *settings, game2.rand);
@@ -280,10 +280,10 @@ TEST_CASE("Death and respawn determinism fuzz", "[determinism][death]") {
       game_b.AddWorm(w_b);
     }
 
-    game_a.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game_a.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
-    game_b.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game_b.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game_a.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game_a.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
+    game_b.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game_b.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
     game_a.level.GenerateFromSettings(*common, *settings, game_a.rand);
     game_b.level.GenerateFromSettings(*common, *settings, game_b.rand);

--- a/src/tests/test_map_size_foundation.cpp
+++ b/src/tests/test_map_size_foundation.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+#include "ai/dijkstra.hpp"
+#include "common.hpp"
+#include "level.hpp"
+#include "math.hpp"
+
+static void FillBackground(Level& level, Common& common) {
+  for (int y = 0; y < level.height; ++y) {
+    for (int x = 0; x < level.width; ++x) {
+      level.SetPixel(x, y, 0, common);
+    }
+  }
+}
+
+TEST_CASE("DijkstraLevel CellFromPx clamps to actual level bounds, not hardcoded 504x350",
+          "[map_size]") {
+  PrecomputeTables();
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(FsNode("data") / "TC" / "openliero");
+  common->load(kTcRoot);
+
+  Level level(*common);
+  level.Resize(252, 175);
+  FillBackground(level, *common);
+
+  DijkstraLevel dlevel;
+  dlevel.Build(level, *common);
+
+  // Pixel far outside the 252x175 level must clamp to within level bounds.
+  // Before PR1: CellFromPx clamps to kFullWidth-1=503, kFullHeight-1=349
+  // (hardcoded), so CoordsLevel returns (502, 350) — both outside 252x175.
+  LevelCell* cell = dlevel.CellFromPx(9999, 9999);
+  IVec2 coords = dlevel.CoordsLevel(cell);
+
+  REQUIRE(coords.x < 252);
+  REQUIRE(coords.y < 175);
+}
+
+TEST_CASE("DijkstraLevel CellFromPx works correctly at standard 504x350 size", "[map_size]") {
+  PrecomputeTables();
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(FsNode("data") / "TC" / "openliero");
+  common->load(kTcRoot);
+
+  Level level(*common);
+  level.Resize(504, 350);
+  FillBackground(level, *common);
+
+  DijkstraLevel dlevel;
+  dlevel.Build(level, *common);
+
+  // Interior position should round-trip through cell coords and stay in-bounds.
+  LevelCell* cell = dlevel.CellFromPx(200, 175);
+  IVec2 coords = dlevel.CoordsLevel(cell);
+
+  REQUIRE(coords.x < 504);
+  REQUIRE(coords.y < 350);
+}

--- a/src/tests/test_map_size_foundation.cpp
+++ b/src/tests/test_map_size_foundation.cpp
@@ -32,10 +32,10 @@ TEST_CASE("DijkstraLevel CellFromPx clamps to actual level bounds, not hardcoded
   // Before PR1: CellFromPx clamps to kFullWidth-1=503, kFullHeight-1=349
   // (hardcoded), so CoordsLevel returns (502, 350) — both outside 252x175.
   LevelCell* cell = dlevel.CellFromPx(9999, 9999);
-  IVec2 coords = dlevel.CoordsLevel(cell);
+  IVec2 const kCoords = dlevel.CoordsLevel(cell);
 
-  REQUIRE(coords.x < 252);
-  REQUIRE(coords.y < 175);
+  REQUIRE(kCoords.x < 252);
+  REQUIRE(kCoords.y < 175);
 }
 
 TEST_CASE("DijkstraLevel CellFromPx works correctly at standard 504x350 size", "[map_size]") {
@@ -53,8 +53,8 @@ TEST_CASE("DijkstraLevel CellFromPx works correctly at standard 504x350 size", "
 
   // Interior position should round-trip through cell coords and stay in-bounds.
   LevelCell* cell = dlevel.CellFromPx(200, 175);
-  IVec2 coords = dlevel.CoordsLevel(cell);
+  IVec2 const kCoords = dlevel.CoordsLevel(cell);
 
-  REQUIRE(coords.x < 504);
-  REQUIRE(coords.y < 350);
+  REQUIRE(kCoords.x < 504);
+  REQUIRE(kCoords.y < 350);
 }

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -58,8 +58,8 @@ struct GameRunner {
       game->AddWorm(w);
     }
 
-    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
     game->level.GenerateFromSettings(*common, *settings, game->rand);
     for (auto const& w : game->worms) {

--- a/src/tests/test_snapshot_roundtrip.cpp
+++ b/src/tests/test_snapshot_roundtrip.cpp
@@ -55,8 +55,8 @@ struct GameRunner {
       game->AddWorm(w);
     }
 
-    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
     game->level.GenerateFromSettings(*common, *settings, game->rand);
     for (auto const& w : game->worms) {

--- a/src/tests/test_speculative_suppression.cpp
+++ b/src/tests/test_speculative_suppression.cpp
@@ -97,8 +97,8 @@ struct Runner {
       w->stats_x = idx == 0 ? 0 : 218;
       game->AddWorm(w);
     }
-    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+    game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+    game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
     game->level.GenerateFromSettings(*common, *settings, game->rand);
     for (auto const& w : game->worms) {

--- a/src/tests/test_tc_load.cpp
+++ b/src/tests/test_tc_load.cpp
@@ -271,8 +271,8 @@ TEST_CASE("TC supports game initialization", "[tc_load]") {
     game.AddWorm(w);
   }
 
-  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0, 504, 350));
-  game.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1, 504, 350));
+  game.AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+  game.AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
 
   REQUIRE_NOTHROW(game.level.GenerateFromSettings(*common, *settings, game.rand));
 

--- a/src/video_tool/replay_to_video.cpp
+++ b/src/video_tool/replay_to_video.cpp
@@ -57,9 +57,9 @@ void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
 
   // spectator viewport is always full size
   // +68 on x to align the viewport in the middle
-  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350), 504, 350));
-  game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index, 504, 350));
-  game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index, 504, 350));
+  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+  game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index));
+  game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index));
   game->StartGame();
   game->Focus(renderer);
 


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Replaces all hardcoded `504`/`350` map dimensions with dynamic reads from `level.width`/`level.height`, laying the groundwork for arbitrary map sizes (see implementation plan in `.claude/plans/arbitrary-map-sizes.plan.md`).

- **`DijkstraLevel`** (`dijkstra.hpp/.cpp`): Remove static `kFullWidth/kFullHeight/kPitch/kWidth/kHeight` constants and fixed `cells[]` C-array. Replace with per-instance dims + `std::vector<LevelCell>` + per-instance `cell_offsets[8]` computed in `Build()`. Add `MakeSucc()` factory so callers get a `LevelCellSucc` with the correct offsets pointer.

- **`AiContext`** (`predictive_ai.hpp/.cpp`): Remove static `kWidth/kHeight` and `CellState state[kWidth][kHeight]`. Replace with `std::vector<std::vector<CellState>>` lazily sized by `EnsureState()` (called from `Update()`) using `dlevel.full_width/height` after `Build()`. Fix a pre-existing off-by-one in `Cell()`: clamp to `state_width-1`/`state_height-1`, not `state_width`/`state_height`.

- **`Viewport`/`SpectatorViewport`** (`viewport.hpp/.cpp`, `spectatorviewport.hpp/.cpp`): Remove `levwidth`/`levheight` constructor params. Compute `max_x`/`max_y` from `game.level.width/height` in `Process()` each frame, so viewports always track the actual level size regardless of when they were constructed.

- **`StatsRecorder`/`WormStats`** (`stats_recorder.hpp/.cpp`): Add `virtual Reset(int lev_w, int lev_h)` called from `Game::StartGame()` to size heatmaps to the actual generated level dimensions.

- All callers updated: `localController`, `rollbackController`, `replayController`, `replay_to_video`, `test_determinism`, `test_tc_load`, `test_snapshot_fast`, `test_snapshot_roundtrip`, `test_speculative_suppression`, `framehash_main`.

Level still loads at 504×350 — identical runtime behavior.

## Test plan

- [x] New Catch2 test `test_map_size_foundation`: `DijkstraLevel` with a 252×175 level correctly clamps `CellFromPx` to actual bounds (not hardcoded 504×350)
- [x] All determinism suites pass: `test_determinism`, `test_rollback_correctness`, `test_rollback_desync`
- [x] Smoke launch: `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/openliero` exits 124
- [x] clang-format and clang-tidy diff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)