### PR TITLE
Arbitrary map sizes PR4: zooming spectator viewport

### DIFF
--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -123,28 +123,32 @@ No behavior change; level still loads at 504×350. De-risks everything downstrea
   config version, TOML round-trip, backward-compat (missing keys fall back to
   504×350), and `GenerateFromSettings` at non-default and default dimensions.
 
-### PR 4 — Zooming spectator viewport (render-to-scratch + downscale)
-- Split `SpectatorViewport::Draw` (`spectatorviewport.cpp:33`) into a **world
-  pass** (level + objects + worm sprites at 1:1 into a scratch bitmap sized to
-  the visible region) and an **HUD overlay pass** (health bars/names/weapon
-  lists/banner at native res on top, using the existing `kMultiplier` layout).
-- Compute zoom each frame from both worms' bounding box (+ margin), clamp to map
-  bounds and to **1× max** (never zoom in past native). Area-downscale scratch →
-  spectator rect (extend `ScaleDraw`). Keep `Process()` clamp logic; floats are
-  fine (display-only).
-- Make HUD `stats_x`/`+68` offsets resolution-relative.
-- **Fix minimap scaling**: the minimap currently assumes 504×350 and overwrites
-  the lower-right corner of the HUD on non-standard map sizes. Scale the minimap
-  render to fit its allocated HUD rect regardless of level dimensions.
-- **Fix weapon-select spectator view**: the spectator view in the weapon-selection
-  screen does not handle non-standard map sizes correctly (layout breaks / clips).
-  Fix alongside the render-to-scratch restructuring since the same HUD/world
-  split resolves both issues naturally.
-- **Mergeable because**: on 504×350 maps the bounding box fits, zoom stays 1×,
-  output is visually unchanged.
-- **Validate**: smoke-launch hotseat on the 4096² level, drive worms far apart,
-  confirm both stay visible, HUD stays crisp at 1×, minimap renders within its
-  rect, and weapon-select spectator view is correct at non-standard sizes.
+### PR 4 — Zooming spectator viewport (render-to-scratch + downscale) — **DONE**
+
+Delivered on branch `arbitrary-map-sizes-pr4`:
+
+- `ScaleDrawArea` CPU box-filter downscale added to `gfx/blit.cpp`; 4 Catch2
+  cases in `src/tests/test_blit.cpp`.
+- `SpectatorViewport::Draw` split into world pass (scratch bitmap at visible
+  world region, 1:1 pixel scale) + `ScaleDrawArea` composite + HUD overlay at
+  native renderer resolution.
+- `SpectatorViewport::Process` computes zoom from both worms' bounding box +
+  60 px margin, clamped to 1.0× max (never zooms in past native pixels).
+- Controller viewport rects changed to `Rect(0, 0, 640, 400)`; the old
+  `504+68` centering hack removed.
+- `DrawMiniature` gains independent `step_x`/`step_y` axes (two-axis overload,
+  single-step wrapper kept for call-site compat) and is now `const`-qualified.
+  All minimap draw sites updated; `fileSelectorState.cpp` adds `FillRect` before
+  each draw to clear stale pixels when switching level previews.
+- Spectator window renders at native pixel resolution: `OnWindowResize` queries
+  `SDL_GetWindowSize` and calls `single_screen_renderer.SetRenderResolution(w,h)`;
+  `SpectatorViewport` caches `render_w`/`render_h` from the renderer so
+  `Process()` stays consistent without a `Renderer&` parameter. During
+  single-screen replay `single_screen_renderer` is reset to 640×400 (it doubles
+  as the main window primary renderer in that mode) and restored on game exit.
+
+> **Known limitation**: extreme CPU slowdown when worms move far apart and
+> zoom-out is triggered on a large native spectator window. Addressed in PR 7.
 
 ### PR 5 — Configurable videotool output resolution
 - **`tools_main.cpp`**: add `-w/-h` (or `--res WxH`) parsing alongside `-d/-s/-r`.
@@ -184,6 +188,88 @@ completely blowing out L3 cache every tick. Local play is unaffected (no rollbac
   `test_snapshot_fast` (add a dirty-tracking round-trip case); confirm online play
   on the 4096² level is no longer noticeably slower than local play.
 
+### PR 7 — Rendering pipeline optimisation
+
+With large maps and large native spectator windows, the rendering pipeline can
+exceed the 14 ms frame budget in several places.  This PR opens with a profiling
+pass to identify every hot path, then fixes them in priority order.  Any
+findings that don't fit the scope (e.g. a major bottleneck in simulation,
+networking, or palette handling) are noted as follow-on work rather than
+stretching this PR.
+
+#### Known bottleneck: spectator world pass
+
+`SpectatorViewport::Draw` allocates a scratch bitmap sized to the visible world
+region:
+
+```
+scratch_w = min(render_w / zoom, level.width)
+scratch_h = min(render_h / zoom, level.height)
+```
+
+Every draw pass (level tiles, shadow pass, all sprite types) iterates over
+every pixel of the scratch bitmap.  At a 1280×800 native window with zoom = 0.5
+the scratch is 2560×1600 — 16× more pixels than the old fixed 640×400 case.
+The subsequent `ScaleDrawArea` box-filter is also O(scratch_w × scratch_h), so
+total cost scales as `(render_w × render_h) / zoom²`.
+
+#### Tasks
+
+0. **Profile first.**
+   Run with a 4096² level and the spectator window at a large native size (e.g.
+   1280×800), worms at maximum separation to force full zoom-out.  Use
+   `perf record` / Instruments / Tracy (or even a manual frame timer around the
+   key call sites) to confirm which functions actually dominate.  Let the profile
+   guide which of the tasks below to tackle and in what order; skip tasks that
+   don't appear in the hot path.  If the profiler surfaces a major bottleneck
+   outside the rendering pipeline (simulation tick, palette rebuild, network
+   processing) open a separate follow-on issue rather than folding it here.
+
+1. **Cap the world-pass scratch at a fixed size and GPU-scale to the window.**
+   Render the world pass into a bitmap capped at `min(render_w, level.width) ×
+   min(render_h, level.height)` (i.e. never larger than the level itself,
+   regardless of zoom).  Upload it to an SDL streaming texture and let
+   `SDL_RenderTexture` with `SDL_SCALEMODE_LINEAR` (or `NEAREST` for the chunky
+   pixel look) scale it to the native window on the GPU.  Draw the HUD overlay
+   afterwards at native resolution via a second texture or directly into the
+   renderer surface.  This decouples world-pass cost from native window size
+   entirely and is expected to be the highest-ROI fix.
+
+2. **Frustum-cull the sprite and shadow passes.**
+   Currently every worm, wobject, nobject, bonus, and sobject is visited even
+   when off-screen after zoom-out.  Add a cheap AABB check against the visible
+   world rect `[x, x+scratch_w) × [y, y+scratch_h)` before each
+   `BlitImage` / `BlitShadowImage` call.  On large maps with many off-screen
+   objects this can cut the sprite-pass cost significantly.
+
+3. **SIMD / vectorised `ScaleDrawArea`.**
+   If the CPU downscale path is retained (e.g. for the videotool offline
+   render), the inner accumulation loop in `ScaleDrawArea` (`blit.cpp`) is a
+   natural auto-vectorisation candidate.  Only pursue this if tasks 1 and 2
+   leave a measurable remainder in the profile.
+
+4. **Cap minimum zoom.**
+   A configurable floor (e.g. 0.25×) below which the viewport stops zooming out
+   and pans to the midpoint instead gives a hard upper bound on scratch size
+   independent of worm separation.  Expose as a hidden-menu option.  This is a
+   UX trade-off rather than a pure optimisation, so treat it as optional and
+   decide based on playtest feedback.
+
+5. **Audit and fix any other hot paths found in step 0.**
+   Document findings and fixes here as they are discovered.
+
+#### Ordering
+
+Do step 0 first.  Steps 1 and 2 are independent; step 1 gives the larger
+speedup.  Steps 3 and 4 are conditional on profiling results.
+
+- **Mergeable because**: purely display-side; does not touch simulation, net
+  protocol, or on-disk format.
+- **Validate**: confirm frame time is within budget at 1280×800 and 1920×1080
+  with a 4096² level and worms at maximum separation.  Run `test_blit` to
+  confirm `ScaleDrawArea` correctness is unchanged.  Smoke-launch +
+  clang-format/tidy diff.
+
 ## Validation (every PR)
 
 ```bash
@@ -206,13 +292,15 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 | Memory at 4096² (~117 MB layers + AI) | Medium | D2 cap; fail loudly past 4096; document cost |
 | Determinism regressions from PR1/PR3 sim touch | Medium | `test_determinism`/`test_rollback_*` on every PR |
 | Rollback snapshot too large for online play on big maps | High (4096²) | PR6 — dirty-cell tracking; PR2 already fixed correctness |
+| Spectator world-pass cost O((W×H)/zoom²) on large native windows | High | PR7 — GPU-scale world pass; frustum cull sprites |
 
 ## Acceptance
 
 - [x] PR1: all 504×350 hardcodes read `level.width/height`; behavior unchanged; suites green.
 - [x] PR2: new sized format loads/saves; legacy files still load; 4096² level generates on demand; tools + doc updated.
 - [x] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
-- [ ] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes.
+- [x] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes; native-resolution spectator window.
 - [ ] PR5: videotool output resolution selectable; scaler input dynamic.
 - [ ] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
+- [ ] PR7: spectator viewport frame time within budget at ≥1280×800 with worms at maximum separation on a 4096² level.
 - [ ] Determinism/rollback suites + format checks pass on every PR.

--- a/src/game/controller/localController.cpp
+++ b/src/game/controller/localController.cpp
@@ -49,8 +49,7 @@ LocalController::LocalController(const std::shared_ptr<Common>& common,
   game.AddWorm(worm1);
   game.AddWorm(worm2);
 
-  // +68 on x to align the viewport in the middle
-  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 640, 400)));
 }
 
 LocalController::~LocalController() { EndRecord(); }

--- a/src/game/controller/replayController.cpp
+++ b/src/game/controller/replayController.cpp
@@ -140,14 +140,12 @@ void ReplayController::ChangeState(GameState new_state) {
     game->worms[0]->stats_x = 0;
     game->worms[1]->stats_x = 218;
 
-    // spectator viewport is always full size
-    // +68 on x to align the viewport in the middle
-    game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+    game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 640, 400)));
     if (gfx.settings->single_screen_replay) {
       // on single screen replay, use the spectator viewport for the
       // main screen as well
       // we can't use the same object, as the vector's clean function will delete them
-      game->AddViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+      game->AddViewport(new SpectatorViewport(Rect(0, 0, 640, 400)));
     } else {
       game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index));
       game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index));

--- a/src/game/controller/rollbackController.cpp
+++ b/src/game/controller/rollbackController.cpp
@@ -59,7 +59,7 @@ RollbackController::RollbackController(const std::shared_ptr<Common>& common,
                                  : settings->worm_settings[idx];
   }
   ConfigureGameSlots(game, ws);
-  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+  game.AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 640, 400)));
 }
 
 RollbackController::~RollbackController() = default;

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -113,11 +113,16 @@ void LevelSelectorState::DrawExtra() {
       if (level.load(common, *gfx->settings, r)) {
         int const kCenterX = gfx->single_screen_renderer.render_res_x / 2;
 
-        int const kHudStep = std::max({(level.width + 51) / 52, (level.height + 35) / 36, 1});
-        level.DrawMiniature(gfx->frozen_screen, 134, 162, kHudStep);
-        int const kSpecStep = std::max({(level.width + 251) / 252, (level.height + 174) / 175, 1});
-        level.DrawMiniature(gfx->frozen_spectator_screen, kCenterX - 126,
-                            gfx->single_screen_renderer.render_res_y - 208, kSpecStep);
+        int const kHudStepX = std::max((level.width + 51) / 52, 1);
+        int const kHudStepY = std::max((level.height + 35) / 36, 1);
+        FillRect(gfx->frozen_screen, 134, 162, 52, 36, 0);
+        level.DrawMiniature(gfx->frozen_screen, 134, 162, kHudStepX, kHudStepY);
+        int const kSpecStepX = std::max((level.width + 251) / 252, 1);
+        int const kSpecStepY = std::max((level.height + 174) / 175, 1);
+        int const kSpecY = gfx->single_screen_renderer.render_res_y - 208;
+        FillRect(gfx->frozen_spectator_screen, kCenterX - 126, kSpecY, 252, 175, 0);
+        level.DrawMiniature(gfx->frozen_spectator_screen, kCenterX - 126, kSpecY, kSpecStepX,
+                            kSpecStepY);
       }
     } catch (std::runtime_error&) {  // NOLINT(bugprone-empty-catch) — bad preview is non-fatal; we
                                      // just skip drawing it.

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -113,9 +113,11 @@ void LevelSelectorState::DrawExtra() {
       if (level.load(common, *gfx->settings, r)) {
         int const kCenterX = gfx->single_screen_renderer.render_res_x / 2;
 
-        level.DrawMiniature(gfx->frozen_screen, 134, 162, 10);
+        int const kHudStep = std::max({(level.width + 51) / 52, (level.height + 35) / 36, 1});
+        level.DrawMiniature(gfx->frozen_screen, 134, 162, kHudStep);
+        int const kSpecStep = std::max({(level.width + 251) / 252, (level.height + 174) / 175, 1});
         level.DrawMiniature(gfx->frozen_spectator_screen, kCenterX - 126,
-                            gfx->single_screen_renderer.render_res_y - 208, 2);
+                            gfx->single_screen_renderer.render_res_y - 208, kSpecStep);
       }
     } catch (std::runtime_error&) {  // NOLINT(bugprone-empty-catch) — bad preview is non-fatal; we
                                      // just skip drawing it.

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -397,11 +397,19 @@ void Gfx::OnWindowResize(uint32_t window_id) {
     }
 
     if (settings->spectator_window) {
+      int w = 0;
+      int h = 0;
+      SDL_GetWindowSize(sdl_spectator_window, &w, &h);
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
-                                                SDL_TEXTUREACCESS_STREAMING, 640, 400);
-      sdl_spectator_draw_surface = SDL_CreateSurface(640, 400, SDL_PIXELFORMAT_ARGB8888);
-      SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, 640, 400,
+                                                SDL_TEXTUREACCESS_STREAMING, w, h);
+      sdl_spectator_draw_surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_ARGB8888);
+      SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, w, h,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);
+      // Only resize the renderer when it isn't being used as primary renderer
+      // for the main window (i.e. during single-screen replay).
+      if (primary_renderer != &single_screen_renderer) {
+        single_screen_renderer.SetRenderResolution(w, h);
+      }
     }
   }
 }
@@ -1368,10 +1376,14 @@ bool Gfx::RunOneFrame() {
         controller = std::move(new_controller);
       } else if (kMenuSelection == MainMenu::kMaResumeGame) {
         if (controller->IsReplay()) {
+          // single_screen_renderer is drawn to the main window in replay mode,
+          // so it must fit in the main window surface (max 640×400).
+          single_screen_renderer.SetRenderResolution(640, 400);
           primary_renderer = &single_screen_renderer;
         }
       } else if (kMenuSelection == MainMenu::kMaReplay) {
         if (settings->single_screen_replay) {
+          single_screen_renderer.SetRenderResolution(640, 400);
           primary_renderer = &single_screen_renderer;
         }
       } else if (kMenuSelection == MainMenu::kMaHostGame) {
@@ -1438,6 +1450,15 @@ bool Gfx::RunOneFrame() {
       primary_renderer = &play_renderer;
       controller->Unfocus();
       ClearKeys();
+
+      // Restore spectator renderer to the actual window pixel size now that
+      // it's no longer shared with the main window.
+      if (sdl_spectator_window && settings->spectator_window) {
+        int w = 0;
+        int h = 0;
+        SDL_GetWindowSize(sdl_spectator_window, &w, &h);
+        single_screen_renderer.SetRenderResolution(w, h);
+      }
 
       // Draw one frame so the menu background captures the final game state
       play_renderer.Clear();

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -756,6 +756,35 @@ void ScaleDraw(uint32_t const* src, int w, int h, std::size_t src_pitch, uint8_t
   }
 }
 
+void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch,
+                   uint32_t* dest, int dest_w, int dest_h, std::size_t dest_pitch) {
+  for (int dy = 0; dy < dest_h; ++dy) {
+    int const kSy1 = dy * src_h / dest_h;
+    int const kSy2 = (dy + 1) * src_h / dest_h;
+    for (int dx = 0; dx < dest_w; ++dx) {
+      int const kSx1 = dx * src_w / dest_w;
+      int const kSx2 = (dx + 1) * src_w / dest_w;
+      int const kCount = (kSy2 - kSy1) * (kSx2 - kSx1);
+      if (kCount == 0) {
+        dest[dy * dest_pitch + dx] = src[kSy1 * src_pitch + kSx1];
+        continue;
+      }
+      uint64_t r = 0, g = 0, b = 0;
+      for (int sy = kSy1; sy < kSy2; ++sy) {
+        uint32_t const* row = src + sy * src_pitch + kSx1;
+        for (int sx = kSx1; sx < kSx2; ++sx) {
+          uint32_t const kPix = *row++;
+          r += (kPix >> 16) & 0xFFU;
+          g += (kPix >> 8) & 0xFFU;
+          b += kPix & 0xFFU;
+        }
+      }
+      dest[dy * dest_pitch + dx] =
+          0xFF000000U | ((r / kCount) << 16) | ((g / kCount) << 8) | (b / kCount);
+    }
+  }
+}
+
 int FitScreen(int back_w, int back_h, int scr_w, int scr_h, int& offset_x, int& offset_y) {
   int mag = 1;
 

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -756,8 +756,8 @@ void ScaleDraw(uint32_t const* src, int w, int h, std::size_t src_pitch, uint8_t
   }
 }
 
-void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch,
-                   uint32_t* dest, int dest_w, int dest_h, std::size_t dest_pitch) {
+void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch, uint32_t* dest,
+                   int dest_w, int dest_h, std::size_t dest_pitch) {
   for (int dy = 0; dy < dest_h; ++dy) {
     int const kSy1 = dy * src_h / dest_h;
     int const kSy2 = (dy + 1) * src_h / dest_h;
@@ -769,7 +769,9 @@ void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pi
         dest[dy * dest_pitch + dx] = src[kSy1 * src_pitch + kSx1];
         continue;
       }
-      uint64_t r = 0, g = 0, b = 0;
+      uint64_t r = 0;
+      uint64_t g = 0;
+      uint64_t b = 0;
       for (int sy = kSy1; sy < kSy2; ++sy) {
         uint32_t const* row = src + sy * src_pitch + kSx1;
         for (int sx = kSx1; sx < kSx2; ++sx) {

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -52,6 +52,11 @@ void DrawGraph(Bitmap& scr, std::vector<double> const& data, int height, int sta
 void ScaleDraw(uint32_t const* src, int w, int h, std::size_t src_pitch, uint8_t* dest,
                std::size_t dest_pitch, int mag, int fade);
 
+// Box-filter (area-averaging) downscale from ARGB src to ARGB dest.
+// Pitches are in uint32_t units (pixels, not bytes).
+void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch,
+                   uint32_t* dest, int dest_w, int dest_h, std::size_t dest_pitch);
+
 int FitScreen(int back_w, int back_h, int scr_w, int scr_h, int& offset_x, int& offset_y);
 
 struct Heatmap {

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -54,8 +54,8 @@ void ScaleDraw(uint32_t const* src, int w, int h, std::size_t src_pitch, uint8_t
 
 // Box-filter (area-averaging) downscale from ARGB src to ARGB dest.
 // Pitches are in uint32_t units (pixels, not bytes).
-void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch,
-                   uint32_t* dest, int dest_w, int dest_h, std::size_t dest_pitch);
+void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch, uint32_t* dest,
+                   int dest_w, int dest_h, std::size_t dest_pitch);
 
 int FitScreen(int back_w, int back_h, int scr_w, int scr_h, int& offset_x, int& offset_y);
 

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -482,22 +482,22 @@ bool Level::SelectSpawn(Rand& rand, int w, int h, IVec2& selected) {
   return i > 0;
 }
 
-void Level::DrawMiniature(Bitmap& dest, int map_x, int map_y, int step) {
-  int my = step / 2;
+void Level::DrawMiniature(Bitmap& dest, int map_x, int map_y, int step_x, int step_y) const {
+  int my = step_y / 2;
 
-  int const kMapEndY = map_y + ((height + step / 2) / step);
-  int const kMapEndX = map_x + ((width + step / 2) / step);
+  int const kMapEndY = map_y + ((height + step_y / 2) / step_y);
+  int const kMapEndX = map_x + ((width + step_x / 2) / step_x);
 
   for (int y = map_y; y < kMapEndY; ++y) {
-    int mx = step / 2;
+    int mx = step_x / 2;
     for (int x = map_x; x < kMapEndX; ++x) {
       auto const kIdx = static_cast<unsigned int>(mx + my * width);
       if (kIdx < material_id.size() && dest.clip_rect.Inside(x, y)) {
         dest.GetPixel(x, y) =
             AppearanceAt(static_cast<int>(kIdx), dest.mode, dest.pal32, dest.cycles);
       }
-      mx += step;
+      mx += step_x;
     }
-    my += step;
+    my += step_y;
   }
 }

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -30,7 +30,10 @@ struct Level {
   void MakeShadow(Common& common);
   void GenerateFromSettings(Common& common, Settings const& settings, Rand& rand);
   bool SelectSpawn(Rand& rand, int w, int h, IVec2& selected);
-  void DrawMiniature(Bitmap& dest, int map_x, int map_y, int step);
+  void DrawMiniature(Bitmap& dest, int map_x, int map_y, int step_x, int step_y) const;
+  void DrawMiniature(Bitmap& dest, int map_x, int map_y, int step) const {
+    DrawMiniature(dest, map_x, map_y, step, step);
+  }
 
   // Per-level animation ramp: a short list of ARGB colours that cycle each
   // frame. `shift` controls speed: phase = (cycles >> shift) % colors.size().

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -130,9 +130,10 @@ void MainMenuState::Enter() {
   gfx->frozen_screen.Copy(gfx->play_renderer.bmp);
   gfx->single_screen_renderer.Clear();
   if (gfx->controller->CurrentLevel()) {
-    gfx->controller->CurrentLevel()->DrawMiniature(gfx->single_screen_renderer.bmp, kCenterX - 126,
-                                                   gfx->single_screen_renderer.render_res_y - 208,
-                                                   2);
+    Level* level = gfx->controller->CurrentLevel();
+    int const kMinimapStep = std::max({(level->width + 251) / 252, (level->height + 174) / 175, 1});
+    level->DrawMiniature(gfx->single_screen_renderer.bmp, kCenterX - 126,
+                         gfx->single_screen_renderer.render_res_y - 208, kMinimapStep);
   }
   gfx->frozen_spectator_screen.Copy(gfx->single_screen_renderer.bmp);
 

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -130,10 +130,12 @@ void MainMenuState::Enter() {
   gfx->frozen_screen.Copy(gfx->play_renderer.bmp);
   gfx->single_screen_renderer.Clear();
   if (gfx->controller->CurrentLevel()) {
-    Level* level = gfx->controller->CurrentLevel();
-    int const kMinimapStep = std::max({(level->width + 251) / 252, (level->height + 174) / 175, 1});
+    Level const* level = gfx->controller->CurrentLevel();
+    int const kMinimapStepX = std::max((level->width + 251) / 252, 1);
+    int const kMinimapStepY = std::max((level->height + 174) / 175, 1);
     level->DrawMiniature(gfx->single_screen_renderer.bmp, kCenterX - 126,
-                         gfx->single_screen_renderer.render_res_y - 208, kMinimapStep);
+                         gfx->single_screen_renderer.render_res_y - 208, kMinimapStepX,
+                         kMinimapStepY);
   }
   gfx->frozen_spectator_screen.Copy(gfx->single_screen_renderer.bmp);
 

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -11,192 +11,95 @@
 #include "text.hpp"
 
 void SpectatorViewport::Process(Game& game) {
-  max_x = game.level.width - rect.Width();
-  max_y = game.level.height - rect.Height();
+  int const kRenderW = rect.Width();
+  int const kRenderH = rect.Height();
 
+  // Bounding box of all worms + margin to keep both worms visible with headroom.
+  int const kMargin = 60;
+  int wmin_x = game.level.width;
+  int wmin_y = game.level.height;
+  int wmax_x = 0;
+  int wmax_y = 0;
+  for (auto const& worm_ptr : game.worms) {
+    int const kWx = Ftoi(worm_ptr->pos.x);
+    int const kWy = Ftoi(worm_ptr->pos.y);
+    wmin_x = std::min(wmin_x, kWx);
+    wmin_y = std::min(wmin_y, kWy);
+    wmax_x = std::max(wmax_x, kWx);
+    wmax_y = std::max(wmax_y, kWy);
+  }
+
+  int const kBboxW = std::max(1, wmax_x - wmin_x + 2 * kMargin);
+  int const kBboxH = std::max(1, wmax_y - wmin_y + 2 * kMargin);
+  float const kZoomX = static_cast<float>(kRenderW) / static_cast<float>(kBboxW);
+  float const kZoomY = static_cast<float>(kRenderH) / static_cast<float>(kBboxH);
+  zoom = std::min({kZoomX, kZoomY, 1.0F});
+
+  int const kVisibleW = static_cast<int>(static_cast<float>(kRenderW) / zoom);
+  int const kVisibleH = static_cast<int>(static_cast<float>(kRenderH) / zoom);
+
+  // Center viewport on worm bounding box midpoint.
+  x = (wmin_x + wmax_x) / 2 - kVisibleW / 2;
+  y = (wmin_y + wmax_y) / 2 - kVisibleH / 2;
+
+  // Screen shake (display-only, applied after centering).
   int const kRealShake = Ftoi(shake);
+  if (kRealShake > 0) {
+    x += rand(kRealShake * 2) - kRealShake;
+    y += rand(kRealShake * 2) - kRealShake;
+  }
+
+  // Clamp to map bounds (max_x/y >= 0 even when visible region > map).
+  max_x = std::max(0, game.level.width - kVisibleW);
+  max_y = std::max(0, game.level.height - kVisibleH);
+  x = std::clamp(x, 0, max_x);
+  y = std::clamp(y, 0, max_y);
 
   // FIXME this is a bit broken
   if (game.WormByIdx(0)->killed_timer == Worm::kKilledTimerInitial ||
       game.WormByIdx(1)->killed_timer == Worm::kKilledTimerInitial) {
     banner_y = -8;
   }
-
-  if (kRealShake > 0) {
-    x += rand(kRealShake * 2) - kRealShake;
-    y += rand(kRealShake * 2) - kRealShake;
-  }
-
-  x = std::max(x, 0);
-  y = std::max(y, 0);
-  x = std::min(x, max_x);
-  y = std::min(y, max_y);
 }
 
 void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bool /*is_replay*/) {
   Common& common = *game.common;
   int const kMultiplier = renderer.render_res_x / 320;
   int const kCenterX = renderer.render_res_x / 2;
-  IVec2 const kRenderPos(x, y);
-  fixedvec const kOffs = rect.Ul() - kRenderPos;
+  int const kRenderW = rect.Width();
+  int const kRenderH = rect.Height();
 
-  // Shadows and explosion masks query the level (screen + offset = world).
+  // ── World pass ────────────────────────────────────────────────────────────
+  // Scratch bitmap sized to the visible world region, capped to map dimensions.
+  int const kScrW =
+      std::min(static_cast<int>(static_cast<float>(kRenderW) / zoom), game.level.width);
+  int const kScrH =
+      std::min(static_cast<int>(static_cast<float>(kRenderH) / zoom), game.level.height);
+
+  scratch_bmp.Alloc(kScrW, kScrH);
+  scratch_bmp.pal32 = renderer.pal32;
+  scratch_bmp.mode = renderer.mode;
+  scratch_bmp.cycles = game.cycles;
+  Fill(scratch_bmp, 0);
+
+  // Offset: world pixel (x, y) maps to scratch pixel (0, 0).
+  int const kOx = -x;
+  int const kOy = -y;
+
   ShadowQuery const kShadow{.common = common,
                             .level = game.level,
                             .pal32 = renderer.pal32,
-                            .world_offset_x = -kOffs.x,
-                            .world_offset_y = -kOffs.y,
+                            .world_offset_x = x,
+                            .world_offset_y = y,
                             .mode = renderer.mode,
                             .cycles = game.cycles};
 
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    int offset_x = kOffs.x / (i + 1);
-    // fix misalignment. Not sure why this is needed
-    if (i == 1) {
-      offset_x += 2;
-    }
-    int const kOffsetWeaponListX = kCenterX - 15 + (i == 0 ? -90 : 60);
-    if (worm.visible) {
-      int const kLifebarWidth = worm.health * 100 / worm.settings->health;
-      DrawBar(renderer.bmp, offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 39,
-              kLifebarWidth, kLifebarWidth / 10 + 234);
-    } else {
-      int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
-      if (lifebar_width > 0) {
-        lifebar_width = std::min(lifebar_width, 100);
-        DrawBar(renderer.bmp, offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 39,
-                lifebar_width, lifebar_width / 10 + 234);
-      }
-    }
-
-    // Draw kills status
-
-    WormWeapon const& ww = worm.weapons[worm.current_weapon];
-
-    if (ww.Available()) {
-      if (ww.ammo > 0) {
-        int const kAmmoBarWidth = ww.ammo * 100 / ww.type->ammo;
-
-        if (kAmmoBarWidth > 0) {
-          DrawBar(renderer.bmp, offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 34,
-                  kAmmoBarWidth, kAmmoBarWidth / 10 + 245);
-        }
-      }
-    } else {
-      int ammo_bar_width = 0;
-
-      if (ww.type->loading_time != 0) {
-        int const kComputedLoadingTime = ww.type->ComputedLoadingTime(*game.settings);
-        ammo_bar_width = 100 - ww.loading_left * 100 / kComputedLoadingTime;
-      } else {
-        ammo_bar_width = 100 - ww.loading_left * 100;
-      }
-
-      if (ammo_bar_width > 0) {
-        DrawBar(renderer.bmp, offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 34,
-                ammo_bar_width, ammo_bar_width / 10 + 245);
-      }
-
-      if ((game.cycles % 20) > 10 && worm.visible) {
-        common.font.DrawString(renderer.bmp, LS(Reloading), offset_x + worm.stats_x * kMultiplier,
-                               164, 50);
-      }
-    }
-
-    common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)),
-                           offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 29, 10);
-
-    // always display player names, color and time in spectator view
-    common.font.DrawString(renderer.bmp, worm.settings->name, offset_x + worm.stats_x * kMultiplier,
-                           renderer.render_res_y - 15, 7);
-    FillRect(renderer.bmp, offset_x + worm.stats_x * kMultiplier - 1, renderer.render_res_y - 7 - 1,
-             8, 8, 7);
-    FillRect(renderer.bmp, offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 7, 6, 6,
-             worm.settings->color);
-    // time
-    // FIXME: only draw this once, not once per worm
-    common.font.DrawString(
-        renderer.bmp,
-        TimeToStringEx(game.cycles * 14, /*force_hours=*/false, /*force_minutes=*/true),
-        kCenterX - 15, renderer.render_res_y - 15, 7);
-
-    // draw available/selected weapons
-    if (state == kStateGame) {
-      for (int i = 0; i < 5; i++) {
-        WormWeapon const& ww = worm.weapons[i];
-        if (ww.ammo > 0) {
-          int const kAmmoBarWidth = ww.ammo * 60 / ww.type->ammo;
-
-          if (kAmmoBarWidth > 0) {
-            DrawBar(renderer.bmp, kOffsetWeaponListX, renderer.render_res_y - 40 + i * 8,
-                    kAmmoBarWidth, 5, kAmmoBarWidth / 6 + 245);
-          }
-        }
-        if (worm.current_weapon == i) {
-          common.font.DrawString(renderer.bmp, worm.weapons[i].type->name, kOffsetWeaponListX,
-                                 renderer.render_res_y - 40 + i * 8, 187);
-        } else {
-          common.font.DrawString(renderer.bmp, worm.weapons[i].type->name, kOffsetWeaponListX,
-                                 renderer.render_res_y - 40 + i * 8, 185);
-        }
-      }
-    }
-
-    int const kStateColours[2][2] = {{6, 10}, {79, 4}};
-
-    switch (game.settings->game_mode) {
-      case Settings::kGmKillEmAll:
-      case Settings::kGmScalesOfJustice: {
-        common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)),
-                               offset_x + worm.stats_x * kMultiplier, renderer.render_res_y - 22,
-                               6);
-      } break;
-
-      case Settings::kGmHoldazone: {
-        int state = 0;
-
-        for (auto const& w : game.worms) {
-          if (w.get() != &worm && w->timer <= worm.timer) {
-            state = 1;
-          }
-        }
-
-        int const kColor = kStateColours[game.holdazone.holder_idx != worm.index][state];
-
-        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                               renderer.render_res_y - 39, kColor);
-      } break;
-
-      case Settings::kGmGameOfTag: {
-        int state = 0;
-
-        for (auto const& w : game.worms) {
-          if (w.get() != &worm && w->timer >= worm.timer) {
-            state = 1;
-          }
-        }
-
-        int const kColor = kStateColours[game.last_killed_idx != worm.index][state];
-
-        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                               renderer.render_res_y - 39, kColor);
-      } break;
-
-      default:
-        break;
-    }
-  }
-
-  renderer.bmp.cycles = game.cycles;
-  DrawLevel(renderer.bmp, game.level, kOffs.x, kOffs.y);
+  DrawLevel(scratch_bmp, game.level, kOx, kOy);
 
   if (game.settings->game_mode == Settings::kGmHoldazone) {
     bool const kTimingOut = game.holdazone.timeout_left < 70 * 4;
-
     int const kColor = kTimingOut ? 168 : 50;
     int contender_color = 0;
-
     if (game.holdazone.contender_idx >= 0) {
       Worm const* contender = game.WormByIdx(game.holdazone.contender_idx);
       if (kTimingOut) {
@@ -207,60 +110,34 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     } else {
       contender_color = kColor;
     }
-
-    DrawDashedLineBox(renderer.bmp, game.holdazone.rect.x1 + kOffs.x,
-                      game.holdazone.rect.y1 + kOffs.y, kColor, contender_color,
-                      game.holdazone.contender_frames, Settings::kZoneCaptureTime,
-                      game.holdazone.rect.Width(), game.holdazone.rect.Height(), game.cycles / 10);
+    DrawDashedLineBox(scratch_bmp, game.holdazone.rect.x1 + kOx, game.holdazone.rect.y1 + kOy,
+                      kColor, contender_color, game.holdazone.contender_frames,
+                      Settings::kZoneCaptureTime, game.holdazone.rect.Width(),
+                      game.holdazone.rect.Height(), game.cycles / 10);
   }
 
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm const& worm = *game.worms[i];
     if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
       if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
-        int const kTempX = Ftoi(worm.pos.x) - 7 + kOffs.x;
-        int const kTempY = Ftoi(worm.pos.y) - 5 + kOffs.y;
-
-        BlitImageTrans(renderer.bmp,
+        int const kTempX = Ftoi(worm.pos.x) - 7 + kOx;
+        int const kTempY = Ftoi(worm.pos.y) - 5 + kOy;
+        BlitImageTrans(scratch_bmp,
                        common.WormSpriteObj(worm.current_frame, worm.direction, worm.index), kTempX,
                        kTempY, game.cycles);
       }
     }
-
-    if (banner_y > -8 && worm.health <= 0) {
-      if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
-        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
-      }
-    }
-  }
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    if (worm.health <= 0 && banner_y > -8) {
-      if (worm.last_killed_by_idx == worm.index) {
-        std::string const kMsg(worm.settings->name + LS(CommittedSuicideMsg));
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
-      } else {
-        std::string const kMsg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
-                               worm.settings->name);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
-      }
-    }
   }
 
-  // Pass 1: all shadows. Every shadow is drawn before any sprite so no
-  // object's shadow can overwrite another object's already-rendered sprite.
+  // Pass 1: all shadows before any sprite.
   if (game.settings->shadow) {
     {
       auto br = game.bonuses.All();
       for (Bonus const* i = nullptr; (i = br.Next());) {
         if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
           int const kF = common.bonus_frames[i->frame];
-          BlitShadowImage(kShadow, renderer.bmp, common.small_sprites.SpritePtr(kF),
-                          Ftoi(i->x) - 5 + kOffs.x,  // TODO: Use offsX
-                          Ftoi(i->y) - 1 + kOffs.y, 7, 7);
+          BlitShadowImage(kShadow, scratch_bmp, common.small_sprites.SpritePtr(kF),
+                          Ftoi(i->x) - 5 + kOx, Ftoi(i->y) - 1 + kOy, 7, 7);
         }
       }
     }
@@ -270,11 +147,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       for (SObject const* i = nullptr; (i = sr.Next());) {
         SObjectType const& t = common.sobject_types[i->id];
         int const kFrame = i->cur_frame + t.start_frame;
-        BlitShadowImage(kShadow, renderer.bmp, common.large_sprites.SpritePtr(kFrame),
-                        i->x + kOffs.x - 3,
-                        i->y + kOffs.y + 3,  // TODO: Original doesn't offset the shadow, which is
-                                             // clearly wrong. Check that this offset is correct.
-                        16, 16);
+        BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame),
+                        i->x + kOx - 3, i->y + kOy + 3, 16, 16);
       }
     }
 
@@ -308,16 +182,16 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
           int const kPosX = Ftoi(i->pos.x) - 3;
           int const kPosY = Ftoi(i->pos.y) - 3;
           if (w.shadow) {
-            BlitShadowImage(kShadow, renderer.bmp,
+            BlitShadowImage(kShadow, scratch_bmp,
                             common.small_sprites.SpritePtr(w.start_frame + cur_frame),
-                            kPosX - 3 + kOffs.x, kPosY + 3 + kOffs.y, 7, 7);
+                            kPosX - 3 + kOx, kPosY + 3 + kOy, 7, 7);
           }
         } else if (i->cur_frame > 0) {
-          int const kPosX = Ftoi(i->pos.x) + kOffs.x - 3;
-          int const kPosY = Ftoi(i->pos.y) + kOffs.y + 3;
+          int const kPosX = Ftoi(i->pos.x) + kOx - 3;
+          int const kPosY = Ftoi(i->pos.y) + kOy + 3;
           uint32_t const kShadowed = kShadow.ShadowedArgb(kPosX, kPosY);
-          if (kShadowed != 0 && renderer.bmp.clip_rect.Inside(kPosX, kPosY)) {
-            renderer.bmp.GetPixel(kPosX, kPosY) = kShadowed;
+          if (kShadowed != 0 && scratch_bmp.clip_rect.Inside(kPosX, kPosY)) {
+            scratch_bmp.GetPixel(kPosX, kPosY) = kShadowed;
           }
         }
       }
@@ -329,17 +203,17 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
         NObjectType const& t = *i->type;
         if (t.start_frame > 0) {
           auto pos = Ftoi(i->pos) - IVec2(3, 3);
-          BlitShadowImage(kShadow, renderer.bmp,
+          BlitShadowImage(kShadow, scratch_bmp,
                           common.small_sprites.SpritePtr(t.start_frame + i->cur_frame),
-                          pos.x - 3 + kOffs.x, pos.y + 3 + kOffs.y, 7, 7);
+                          pos.x - 3 + kOx, pos.y + 3 + kOy, 7, 7);
         } else if (i->cur_frame > 1) {
-          auto pos = Ftoi(i->pos) + kOffs;
-          pos.x -= 3;
-          pos.y += 3;
-          if (renderer.bmp.clip_rect.Encloses(pos)) {
+          auto pos = Ftoi(i->pos);
+          pos.x += kOx - 3;
+          pos.y += kOy + 3;
+          if (scratch_bmp.clip_rect.Encloses(pos)) {
             uint32_t const kShadowed = kShadow.ShadowedArgb(pos.x, pos.y);
             if (kShadowed != 0) {
-              renderer.bmp.GetPixel(pos.x, pos.y) = kShadowed;
+              scratch_bmp.GetPixel(pos.x, pos.y) = kShadowed;
             }
           }
         }
@@ -349,48 +223,48 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     for (auto const& worm_ptr : game.worms) {
       Worm const& w = *worm_ptr;
       if (w.visible) {
-        int const kTempX = Ftoi(w.pos.x) - 7 + kOffs.x;
-        int const kTempY = Ftoi(w.pos.y) - 5 + kOffs.y;
+        int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
+        int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
         if (w.ninjarope.out) {
-          int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOffs.x;
-          int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOffs.y;
-          DrawShadowLine(kShadow, renderer.bmp, kNinjaropeX - 3, kNinjaropeY + 3, kTempX + 7 - 3,
+          int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
+          int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
+          DrawShadowLine(kShadow, scratch_bmp, kNinjaropeX - 3, kNinjaropeY + 3, kTempX + 7 - 3,
                          kTempY + 4 + 3);
-          BlitShadowImage(kShadow, renderer.bmp, common.large_sprites.SpritePtr(84),
-                          kNinjaropeX - 4, kNinjaropeY + 2, 16, 16);
+          BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(84), kNinjaropeX - 4,
+                          kNinjaropeY + 2, 16, 16);
         }
-        BlitShadowImage(kShadow, renderer.bmp,
+        BlitShadowImage(kShadow, scratch_bmp,
                         common.WormSprite(w.current_frame, w.direction, w.index), kTempX - 3,
                         kTempY + 3, 16, 16);
       }
     }
 
     for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
-      auto ipos = Ftoi(i->pos) + kOffs;
-      ipos.x -= 3;
-      ipos.y += 3;
-      if (renderer.bmp.clip_rect.Encloses(ipos)) {
+      auto ipos = Ftoi(i->pos);
+      ipos.x += kOx - 3;
+      ipos.y += kOy + 3;
+      if (scratch_bmp.clip_rect.Encloses(ipos)) {
         uint32_t const kShadowed = kShadow.ShadowedArgb(ipos.x, ipos.y);
         if (kShadowed != 0) {
-          renderer.bmp.GetPixel(ipos.x, ipos.y) = kShadowed;
+          scratch_bmp.GetPixel(ipos.x, ipos.y) = kShadowed;
         }
       }
     }
   }
 
-  // Pass 2: all sprites, drawn on top of the fully-composited shadow layer.
+  // Pass 2: all sprites on top of the fully-composited shadow layer.
   {
     auto br = game.bonuses.All();
     for (Bonus const* i = nullptr; (i = br.Next());) {
       if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
         int const kF = common.bonus_frames[i->frame];
-        BlitImage(renderer.bmp, common.small_sprites[kF], Ftoi(i->x) - 3 + kOffs.x,
-                  Ftoi(i->y) - 3 + kOffs.y);
+        BlitImage(scratch_bmp, common.small_sprites[kF], Ftoi(i->x) - 3 + kOx,
+                  Ftoi(i->y) - 3 + kOy);
         if (game.settings->names_on_bonuses && i->frame == 0) {
           std::string const& name = common.weapons[i->weapon].name;
           int const kLen = static_cast<int>(name.size()) * 4;
-          common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOffs.x,
-                               Ftoi(i->y) - 10 + kOffs.y);
+          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOx,
+                               Ftoi(i->y) - 10 + kOy);
         }
       }
     }
@@ -401,8 +275,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     for (SObject const* i = nullptr; (i = sr.Next());) {
       SObjectType const& t = common.sobject_types[i->id];
       int const kFrame = i->cur_frame + t.start_frame;
-      BlitImageR(kShadow, renderer.bmp, common.large_sprites.SpritePtr(kFrame), i->x + kOffs.x,
-                 i->y + kOffs.y, 16, 16);
+      BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), i->x + kOx,
+                 i->y + kOy, 16, 16);
     }
   }
 
@@ -435,27 +309,22 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
         }
         int const kPosX = Ftoi(i->pos.x) - 3;
         int const kPosY = Ftoi(i->pos.y) - 3;
-        BlitImage(renderer.bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOffs.x,
-                  kPosY + kOffs.y);
+        BlitImage(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOx,
+                  kPosY + kOy);
       } else if (i->cur_frame > 0) {
-        int const kPosX = Ftoi(i->pos.x) + kOffs.x;
-        int const kPosY = Ftoi(i->pos.y) + kOffs.y;
-        renderer.bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
+        int const kPosX = Ftoi(i->pos.x) + kOx;
+        int const kPosY = Ftoi(i->pos.y) + kOy;
+        scratch_bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
       }
-
       if (!common.h[HRemExp] && i->type - common.weapons.data() == 34 &&
-          game.settings->names_on_bonuses)  // TODO: Read from EXE
-      {
+          game.settings->names_on_bonuses) {
         if (i->cur_frame == 0) {
           int const kNameNum =
-              static_cast<int>(&*i - game.wobjects.arr) %
-              static_cast<int>(common.weapons.size());  // TODO: Something nicer maybe
-
+              static_cast<int>(&*i - game.wobjects.arr) % static_cast<int>(common.weapons.size());
           std::string const& name = common.weapons[kNameNum].name;
           int const kWidth = static_cast<int>(name.size()) * 4;
-
-          common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOffs.x,
-                               Ftoi(i->pos.y) - 10 + kOffs.y);
+          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOx,
+                               Ftoi(i->pos.y) - 10 + kOy);
         }
       }
     }
@@ -467,12 +336,14 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       NObjectType const& t = *i->type;
       if (t.start_frame > 0) {
         auto pos = Ftoi(i->pos) - IVec2(3, 3);
-        BlitImage(renderer.bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOffs.x,
-                  pos.y + kOffs.y);
+        BlitImage(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOx,
+                  pos.y + kOy);
       } else if (i->cur_frame > 1) {
-        auto pos = Ftoi(i->pos) + kOffs;
-        if (renderer.bmp.clip_rect.Encloses(pos)) {
-          renderer.bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
+        auto pos = Ftoi(i->pos);
+        pos.x += kOx;
+        pos.y += kOy;
+        if (scratch_bmp.clip_rect.Encloses(pos)) {
+          scratch_bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
         }
       }
     }
@@ -480,95 +351,207 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
   for (std::size_t i = 0; i < game.worms.size(); ++i) {
     Worm const& w = *game.worms[i];
-
     if (w.visible) {
-      int const kTempX = Ftoi(w.pos.x) - 7 + kOffs.x;
-      int const kTempY = Ftoi(w.pos.y) - 5 + kOffs.y;
+      int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
+      int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
       int const kAngleFrame = w.AngleFrame();
-
       if (w.weapons[w.current_weapon].Available()) {
-        int const kHotspotX = w.hotspot_x + kOffs.x;
-        int const kHotspotY = w.hotspot_y + kOffs.y;
-
+        int const kHotspotX = w.hotspot_x + kOx;
+        int const kHotspotY = w.hotspot_y + kOy;
         WormWeapon const& ww = w.weapons[w.current_weapon];
         Weapon const& weapon = *ww.type;
-
         if (weapon.laser_sight) {
-          DrawLaserSight(renderer.bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
+          DrawLaserSight(scratch_bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
         }
-
         if (ww.type - common.weapons.data() == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
-          DrawLine(renderer.bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4,
-                   weapon.color_bullets);
+          DrawLine(scratch_bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4, weapon.color_bullets);
         }
       }
-
       if (w.ninjarope.out) {
-        int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOffs.x;
-        int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOffs.y;
-
-        DrawNinjarope(common, renderer.bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
-
-        BlitImage(renderer.bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
+        int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
+        int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
+        DrawNinjarope(common, scratch_bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
+        BlitImage(scratch_bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
       }
-
       if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
-        /* TODO
-        //NOTE! Check fctab so it's correct
-        //NOTE! Check function 1071C and see what it actually does*/
-
-        BlitFireCone(renderer.bmp, w.fire_cone / 2, common.FireConeSprite(kAngleFrame, w.direction),
+        BlitFireCone(scratch_bmp, w.fire_cone / 2, common.FireConeSprite(kAngleFrame, w.direction),
                      Common::fire_cone_offset[w.direction][kAngleFrame][0] + kTempX,
                      Common::fire_cone_offset[w.direction][kAngleFrame][1] + kTempY);
       }
-
-      BlitImage(renderer.bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), kTempX,
+      BlitImage(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), kTempX,
                 kTempY);
     }
-
     if (w.ai) {
-      w.ai->DrawDebug(game, w, renderer, kOffs.x, kOffs.y);
+      w.ai->DrawDebug(game, w, renderer, kOx, kOy);
     }
   }
-
-  /*
-  auto& dp = gfx.debugPoints;
-
-  for (auto& p : dp)
-  {
-          int x = ftoi(p.first) + offsX;
-          int y = ftoi(p.second) + offsY;
-
-          if(isInside(renderer.bmp.clip_rect, x, y))
-                  renderer.bmp.getPixel(x, y) = 0;
-  }*/
 
   for (auto& i : game.worms) {
     Worm const& worm = *i;
     if (worm.visible) {
-      auto temp =
-          Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16) + kOffs;
-      // int tempX = ftoi(worm.pos.x) - 1 + ftoi(cosTable[ftoi(worm.aimingAngle)] * 16) + offs.x;
-      // int tempY = ftoi(worm.pos.y) - 2 + ftoi(sinTable[ftoi(worm.aimingAngle)] * 16) + offs.y;
-
-      BlitImage(renderer.bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
-                temp.y);
-
+      auto temp = Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
+      temp.x += kOx;
+      temp.y += kOy;
+      BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
       if (worm.Pressed(Worm::kChange)) {
         std::string const& name = worm.weapons[worm.current_weapon].type->name;
-
-        int const kLen = static_cast<int>(name.size()) * 4;  // TODO: Read 4 from exe? (SW_CHARWID)
-
-        common.DrawTextSmall(renderer.bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOffs.x,
-                             Ftoi(worm.pos.y) - 10 + kOffs.y);
+        int const kLen = static_cast<int>(name.size()) * 4;
+        common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOx,
+                             Ftoi(worm.pos.y) - 10 + kOy);
       }
     }
   }
 
   for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
-    auto ipos = Ftoi(i->pos) + kOffs;
-    if (renderer.bmp.clip_rect.Encloses(ipos)) {
-      renderer.bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
+    auto ipos = Ftoi(i->pos);
+    ipos.x += kOx;
+    ipos.y += kOy;
+    if (scratch_bmp.clip_rect.Encloses(ipos)) {
+      scratch_bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
+    }
+  }
+
+  // ── Composite scratch → renderer ─────────────────────────────────────────
+  if (zoom >= 1.0F) {
+    BlitBitmap(renderer.bmp, scratch_bmp, 0, 0, kScrW, kScrH);
+  } else {
+    ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, renderer.bmp.pixels,
+                  kRenderW, kRenderH, renderer.bmp.pitch);
+  }
+
+  // ── HUD overlay (native resolution, drawn on top) ─────────────────────────
+  for (std::size_t i = 0; i < game.worms.size(); ++i) {
+    Worm const& worm = *game.worms[i];
+    int const kHudX = worm.stats_x * kMultiplier;
+    int const kOffsetWeaponListX = kCenterX - 15 + (i == 0 ? -90 : 60);
+
+    if (worm.visible) {
+      int const kLifebarWidth = worm.health * 100 / worm.settings->health;
+      DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, kLifebarWidth,
+              kLifebarWidth / 10 + 234);
+    } else {
+      int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
+      if (lifebar_width > 0) {
+        lifebar_width = std::min(lifebar_width, 100);
+        DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, lifebar_width,
+                lifebar_width / 10 + 234);
+      }
+    }
+
+    WormWeapon const& ww = worm.weapons[worm.current_weapon];
+    if (ww.Available()) {
+      if (ww.ammo > 0) {
+        int const kAmmoBarWidth = ww.ammo * 100 / ww.type->ammo;
+        if (kAmmoBarWidth > 0) {
+          DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, kAmmoBarWidth,
+                  kAmmoBarWidth / 10 + 245);
+        }
+      }
+    } else {
+      int ammo_bar_width = 0;
+      if (ww.type->loading_time != 0) {
+        int const kComputedLoadingTime = ww.type->ComputedLoadingTime(*game.settings);
+        ammo_bar_width = 100 - ww.loading_left * 100 / kComputedLoadingTime;
+      } else {
+        ammo_bar_width = 100 - ww.loading_left * 100;
+      }
+      if (ammo_bar_width > 0) {
+        DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, ammo_bar_width,
+                ammo_bar_width / 10 + 245);
+      }
+      if ((game.cycles % 20) > 10 && worm.visible) {
+        common.font.DrawString(renderer.bmp, LS(Reloading), kHudX, 164, 50);
+      }
+    }
+
+    common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)), kHudX,
+                           renderer.render_res_y - 29, 10);
+    common.font.DrawString(renderer.bmp, worm.settings->name, kHudX, renderer.render_res_y - 15, 7);
+    FillRect(renderer.bmp, kHudX - 1, renderer.render_res_y - 7 - 1, 8, 8, 7);
+    FillRect(renderer.bmp, kHudX, renderer.render_res_y - 7, 6, 6, worm.settings->color);
+    // FIXME: only draw this once, not once per worm
+    common.font.DrawString(
+        renderer.bmp,
+        TimeToStringEx(game.cycles * 14, /*force_hours=*/false, /*force_minutes=*/true),
+        kCenterX - 15, renderer.render_res_y - 15, 7);
+
+    if (state == kStateGame) {
+      for (int j = 0; j < 5; j++) {
+        WormWeapon const& wwj = worm.weapons[j];
+        if (wwj.ammo > 0) {
+          int const kAmmoBarWidth = wwj.ammo * 60 / wwj.type->ammo;
+          if (kAmmoBarWidth > 0) {
+            DrawBar(renderer.bmp, kOffsetWeaponListX, renderer.render_res_y - 40 + j * 8,
+                    kAmmoBarWidth, 5, kAmmoBarWidth / 6 + 245);
+          }
+        }
+        if (worm.current_weapon == j) {
+          common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
+                                 renderer.render_res_y - 40 + j * 8, 187);
+        } else {
+          common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
+                                 renderer.render_res_y - 40 + j * 8, 185);
+        }
+      }
+    }
+
+    int const kStateColours[2][2] = {{6, 10}, {79, 4}};
+    switch (game.settings->game_mode) {
+      case Settings::kGmKillEmAll:
+      case Settings::kGmScalesOfJustice: {
+        common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)), kHudX,
+                               renderer.render_res_y - 22, 6);
+      } break;
+      case Settings::kGmHoldazone: {
+        int hstate = 0;
+        for (auto const& w : game.worms) {
+          if (w.get() != &worm && w->timer <= worm.timer) {
+            hstate = 1;
+          }
+        }
+        int const kColor = kStateColours[game.holdazone.holder_idx != worm.index][hstate];
+        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                               renderer.render_res_y - 39, kColor);
+      } break;
+      case Settings::kGmGameOfTag: {
+        int gstate = 0;
+        for (auto const& w : game.worms) {
+          if (w.get() != &worm && w->timer >= worm.timer) {
+            gstate = 1;
+          }
+        }
+        int const kColor = kStateColours[game.last_killed_idx != worm.index][gstate];
+        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                               renderer.render_res_y - 39, kColor);
+      } break;
+      default:
+        break;
+    }
+  }
+
+  // ── Banner messages ───────────────────────────────────────────────────────
+  for (std::size_t i = 0; i < game.worms.size(); ++i) {
+    Worm const& worm = *game.worms[i];
+    if (banner_y > -8 && worm.health <= 0) {
+      if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
+      }
+    }
+  }
+  for (std::size_t i = 0; i < game.worms.size(); ++i) {
+    Worm const& worm = *game.worms[i];
+    if (worm.health <= 0 && banner_y > -8) {
+      if (worm.last_killed_by_idx == worm.index) {
+        std::string const kMsg(worm.settings->name + LS(CommittedSuicideMsg));
+        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
+      } else {
+        std::string const kMsg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
+                               worm.settings->name);
+        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
+        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
+      }
     }
   }
 }

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -11,8 +11,8 @@
 #include "text.hpp"
 
 void SpectatorViewport::Process(Game& game) {
-  int const kRenderW = rect.Width();
-  int const kRenderH = rect.Height();
+  int const kRenderW = render_w;
+  int const kRenderH = render_h;
 
   // Bounding box of all worms + margin to keep both worms visible with headroom.
   int const kMargin = 60;
@@ -64,10 +64,12 @@ void SpectatorViewport::Process(Game& game) {
 
 void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bool /*is_replay*/) {
   Common& common = *game.common;
+  render_w = renderer.render_res_x;
+  render_h = renderer.render_res_y;
   int const kMultiplier = renderer.render_res_x / 320;
   int const kCenterX = renderer.render_res_x / 2;
-  int const kRenderW = rect.Width();
-  int const kRenderH = rect.Height();
+  int const kRenderW = render_w;
+  int const kRenderH = render_h;
 
   // ── World pass ────────────────────────────────────────────────────────────
   // Scratch bitmap sized to the visible world region, capped to map dimensions.

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -66,17 +66,15 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   Common& common = *game.common;
   render_w = renderer.render_res_x;
   render_h = renderer.render_res_y;
-  int const kMultiplier = renderer.render_res_x / 320;
-  int const kCenterX = renderer.render_res_x / 2;
-  int const kRenderW = render_w;
-  int const kRenderH = render_h;
+  int const kMultiplier = render_w / 320;
+  int const kCenterX = render_w / 2;
 
   // ── World pass ────────────────────────────────────────────────────────────
   // Scratch bitmap sized to the visible world region, capped to map dimensions.
   int const kScrW =
-      std::min(static_cast<int>(static_cast<float>(kRenderW) / zoom), game.level.width);
+      std::min(static_cast<int>(static_cast<float>(render_w) / zoom), game.level.width);
   int const kScrH =
-      std::min(static_cast<int>(static_cast<float>(kRenderH) / zoom), game.level.height);
+      std::min(static_cast<int>(static_cast<float>(render_h) / zoom), game.level.height);
 
   scratch_bmp.Alloc(kScrW, kScrH);
   scratch_bmp.pal32 = renderer.pal32;
@@ -418,7 +416,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     BlitBitmap(renderer.bmp, scratch_bmp, 0, 0, kScrW, kScrH);
   } else {
     ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, renderer.bmp.pixels,
-                  kRenderW, kRenderH, renderer.bmp.pitch);
+                  render_w, render_h, renderer.bmp.pitch);
   }
 
   // ── HUD overlay (native resolution, drawn on top) ─────────────────────────

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -20,4 +20,9 @@ struct SpectatorViewport : Viewport {
   // Current zoom factor (1.0 = native, <1.0 = zoomed out). Display-only —
   // never touches the simulation and may use floats freely.
   float zoom{1.0F};
+  // Render dimensions cached from the renderer at the start of each Draw()
+  // call. Process() reads these so it stays consistent with the current
+  // renderer resolution without needing a Renderer& parameter.
+  int render_w{640};
+  int render_h{400};
 };

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <ctime>
 #include "game.hpp"
+#include "gfx/bitmap.hpp"
 #include "math/rect.hpp"
-#include "rand.hpp"
 #include "viewport.hpp"
 #include "worm.hpp"
 
@@ -14,4 +13,11 @@ struct SpectatorViewport : Viewport {
 
   void Draw(Game& game, Renderer& renderer, GameState state, bool is_replay) override;
   void Process(Game& game) override;
+
+  // Reused scratch buffer for the world pass; sized to the visible world
+  // region each frame and downscaled into the spectator rect.
+  Bitmap scratch_bmp;
+  // Current zoom factor (1.0 = native, <1.0 = zoomed out). Display-only —
+  // never touches the simulation and may use floats freely.
+  float zoom{1.0F};
 };

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -595,24 +595,24 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState /*state*/, bool is
     int const kMapY = renderer.render_res_y - 38;
 
     // Fit the minimap into a 52×36 pixel area regardless of map size.
-    int const kMinimapStep =
-        std::max({(game.level.width + 51) / 52, (game.level.height + 35) / 36, 1});
-    game.level.DrawMiniature(renderer.bmp, kMapX, kMapY, kMinimapStep);
+    int const kMinimapStepX = std::max((game.level.width + 51) / 52, 1);
+    int const kMinimapStepY = std::max((game.level.height + 35) / 36, 1);
+    game.level.DrawMiniature(renderer.bmp, kMapX, kMapY, kMinimapStepX, kMinimapStepY);
 
     for (auto& worm : game.worms) {
       Worm const& w = *worm;
 
       if (w.visible) {
-        int const kX = Ftoi(w.pos.x) / kMinimapStep + kMapX;
-        int const kY = Ftoi(w.pos.y) / kMinimapStep + kMapY;
+        int const kX = Ftoi(w.pos.x) / kMinimapStepX + kMapX;
+        int const kY = Ftoi(w.pos.y) / kMinimapStepY + kMapY;
 
         renderer.bmp.SetPixel(kX, kY, w.MinimapColor());
       }
     }
 
     if (game.settings->game_mode == Settings::kGmHoldazone && game.holdazone.timeout_left > 0) {
-      int const kX = game.holdazone.rect.CenterX() / kMinimapStep + kMapX;
-      int const kY = game.holdazone.rect.CenterY() / kMinimapStep + kMapY;
+      int const kX = game.holdazone.rect.CenterX() / kMinimapStepX + kMapX;
+      int const kY = game.holdazone.rect.CenterY() / kMinimapStepY + kMapY;
 
       int color = 168;
 

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -594,22 +594,25 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState /*state*/, bool is
     int const kMapX = kCenterX - 26;
     int const kMapY = renderer.render_res_y - 38;
 
-    game.level.DrawMiniature(renderer.bmp, kMapX, kMapY, 10);
+    // Fit the minimap into a 52×36 pixel area regardless of map size.
+    int const kMinimapStep =
+        std::max({(game.level.width + 51) / 52, (game.level.height + 35) / 36, 1});
+    game.level.DrawMiniature(renderer.bmp, kMapX, kMapY, kMinimapStep);
 
     for (auto& worm : game.worms) {
       Worm const& w = *worm;
 
       if (w.visible) {
-        int const kX = Ftoi(w.pos.x) / 10 + kMapX;
-        int const kY = Ftoi(w.pos.y) / 10 + kMapY;
+        int const kX = Ftoi(w.pos.x) / kMinimapStep + kMapX;
+        int const kY = Ftoi(w.pos.y) / kMinimapStep + kMapY;
 
         renderer.bmp.SetPixel(kX, kY, w.MinimapColor());
       }
     }
 
     if (game.settings->game_mode == Settings::kGmHoldazone && game.holdazone.timeout_left > 0) {
-      int const kX = game.holdazone.rect.CenterX() / 10 + kMapX;
-      int const kY = game.holdazone.rect.CenterY() / 10 + kMapY;
+      int const kX = game.holdazone.rect.CenterX() / kMinimapStep + kMapX;
+      int const kY = game.holdazone.rect.CenterY() / kMinimapStep + kMapY;
 
       int color = 168;
 

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -125,7 +125,11 @@ void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState /*sta
     FillRect(renderer.bmp, kCenterX + kTextSize / 2 - 16, kCenterY + 23, 14, 14,
              Palette::kWormColorBlocks[1].base);
     common.font.DrawCenteredText(renderer.bmp, "WEAPON SELECTION", kCenterX, kCenterY + 48, 7, 2);
-    game.level.DrawMiniature(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208, 2);
+    // Fit the minimap into a 252×175 pixel area regardless of map size.
+    int const kMinimapStep =
+        std::max({(game.level.width + 251) / 252, (game.level.height + 174) / 175, 1});
+    game.level.DrawMiniature(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208,
+                             kMinimapStep);
 
     gfx.frozen_spectator_screen.Copy(renderer.bmp);
     cached_spectator_background = true;

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -128,6 +128,7 @@ void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState /*sta
     // Fit the minimap into a 252×175 pixel area regardless of map size.
     int const kMinimapStepX = std::max((game.level.width + 251) / 252, 1);
     int const kMinimapStepY = std::max((game.level.height + 174) / 175, 1);
+    FillRect(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208, 252, 175, 0);
     game.level.DrawMiniature(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208,
                              kMinimapStepX, kMinimapStepY);
 

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -126,10 +126,10 @@ void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState /*sta
              Palette::kWormColorBlocks[1].base);
     common.font.DrawCenteredText(renderer.bmp, "WEAPON SELECTION", kCenterX, kCenterY + 48, 7, 2);
     // Fit the minimap into a 252×175 pixel area regardless of map size.
-    int const kMinimapStep =
-        std::max({(game.level.width + 251) / 252, (game.level.height + 174) / 175, 1});
+    int const kMinimapStepX = std::max((game.level.width + 251) / 252, 1);
+    int const kMinimapStepY = std::max((game.level.height + 174) / 175, 1);
     game.level.DrawMiniature(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208,
-                             kMinimapStep);
+                             kMinimapStepX, kMinimapStepY);
 
     gfx.frozen_spectator_screen.Copy(renderer.bmp);
     cached_spectator_background = true;

--- a/src/tests/test_blit.cpp
+++ b/src/tests/test_blit.cpp
@@ -336,6 +336,39 @@ TEST_CASE("scaledraw magnifies argb and applies the composition fade", "[blit][a
   REQUIRE(dest1[0] == 0xFF000000U);
 }
 
+TEST_CASE("scaledrawarea 1x1 src to 1x1 dest copies the pixel", "[blit][scaledrawarea]") {
+  uint32_t const kSrc = 0xFF102030U;
+  uint32_t dest = 0;
+  ScaleDrawArea(&kSrc, 1, 1, 1, &dest, 1, 1, 1);
+  REQUIRE(dest == 0xFF102030U);
+}
+
+TEST_CASE("scaledrawarea 2x2 src to 1x1 dest averages all four pixels", "[blit][scaledrawarea]") {
+  // Four pixels: R channels 0x10, 0x30, 0x50, 0x70 — avg = 0x40.
+  uint32_t const kSrc[4] = {0xFF100000U, 0xFF300000U, 0xFF500000U, 0xFF700000U};
+  uint32_t dest = 0;
+  ScaleDrawArea(kSrc, 2, 2, 2, &dest, 1, 1, 1);
+  REQUIRE(dest == 0xFF400000U);
+}
+
+TEST_CASE("scaledrawarea 4x1 src to 2x1 dest averages pairs", "[blit][scaledrawarea]") {
+  // Two pairs: (0x04, 0x08) avg 0x06; (0x10, 0x20) avg 0x18.
+  uint32_t const kSrc[4] = {0xFF040000U, 0xFF080000U, 0xFF100000U, 0xFF200000U};
+  uint32_t dest[2] = {};
+  ScaleDrawArea(kSrc, 4, 1, 4, dest, 2, 1, 2);
+  REQUIRE(dest[0] == 0xFF060000U);
+  REQUIRE(dest[1] == 0xFF180000U);
+}
+
+TEST_CASE("scaledrawarea 1x4 src to 1x2 dest averages column pairs", "[blit][scaledrawarea]") {
+  // Vertical: (0x04, 0x08) avg 0x06; (0x20, 0x40) avg 0x30.
+  uint32_t const kSrc[4] = {0xFF000004U, 0xFF000008U, 0xFF000020U, 0xFF000040U};
+  uint32_t dest[2] = {};
+  ScaleDrawArea(kSrc, 1, 4, 1, dest, 1, 2, 1);
+  REQUIRE(dest[0] == 0xFF000006U);
+  REQUIRE(dest[1] == 0xFF000030U);
+}
+
 TEST_CASE("updatemenupalettes repacks pal32 with the menu animation", "[blit][pal32]") {
   // Regression: the menu palette rebuild must end with an UpdatePal32 (and
   // must not compose) — menus draw through pal32, so a stale LUT freezes


### PR DESCRIPTION
## Summary

- Adds `ScaleDrawArea` box-filter area-averaging downscale to `gfx/blit.cpp` (4 Catch2 tests in `test_blit.cpp`)
- Rewrites `SpectatorViewport::Draw` into a **world pass** (level + objects + sprites at 1:1 into a scratch bitmap) + `ScaleDrawArea` composite + **HUD overlay** at native resolution on top
- `SpectatorViewport::Process` computes zoom each frame from the worm bounding box + 60 px margin, clamped to 1.0× max
- Controller viewport rects changed to `Rect(0, 0, 640, 400)`; old `504+68` centering hack removed
- `DrawMiniature` gains independent `step_x`/`step_y` axes and is now `const`-qualified; all minimap call sites updated; `fileSelectorState.cpp` adds `FillRect` before each draw to clear stale pixels when switching level previews
- Spectator window renders at the actual pixel resolution of the OS window: `OnWindowResize` queries `SDL_GetWindowSize` and resizes `single_screen_renderer` to match; single-screen replay mode resets it to 640×400 (where it doubles as the main window renderer) and restores on game exit

## Known limitation

Extreme CPU slowdown when worms move far apart and trigger zoom-out on a large native spectator window. Root cause: scratch bitmap scales as `(render_w × render_h) / zoom²`. To be addressed in PR7 (rendering pipeline optimisation), which opens with a profiling pass before fixing.

## Test plan

- [x] Build and run `test_blit` — 4 `ScaleDrawArea` cases pass
- [x] Smoke-launch: `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/openliero` exits 124
- [x] Hotseat on the standard 504×350 map: zoom stays at 1×, HUD and minimap correct
- [x] Hotseat on a large map (e.g. generated 4096²): worms moving apart triggers zoom-out and both remain visible; HUD stays crisp
- [x] Level selector preview: minimap fills its allocated rect for non-square maps; switching levels clears stale pixels
- [x] Resize spectator window to a non-640×400 size and confirm it renders at native resolution (no SDL upscale artifacts)
- [x] clang-format and clang-tidy diff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)