### PR TITLE
Arbitrary map sizes PR 5: configurable videotool output resolution

### DIFF
--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -150,7 +150,7 @@ Delivered on branch `arbitrary-map-sizes-pr4`:
 > **Known limitation**: extreme CPU slowdown when worms move far apart and
 > zoom-out is triggered on a large native spectator window. Addressed in PR 7.
 
-### PR 5 — Configurable videotool output resolution
+### PR 5 — Configurable videotool output resolution — **DONE**
 - **`tools_main.cpp`**: add `-w/-h` (or `--res WxH`) parsing alongside `-d/-s/-r`.
 - **`replay_to_video.{hpp,cpp}`**: thread output dims through; remove hardcoded
   `kW=1280/kH=720` (lines 66-67); set spectator render resolution from the
@@ -300,7 +300,7 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 - [x] PR2: new sized format loads/saves; legacy files still load; 4096² level generates on demand; tools + doc updated.
 - [x] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
 - [x] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes; native-resolution spectator window.
-- [ ] PR5: videotool output resolution selectable; scaler input dynamic.
+- [x] PR5: videotool output resolution selectable; scaler input dynamic.
 - [ ] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
 - [ ] PR7: spectator viewport frame time within budget at ≥1280×800 with worms at maximum separation on a 4096² level.
 - [ ] Determinism/rollback suites + format checks pass on every PR.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,12 @@ if(OPENLIERO_BUILD_TESTS)
     target_include_directories(test_sfx_loader PRIVATE src src/game)
     catch_discover_tests(test_sfx_loader DISCOVERY_MODE PRE_TEST)
   endif()
+
+  if(OPENLIERO_BUILD_VIDEOTOOL)
+    add_executable(test_videotool_args src/tests/test_videotool_args.cpp)
+    target_link_libraries(test_videotool_args PRIVATE game Catch2::Catch2WithMain)
+    catch_discover_tests(test_videotool_args DISCOVERY_MODE PRE_TEST)
+  endif()
 endif()
 
 # documentation

--- a/src/tests/test_videotool_args.cpp
+++ b/src/tests/test_videotool_args.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch_test_macros.hpp>
+#include "video_tool/videotool_args.hpp"
+
+TEST_CASE("ParseVideoToolArgs defaults") {
+  char prog[] = "videotool";
+  char* argv[] = {prog};
+  auto args = ParseVideoToolArgs(1, argv);
+  CHECK(args.width == 1280);
+  CHECK(args.height == 720);
+  CHECK(!args.spectator);
+  CHECK(!args.dir);
+  CHECK(args.tc_name == "openliero");
+  CHECK(args.replay_path.empty());
+}
+
+TEST_CASE("ParseVideoToolArgs -w/-h set output resolution") {
+  char prog[] = "videotool";
+  char fw[] = "-w";
+  char vw[] = "1920";
+  char fh[] = "-h";
+  char vh[] = "1080";
+  char* argv[] = {prog, fw, vw, fh, vh};
+  auto args = ParseVideoToolArgs(5, argv);
+  CHECK(args.width == 1920);
+  CHECK(args.height == 1080);
+}
+
+TEST_CASE("ParseVideoToolArgs -s sets spectator") {
+  char prog[] = "videotool";
+  char fs[] = "-s";
+  char* argv[] = {prog, fs};
+  auto args = ParseVideoToolArgs(2, argv);
+  CHECK(args.spectator);
+  CHECK(!args.dir);
+  CHECK(args.width == 1280);
+  CHECK(args.height == 720);
+}
+
+TEST_CASE("ParseVideoToolArgs -r sets replay path") {
+  char prog[] = "videotool";
+  char fr[] = "-r";
+  char vr[] = "/path/to/replay.lrp";
+  char* argv[] = {prog, fr, vr};
+  auto args = ParseVideoToolArgs(3, argv);
+  CHECK(args.replay_path == "/path/to/replay.lrp");
+}
+
+TEST_CASE("ParseVideoToolArgs positional arg sets tc name") {
+  char prog[] = "videotool";
+  char tc[] = "mytc";
+  char* argv[] = {prog, tc};
+  auto args = ParseVideoToolArgs(2, argv);
+  CHECK(args.tc_name == "mytc");
+}
+
+TEST_CASE("ParseVideoToolArgs combined flags and resolution") {
+  char prog[] = "videotool";
+  char fs[] = "-s";
+  char fw[] = "-w";
+  char vw[] = "3840";
+  char fh[] = "-h";
+  char vh[] = "2160";
+  char fr[] = "-r";
+  char vr[] = "game.lrp";
+  char* argv[] = {prog, fs, fw, vw, fh, vh, fr, vr};
+  auto args = ParseVideoToolArgs(8, argv);
+  CHECK(args.spectator);
+  CHECK(args.width == 3840);
+  CHECK(args.height == 2160);
+  CHECK(args.replay_path == "game.lrp");
+  CHECK(!args.dir);
+}
+
+TEST_CASE("ParseVideoToolArgs -d sets directory mode") {
+  char prog[] = "videotool";
+  char fd[] = "-d";
+  char* argv[] = {prog, fd};
+  auto args = ParseVideoToolArgs(2, argv);
+  CHECK(args.dir);
+}

--- a/src/video_tool/replay_to_video.cpp
+++ b/src/video_tool/replay_to_video.cpp
@@ -21,12 +21,13 @@ extern "C" {
 #include "game/mixer/mixer.hpp"
 
 void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
-                   std::string const& full_path, std::string const& replay_video_name) {
+                   std::string const& full_path, std::string const& replay_video_name, int width,
+                   int height) {
   ReplayReader replay_reader(std::make_unique<io::FileReader>(full_path.c_str(), "rb"));
   Renderer renderer;
 
   if (spectator) {
-    renderer.Init(640, 400);
+    renderer.Init(width, height);
     renderer.LoadPalette(*common);
   } else {
     renderer.Init(320, 200);
@@ -55,16 +56,11 @@ void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
     game->worms[1]->stats_x = 218;
   }
 
-  // spectator viewport is always full size
-  // +68 on x to align the viewport in the middle
-  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, 504 + 68, 350)));
+  game->AddSpectatorViewport(new SpectatorViewport(Rect(0, 0, width, height)));
   game->AddViewport(new Viewport(Rect(0, 0, 158, 158), game->worms[0]->index));
   game->AddViewport(new Viewport(Rect(160, 0, 158 + 160, 158), game->worms[1]->index));
   game->StartGame();
   game->Focus(renderer);
-
-  int const kW = 1280;
-  int const kH = 720;
 
   AVRational framerate;
   framerate.num = 1;
@@ -75,7 +71,7 @@ void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
   native_framerate.den = 70;
 
   video_recorder vidrec;
-  VidrecInit(&vidrec, replay_video_name.c_str(), kW, kH, framerate);
+  VidrecInit(&vidrec, replay_video_name.c_str(), width, height, framerate);
 
   std::vector<int16_t> sound_buffer = std::vector<int16_t>();
 
@@ -91,7 +87,7 @@ void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
 
   int offset_x = 0;
   int offset_y = 0;
-  int const kMag = FitScreen(640, 400, renderer.bmp.w, renderer.bmp.h, offset_x, offset_y);
+  int const kMag = FitScreen(width, height, renderer.bmp.w, renderer.bmp.h, offset_x, offset_y);
 
   int f = 0;
 

--- a/src/video_tool/replay_to_video.hpp
+++ b/src/video_tool/replay_to_video.hpp
@@ -5,4 +5,5 @@
 #include "game/common.hpp"
 
 void ReplayToVideo(std::shared_ptr<Common> const& common, bool spectator,
-                   std::string const& full_path, std::string const& replay_video_name);
+                   std::string const& full_path, std::string const& replay_video_name,
+                   int width = 1280, int height = 720);

--- a/src/video_tool/tools_main.cpp
+++ b/src/video_tool/tools_main.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "replay_to_video.hpp"
+#include "video_tool/videotool_args.hpp"
 
 // NOLINTNEXTLINE(misc-no-recursion) — small glob matcher; recursion depth bounded by pattern length.
 bool Match(unsigned char const* str, unsigned char const* pat) {
@@ -29,72 +30,36 @@ bool Match(std::string const& str, std::string const& pat) {
 }
 
 int main(int argc, char* argv[]) try {
-  bool tc_set = false;
-  bool dir = false;
-  bool spectator = false;
-
-  std::string tc_name;
-  std::string replay_path;
-
-  for (int i = 1; i < argc; ++i) {
-    if (argv[i][0] == '-') {
-      switch (argv[i][1]) {
-        case 'd':
-          dir = true;
-          break;
-
-        case 's':
-          spectator = true;
-          break;
-
-        case 'r':
-          ++i;
-          if (i < argc) {
-            replay_path = &argv[i][0];
-          }
-          break;
-        default:
-          break;
-      }
-    } else {
-      tc_name = argv[i];
-      tc_set = true;
-    }
-  }
-
-  if (!tc_set) {
-    tc_name = "openliero";
-  }
+  VideoToolArgs const kArgs = ParseVideoToolArgs(argc, argv);
 
   PrecomputeTables();
 
   // Use the same path-resolution logic as the main binary.
-  // paths::Resolve ignores single-dash flags, so -d/-s/-r pass through harmlessly.
+  // paths::Resolve ignores single-dash flags, so -d/-s/-r/-w/-h pass through harmlessly.
   // Output videos land next to the replay file; no writes go to any config path.
   auto r = paths::Resolve(argc, argv);
   std::shared_ptr<Common> const kCommon = std::make_shared<Common>();
-  kCommon->load(r.config_node / "TC" / tc_name);
+  kCommon->load(r.config_node / "TC" / kArgs.tc_name);
 
-  std::string suffix = "_n";
-  if (spectator) {
-    suffix = "_s";
-  }
+  std::string const kSuffix = kArgs.spectator ? "_s" : "_n";
 
-  if (dir) {
-    auto const& root = GetRoot(replay_path);
+  if (kArgs.dir) {
+    auto const& root = GetRoot(kArgs.replay_path);
     DirectoryListing di(root);
 
     for (auto const& path : di) {
       if (GetExtension(path.name) == "lrp") {
         auto const& full_path = JoinPath(root, path.name);
-        if (Match(full_path, replay_path)) {
+        if (Match(full_path, kArgs.replay_path)) {
           std::printf("Converting %s\n", full_path.c_str());
-          ReplayToVideo(kCommon, spectator, full_path, full_path + suffix + ".mp4");
+          ReplayToVideo(kCommon, kArgs.spectator, full_path, full_path + kSuffix + ".mp4",
+                        kArgs.width, kArgs.height);
         }
       }
     }
   } else {
-    ReplayToVideo(kCommon, spectator, replay_path, replay_path + suffix + ".mp4");
+    ReplayToVideo(kCommon, kArgs.spectator, kArgs.replay_path, kArgs.replay_path + kSuffix + ".mp4",
+                  kArgs.width, kArgs.height);
   }
 
   return 0;

--- a/src/video_tool/video_recorder.c
+++ b/src/video_tool/video_recorder.c
@@ -136,7 +136,7 @@ int VidrecInit(video_recorder* self, char const* filename, int width, int height
 		}
 
 		/* Allocate temporary picture for source format conversion */
-		self->tmp_picture = alloc_frame(SOURCE_PIX_FMT, 640, 400);
+		self->tmp_picture = alloc_frame(SOURCE_PIX_FMT, width, height);
 		if (!self->tmp_picture) {
 			fprintf(stderr, "Could not allocate temporary picture\n");
 			return 1;
@@ -324,7 +324,7 @@ int VidrecWriteVideoFrame(video_recorder* self, AVFrame* pic)
 
 	/* Set up the conversion context if needed */
 	if (self->img_convert_ctx == NULL) {
-		self->img_convert_ctx = sws_getContext(640, 400,
+		self->img_convert_ctx = sws_getContext(pic->width, pic->height,
 		                                       SOURCE_PIX_FMT,
 		                                       c->width, c->height,
 		                                       c->pix_fmt,
@@ -343,7 +343,7 @@ int VidrecWriteVideoFrame(video_recorder* self, AVFrame* pic)
 	}
 
 	sws_scale(self->img_convert_ctx, (const uint8_t * const*) pic->data,
-	          pic->linesize, 0, 400, self->picture->data,
+	          pic->linesize, 0, pic->height, self->picture->data,
 	          self->picture->linesize);
 
 	self->picture->pts = self->frame_count++;

--- a/src/video_tool/videotool_args.hpp
+++ b/src/video_tool/videotool_args.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+
+struct VideoToolArgs {
+  bool dir{false};
+  bool spectator{false};
+  int width{1280};
+  int height{720};
+  std::string tc_name{"openliero"};
+  std::string replay_path;
+};
+
+inline VideoToolArgs ParseVideoToolArgs(int argc, char* argv[]) {
+  VideoToolArgs args;
+  for (int i = 1; i < argc; ++i) {
+    if (argv[i][0] == '-') {
+      switch (argv[i][1]) {
+        case 'd':
+          args.dir = true;
+          break;
+        case 's':
+          args.spectator = true;
+          break;
+        case 'r':
+          ++i;
+          if (i < argc) {
+            args.replay_path = argv[i];
+          }
+          break;
+        case 'w':
+          ++i;
+          if (i < argc) {
+            args.width = std::stoi(argv[i]);
+          }
+          break;
+        case 'h':
+          ++i;
+          if (i < argc) {
+            args.height = std::stoi(argv[i]);
+          }
+          break;
+        default:
+          break;
+      }
+    } else {
+      args.tc_name = argv[i];
+    }
+  }
+  return args;
+}


### PR DESCRIPTION
## Summary

- Adds `-w W` and `-h H` CLI flags to `videotool` for selecting output resolution (default 1280×720).
- Spectator renderer is initialised at the requested output size, so the world pass renders at native output resolution with no unnecessary rescaling.
- `video_recorder.c`: `tmp_picture` is now allocated at `width×height` instead of hardcoded 640×400; `sws_getContext` and `sws_scale` use `pic->width`/`pic->height` dynamically, fixing a latent bug where the scaler input was hardcoded to 640×400.
- Old `SpectatorViewport(Rect(0, 0, 504+68, 350))` in the videotool updated to `Rect(0, 0, width, height)`.
- New `videotool_args.hpp` extracts arg parsing into a testable inline function; 7 Catch2 tests cover defaults, `-w`/`-h`, and all existing flags.

## Test plan

- [x] `test_videotool_args` — 7 cases / 20 assertions (defaults, `-w`/`-h`, `-s`, `-r`, `-d`, combined)
- [x] All 249 ctest tests pass
- [x] `test_determinism`, `test_rollback_correctness`, `test_rollback_desync` — green
- [x] Smoke launch exits 124 (ran until timeout)
- [x] `clang-format --dry-run -Werror` clean on all touched files
- [x] `clang-tidy` clean on all touched `.cpp` files
- [x] Manual: render a replay at 1920×1080 (`-s -w 1920 -h 1080`) and confirm output dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)