### PR TITLE
Arbitrary map sizes PR6: rollback snapshot dirty-cell optimisation

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -720,22 +720,28 @@ void Game::SaveSnapshotFast(GameSnapshot& snap) {
     snap.level_data.resize(kCells);
   }
 
-  if (level.dirty_bits.empty()) {
-    // First save: dirty tracking not yet initialised.  Prepare() already
-    // pre-filled snap.level_data with the initial level state, but guard in
-    // case Prepare() was not called before the first save.
+  if (level.dirty_bits.empty() || !snap.initialized) {
+    // Full copy: either the first save ever (initialise dirty tracking) or the
+    // first save to this particular slot (populate its base level state).
+    // Deferring the per-slot copy to here (rather than doing it eagerly in
+    // Prepare) spreads 8 × W×H bytes across the first 8 gameplay frames
+    // instead of blocking the weapon-selection init loop with a large upfront
+    // allocation on large levels.
     if (kCells > 0) {
       std::memcpy(snap.level_data.data(), level.material_id.data(), kCells);
     }
     if (!level.display_valid.empty() && !snap.level_display_valid.empty()) {
       std::memcpy(snap.level_display_valid.data(), level.display_valid.data(), kCells);
     }
-    level.InitDirtyTracking();
+    if (level.dirty_bits.empty()) {
+      level.InitDirtyTracking();
+    }
+    snap.initialized = true;
   } else {
     // Sparse update: overwrite only the cells modified since game start.
     // dirty_list accumulates and is never cleared, so every slot always
-    // reflects the cumulative diff from the initial level state, making
-    // every slot independently restorable (base = Prepare()-time data).
+    // reflects the cumulative diff from its initial full-copy baseline,
+    // making every slot independently restorable.
     bool const kHasDv = !level.display_valid.empty() && !snap.level_display_valid.empty();
     for (int32_t i : level.dirty_list) {
       auto const kI = static_cast<std::size_t>(i);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -743,8 +743,8 @@ void Game::SaveSnapshotFast(GameSnapshot& snap) {
     // reflects the cumulative diff from its initial full-copy baseline,
     // making every slot independently restorable.
     bool const kHasDv = !level.display_valid.empty() && !snap.level_display_valid.empty();
-    for (int32_t i : level.dirty_list) {
-      auto const kI = static_cast<std::size_t>(i);
+    for (int32_t const kDirtyIdx : level.dirty_list) {
+      auto const kI = static_cast<std::size_t>(kDirtyIdx);
       snap.level_data[kI] = level.material_id[kI];
       if (kHasDv) {
         snap.level_display_valid[kI] = level.display_valid[kI];
@@ -795,8 +795,8 @@ void Game::LoadSnapshotFast(GameSnapshot const& snap) {
         level.materials[i] = common->materials[level.material_id[i]];
       }
     } else {
-      for (int32_t i : level.dirty_list) {
-        auto const kI = static_cast<std::size_t>(i);
+      for (int32_t const kDirtyIdx : level.dirty_list) {
+        auto const kI = static_cast<std::size_t>(kDirtyIdx);
         level.materials[kI] = common->materials[level.material_id[kI]];
       }
     }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -686,7 +686,7 @@ void Game::LoadSnapshot(std::vector<uint8_t> const& in) {
   LoadGameSnapshot(ar, *this);
 }
 
-void Game::SaveSnapshotFast(GameSnapshot& snap) const {
+void Game::SaveSnapshotFast(GameSnapshot& snap) {
   snap.rand = rand;
   snap.cycles = cycles;
   snap.screen_flash = screen_flash;
@@ -719,18 +719,34 @@ void Game::SaveSnapshotFast(GameSnapshot& snap) const {
   if (snap.level_data.size() != kCells) {
     snap.level_data.resize(kCells);
   }
-  if (snap.level_materials.size() != kCells) {
-    snap.level_materials.resize(kCells);
+
+  if (level.dirty_bits.empty()) {
+    // First save: dirty tracking not yet initialised.  Prepare() already
+    // pre-filled snap.level_data with the initial level state, but guard in
+    // case Prepare() was not called before the first save.
+    if (kCells > 0) {
+      std::memcpy(snap.level_data.data(), level.material_id.data(), kCells);
+    }
+    if (!level.display_valid.empty() && !snap.level_display_valid.empty()) {
+      std::memcpy(snap.level_display_valid.data(), level.display_valid.data(), kCells);
+    }
+    level.InitDirtyTracking();
+  } else {
+    // Sparse update: overwrite only the cells modified since game start.
+    // dirty_list accumulates and is never cleared, so every slot always
+    // reflects the cumulative diff from the initial level state, making
+    // every slot independently restorable (base = Prepare()-time data).
+    bool const kHasDv = !level.display_valid.empty() && !snap.level_display_valid.empty();
+    for (int32_t i : level.dirty_list) {
+      auto const kI = static_cast<std::size_t>(i);
+      snap.level_data[kI] = level.material_id[kI];
+      if (kHasDv) {
+        snap.level_display_valid[kI] = level.display_valid[kI];
+      }
+    }
   }
-  if (kCells > 0) {
-    std::memcpy(snap.level_data.data(), level.material_id.data(), kCells);
-    std::memcpy(snap.level_materials.data(), level.materials.data(), kCells * sizeof(Material));
-  }
-  // display_data is static (never modified during simulation) so only
-  // display_valid is snapshotted; display_data is left untouched on restore.
-  if (!level.display_valid.empty() && !snap.level_display_valid.empty()) {
-    std::memcpy(snap.level_display_valid.data(), level.display_valid.data(), kCells);
-  }
+  // level_materials is omitted from the snapshot (see fast_snapshot.hpp).
+  // display_data is static (never modified during simulation); left untouched.
 }
 
 void Game::LoadSnapshotFast(GameSnapshot const& snap) {
@@ -759,8 +775,25 @@ void Game::LoadSnapshotFast(GameSnapshot const& snap) {
   std::size_t const kCells =
       static_cast<std::size_t>(level.width) * static_cast<std::size_t>(level.height);
   if (kCells > 0) {
+    // Restore material_id (full memcpy; the slot is pre-filled at Prepare() and
+    // dirty cells are overwritten on each save, so the slot is always complete).
     std::memcpy(level.material_id.data(), snap.level_data.data(), kCells);
-    std::memcpy(level.materials.data(), snap.level_materials.data(), kCells * sizeof(Material));
+
+    // Restore materials without storing them in the snapshot.  Clean cells
+    // were never modified, so their materials are still valid from level
+    // initialisation.  Only dirty cells need recomputing.  Fall back to a
+    // full O(W×H) pass when dirty tracking hasn't been initialised yet (e.g.
+    // on the shadow-game bootstrap LoadSnapshotFast).
+    if (level.dirty_bits.empty()) {
+      for (std::size_t i = 0; i < kCells; ++i) {
+        level.materials[i] = common->materials[level.material_id[i]];
+      }
+    } else {
+      for (int32_t i : level.dirty_list) {
+        auto const kI = static_cast<std::size_t>(i);
+        level.materials[kI] = common->materials[level.material_id[kI]];
+      }
+    }
   }
   // display_data is static; restore only display_valid.
   if (!snap.level_display_valid.empty() && !level.display_valid.empty()) {

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -87,7 +87,9 @@ struct Game {
   // Fast in-memory snapshot path used by the rollback ring buffer.
   // Writes/reads directly into a pre-allocated GameSnapshot — no
   // serialisation, no allocation in the steady state.
-  void SaveSnapshotFast(struct GameSnapshot& snap) const;
+  // SaveSnapshotFast is non-const: on the first call it initialises dirty
+  // tracking on the level (Level::InitDirtyTracking).
+  void SaveSnapshotFast(struct GameSnapshot& snap);
   void LoadSnapshotFast(struct GameSnapshot const& snap);
 
   void SpawnZone();

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -365,6 +365,7 @@ void BlitImageOnMap(Common& common, Level& level, PalIdx* mem, int x, int y, int
       *rowdest = n;
       *rowmatdest = common.materials[n];
       if (kDv) kDv[rowdest - kBase] = 0;
+      level.MarkDirty(static_cast<int>(rowdest - kBase));
     }
   });
 }
@@ -431,6 +432,7 @@ void BlitStone(Common& common, Level& level, bool p1, const PalIdx* mem, int x, 
         if (kDv) {
           kDv[rowdest - kBase] = 0;
         }
+        level.MarkDirty(static_cast<int>(rowdest - kBase));
         ++rowsrc;
         ++rowdest;
         ++rowmatdest;
@@ -454,6 +456,7 @@ void BlitStone(Common& common, Level& level, bool p1, const PalIdx* mem, int x, 
           if (kDv) {
             kDv[rowdest - kBase] = 0;
           }
+          level.MarkDirty(static_cast<int>(rowdest - kBase));
         }
 
         ++rowsrc;
@@ -496,6 +499,7 @@ void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, i
             *rowdest = t_frame[((my & 15) << 4) + (mx & 15)];
             *rowmatdest = common.materials[*rowdest];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           }
           break;
 
@@ -505,10 +509,12 @@ void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, i
             *rowdest = 2;
             *rowmatdest = common.materials[2];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           } else if (m.Dirt()) {
             *rowdest = 1;
             *rowmatdest = common.materials[1];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           }
         } break;
         default:
@@ -527,6 +533,7 @@ void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, i
             *rowdest = t_frame[((my & 15) << 4) + (mx & 15)];
             *rowmatdest = common.materials[*rowdest];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           }
           break;
 
@@ -535,6 +542,7 @@ void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, i
             *rowdest = 2;
             *rowmatdest = common.materials[2];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           }
           break;
 
@@ -543,6 +551,7 @@ void DrawDirtEffect(Common& common, Rand& rand, Level& level, int dirt_effect, i
             *rowdest = 1;
             *rowmatdest = common.materials[1];
             if (kDv) kDv[rowdest - kBase] = 0;
+            level.MarkDirty(static_cast<int>(rowdest - kBase));
           }
           break;
         default:

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -220,6 +220,10 @@ void Level::Resize(int width_new, int height_new) {
   height = height_new;
   material_id.resize(width * height);
   materials.resize(width * height);
+  // Dirty tracking is size-dependent; reset so the next SaveSnapshotFast
+  // re-initialises for the new dimensions.
+  dirty_bits.clear();
+  dirty_list.clear();
 }
 
 bool Level::load(Common& common, Settings const& settings, io::Reader& r) {

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -67,10 +67,7 @@ struct Level {
     if (!display_valid.empty()) {
       display_valid[kIdx] = 0;
     }
-    if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(kIdx)]) {
-      dirty_bits[static_cast<std::size_t>(kIdx)] = true;
-      dirty_list.push_back(kIdx);
-    }
+    MarkDirty(kIdx);
   }
 
   void SetPixel(fixedvec pos, PalIdx w, Common& common) {
@@ -80,10 +77,7 @@ struct Level {
     if (!display_valid.empty()) {
       display_valid[kIdx] = 0;
     }
-    if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(kIdx)]) {
-      dirty_bits[static_cast<std::size_t>(kIdx)] = true;
-      dirty_list.push_back(kIdx);
-    }
+    MarkDirty(kIdx);
   }
 
   // Initialise dirty tracking for rollback snapshot optimisation.
@@ -94,8 +88,9 @@ struct Level {
   }
 
   // Mark a flat cell index as dirty for rollback snapshot optimisation.
-  // Called by blit helpers that write material_id directly (bypassing SetPixel).
-  // No-op before InitDirtyTracking is called.
+  // The single choke-point for dirty tracking: SetPixel delegates here, and
+  // blit helpers that write material_id directly (bypassing SetPixel) call it
+  // explicitly. No-op before InitDirtyTracking is called.
   void MarkDirty(int idx) {
     if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(idx)]) {
       dirty_bits[static_cast<std::size_t>(idx)] = true;

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -67,6 +67,10 @@ struct Level {
     if (!display_valid.empty()) {
       display_valid[kIdx] = 0;
     }
+    if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(kIdx)]) {
+      dirty_bits[static_cast<std::size_t>(kIdx)] = true;
+      dirty_list.push_back(kIdx);
+    }
   }
 
   void SetPixel(fixedvec pos, PalIdx w, Common& common) {
@@ -75,6 +79,27 @@ struct Level {
     materials[kIdx] = common.materials[w];
     if (!display_valid.empty()) {
       display_valid[kIdx] = 0;
+    }
+    if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(kIdx)]) {
+      dirty_bits[static_cast<std::size_t>(kIdx)] = true;
+      dirty_list.push_back(kIdx);
+    }
+  }
+
+  // Initialise dirty tracking for rollback snapshot optimisation.
+  // Called once by SaveSnapshotFast before the first rollback save.
+  void InitDirtyTracking() {
+    dirty_bits.assign(static_cast<std::size_t>(width) * static_cast<std::size_t>(height), false);
+    dirty_list.clear();
+  }
+
+  // Mark a flat cell index as dirty for rollback snapshot optimisation.
+  // Called by blit helpers that write material_id directly (bypassing SetPixel).
+  // No-op before InitDirtyTracking is called.
+  void MarkDirty(int idx) {
+    if (!dirty_bits.empty() && !dirty_bits[static_cast<std::size_t>(idx)]) {
+      dirty_bits[static_cast<std::size_t>(idx)] = true;
+      dirty_list.push_back(idx);
     }
   }
 
@@ -117,6 +142,8 @@ struct Level {
     display_valid.swap(other.display_valid);
     argb_ramps.swap(other.argb_ramps);
     display_anim.swap(other.display_anim);
+    dirty_bits.swap(other.dirty_bits);
+    dirty_list.swap(other.dirty_list);
     std::swap(width, other.width);
     std::swap(height, other.height);
     std::swap(origpal, other.origpal);
@@ -160,6 +187,13 @@ struct Level {
   // a colour. All three fields are immutable after load; never snapshotted.
   std::vector<ArgbRamp> argb_ramps;
   std::vector<uint8_t> display_anim;
+
+  // Rollback snapshot optimisation: dirty tracking for SaveSnapshotFast.
+  // Both are empty until InitDirtyTracking() is called (first rollback save).
+  // dirty_list accumulates indices of every cell ever modified via SetPixel;
+  // dirty_bits prevents duplicates. Neither is ever cleared during a game.
+  std::vector<bool> dirty_bits;
+  std::vector<int32_t> dirty_list;
 
   bool old_random_level;
   std::string old_level_file;

--- a/src/game/serialization/fast_snapshot.hpp
+++ b/src/game/serialization/fast_snapshot.hpp
@@ -156,9 +156,15 @@ struct GameSnapshot {
   std::vector<BObject> bobjects_arr;
   std::size_t bobjects_count = 0;
 
+  // Level material_id bytes.  Pre-filled with the level's initial state at
+  // Prepare() time; only dirty cells are overwritten on each subsequent save.
+  // level_materials is omitted: it is always derivable as
+  //   common.materials[material_id[i]]
+  // and is recomputed on restore (see Game::LoadSnapshotFast).
   std::vector<uint8_t> level_data;
-  std::vector<Material> level_materials;
   // display_valid is snapshotted because terrain destruction zeroes it.
+  // Pre-filled with the level's initial state at Prepare() time; dirty cells
+  // overwritten on each subsequent save.
   // display_data is static (never written during simulation) and intentionally
   // omitted here — omitting 64 MB/slot (4096² ARGB) keeps the ring buffer
   // from bloating to ~500 MB for large levels.
@@ -166,16 +172,23 @@ struct GameSnapshot {
 
   uint32_t checksum = 0;
 
-  // Pre-size the dynamic buffers so save/load can avoid allocations.
-  // Call once after the level is generated.
+  // Pre-size the dynamic buffers and fill the level snapshot with the current
+  // level state so that the sparse-save path (SaveSnapshotFast) only needs to
+  // overwrite dirty cells on each subsequent call.
+  // Call once after the level is generated, before the first SaveSnapshotFast.
   void Prepare(Game const& game) {
     bobjects_arr.resize(game.bobjects.limit);
     std::size_t const kCells =
         static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
     level_data.resize(kCells);
-    level_materials.resize(kCells);
+    if (kCells > 0) {
+      std::memcpy(level_data.data(), game.level.material_id.data(), kCells);
+    }
     if (!game.level.display_data.empty()) {
       level_display_valid.resize(kCells);
+      if (kCells > 0) {
+        std::memcpy(level_display_valid.data(), game.level.display_valid.data(), kCells);
+      }
     }
   }
 };

--- a/src/game/serialization/fast_snapshot.hpp
+++ b/src/game/serialization/fast_snapshot.hpp
@@ -156,15 +156,16 @@ struct GameSnapshot {
   std::vector<BObject> bobjects_arr;
   std::size_t bobjects_count = 0;
 
-  // Level material_id bytes.  Pre-filled with the level's initial state at
-  // Prepare() time; only dirty cells are overwritten on each subsequent save.
+  // Level material_id bytes.  On the first save to this slot a full copy of
+  // the live level is written; only dirty cells are overwritten on each
+  // subsequent save to the same slot.
   // level_materials is omitted: it is always derivable as
   //   common.materials[material_id[i]]
   // and is recomputed on restore (see Game::LoadSnapshotFast).
   std::vector<uint8_t> level_data;
   // display_valid is snapshotted because terrain destruction zeroes it.
-  // Pre-filled with the level's initial state at Prepare() time; dirty cells
-  // overwritten on each subsequent save.
+  // First save to this slot copies the full live array; dirty cells are
+  // overwritten on each subsequent save to the same slot.
   // display_data is static (never written during simulation) and intentionally
   // omitted here — omitting 64 MB/slot (4096² ARGB) keeps the ring buffer
   // from bloating to ~500 MB for large levels.
@@ -172,23 +173,26 @@ struct GameSnapshot {
 
   uint32_t checksum = 0;
 
-  // Pre-size the dynamic buffers and fill the level snapshot with the current
-  // level state so that the sparse-save path (SaveSnapshotFast) only needs to
-  // overwrite dirty cells on each subsequent call.
+  // True after the first SaveSnapshotFast call to this slot.  Until then the
+  // level_data / level_display_valid buffers are allocated but contain
+  // uninitialised data; SaveSnapshotFast uses this flag to trigger a one-time
+  // full copy instead of the sparse dirty-cell path.
+  bool initialized = false;
+
+  // Pre-size the dynamic buffers so that the first SaveSnapshotFast call can
+  // write directly without reallocating.  Intentionally does NOT copy level
+  // data — that copy is deferred to the first SaveSnapshotFast call so that
+  // initialising all ring-buffer slots during weapon-selection setup does not
+  // block the main loop with a large upfront memcpy.
   // Call once after the level is generated, before the first SaveSnapshotFast.
   void Prepare(Game const& game) {
     bobjects_arr.resize(game.bobjects.limit);
     std::size_t const kCells =
         static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
     level_data.resize(kCells);
-    if (kCells > 0) {
-      std::memcpy(level_data.data(), game.level.material_id.data(), kCells);
-    }
     if (!game.level.display_data.empty()) {
       level_display_valid.resize(kCells);
-      if (kCells > 0) {
-        std::memcpy(level_display_valid.data(), game.level.display_valid.data(), kCells);
-      }
     }
+    initialized = false;
   }
 };

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -276,58 +276,80 @@ TEST_CASE("Fast snapshot round-trips the display layer", "[snapshot][rollback][d
 
 TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollback][dirty]") {
   // Verifies:
-  //  - Level.dirty_list is populated by SetPixel after SaveSnapshotFast inits tracking
-  //  - Only modified cells are written to the slot on subsequent saves
+  //  - First save to a slot triggers a full copy and initialises dirty tracking
+  //  - Second save to the SAME slot uses the sparse path (only dirty cells written)
+  //  - First save to a FRESH slot always does a full copy regardless of dirty state
   //  - level_materials is absent from GameSnapshot (materials recomputed on restore)
-  //  - Round-trip correctness after dirty-cell restore
+  //  - Round-trip correctness for both post-modification and pre-modification restores
 
   GameRunner r(0x1EADBEE5);
   Game& game = *r.game;
   std::size_t const kCells =
       static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
 
-  GameSnapshot snap;
-  snap.Prepare(game);
+  // snap_a: will be saved twice — before and after the modification.
+  // snap_b: saved once, before the modification, to test restoring to initial state.
+  GameSnapshot snap_a;
+  snap_a.Prepare(game);
+  GameSnapshot snap_b;
+  snap_b.Prepare(game);
 
-  // First save: inits dirty tracking; snap must carry all initial material_ids.
-  game.SaveSnapshotFast(snap);
-  REQUIRE(snap.level_data.size() == kCells);
-  REQUIRE(
-      std::equal(snap.level_data.begin(), snap.level_data.end(), game.level.material_id.begin()));
+  // First save to both slots: full copy; inits dirty tracking.
+  game.SaveSnapshotFast(snap_a);
+  game.SaveSnapshotFast(snap_b);
+  REQUIRE(snap_a.level_data.size() == kCells);
+  REQUIRE(std::equal(snap_a.level_data.begin(), snap_a.level_data.end(),
+                     game.level.material_id.begin()));
   // dirty_list must now be initialised (empty, since no SetPixel since tracking start).
-  REQUIRE(game.level.dirty_list.empty());  // RED gate: dirty_list doesn't exist yet
+  REQUIRE(game.level.dirty_list.empty());
+
+  // Capture the initial material layout for later comparison.
+  std::vector<uint8_t> initial_data(game.level.material_id.begin(), game.level.material_id.end());
 
   // Modify one cell.
   int const kX = 42;
   int const kY = 37;
   int const kIdx = kX + kY * game.level.width;
-  unsigned char const kOldMat = game.level.material_id[kIdx];
+  unsigned char const kOldMat = initial_data[static_cast<std::size_t>(kIdx)];
   unsigned char const kNewMat =
       (kOldMat == 0) ? static_cast<unsigned char>(1) : static_cast<unsigned char>(0);
+  // snap_a should not yet reflect the modification.
+  REQUIRE(snap_a.level_data[static_cast<std::size_t>(kIdx)] == kOldMat);
   game.level.SetPixel(kX, kY, kNewMat, *game.common);
   REQUIRE(game.level.dirty_list.size() == 1);
 
-  // Second save into a fresh slot: must capture the dirty cell.
-  GameSnapshot snap2;
-  snap2.Prepare(game);
-  game.SaveSnapshotFast(snap2);
-  REQUIRE(snap2.level_data[kIdx] == kNewMat);
-  // All other cells still hold their initial values.
+  // Second save to snap_a (already initialised) — sparse path: only the dirty
+  // cell is overwritten; all other cells retain their first-save values.
+  game.SaveSnapshotFast(snap_a);
+  REQUIRE(snap_a.level_data[static_cast<std::size_t>(kIdx)] == kNewMat);
   for (std::size_t i = 0; i < kCells; ++i) {
     if (static_cast<int>(i) != kIdx) {
-      REQUIRE(snap2.level_data[i] == snap.level_data[i]);
+      REQUIRE(snap_a.level_data[i] == initial_data[i]);
     }
   }
 
-  // Corrupt the live cell, restore from snap2, verify correctness.
-  game.level.material_id[kIdx] = kOldMat;
-  game.LoadSnapshotFast(snap2);
-  REQUIRE(game.level.material_id[kIdx] == kNewMat);
-  // materials must be consistent with material_id after restore (no level_materials in slot).
-  REQUIRE(game.level.materials[kIdx].flags == game.common->materials[kNewMat].flags);
+  // Fresh slot saved after the modification: first save → full copy of current state.
+  GameSnapshot snap_c;
+  snap_c.Prepare(game);
+  game.SaveSnapshotFast(snap_c);
+  REQUIRE(snap_c.level_data[static_cast<std::size_t>(kIdx)] == kNewMat);
+  for (std::size_t i = 0; i < kCells; ++i) {
+    if (static_cast<int>(i) != kIdx) {
+      REQUIRE(snap_c.level_data[i] == initial_data[i]);
+    }
+  }
 
-  // Restoring snap (taken before the modification) gives back the old cell value.
-  game.LoadSnapshotFast(snap);
-  REQUIRE(game.level.material_id[kIdx] == kOldMat);
-  REQUIRE(game.level.materials[kIdx].flags == game.common->materials[kOldMat].flags);
+  // Corrupt the live cell and restore from snap_a (post-modification snapshot).
+  game.level.material_id[static_cast<std::size_t>(kIdx)] = kOldMat;
+  game.LoadSnapshotFast(snap_a);
+  REQUIRE(game.level.material_id[static_cast<std::size_t>(kIdx)] == kNewMat);
+  // materials must be consistent with material_id after restore (no level_materials in slot).
+  REQUIRE(game.level.materials[static_cast<std::size_t>(kIdx)].flags ==
+          game.common->materials[kNewMat].flags);
+
+  // Restore from snap_b (saved before the modification) — should recover kOldMat.
+  game.LoadSnapshotFast(snap_b);
+  REQUIRE(game.level.material_id[static_cast<std::size_t>(kIdx)] == kOldMat);
+  REQUIRE(game.level.materials[static_cast<std::size_t>(kIdx)].flags ==
+          game.common->materials[kOldMat].flags);
 }

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -6,7 +6,10 @@
 //   2. Cereal parity: fast-save + fast-restore produces the same
 //      post-restore state as cereal-save + cereal-restore.
 //   3. Performance: save and load both well under 500 µs.
+//   4. Dirty-cell tracking: only modified cells are written on each save;
+//      level_materials is absent from the slot (recomputed on restore).
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <cstdint>
@@ -269,4 +272,62 @@ TEST_CASE("Fast snapshot round-trips the display layer", "[snapshot][rollback][d
   game.SaveSnapshotFast(snap2);
   game.LoadSnapshotFast(snap2);
   REQUIRE(game.level.display_data.empty());
+}
+
+TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollback][dirty]") {
+  // Verifies:
+  //  - Level.dirty_list is populated by SetPixel after SaveSnapshotFast inits tracking
+  //  - Only modified cells are written to the slot on subsequent saves
+  //  - level_materials is absent from GameSnapshot (materials recomputed on restore)
+  //  - Round-trip correctness after dirty-cell restore
+
+  GameRunner r(0x1EADBEE5);
+  Game& game = *r.game;
+  std::size_t const kCells =
+      static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
+
+  GameSnapshot snap;
+  snap.Prepare(game);
+
+  // First save: inits dirty tracking; snap must carry all initial material_ids.
+  game.SaveSnapshotFast(snap);
+  REQUIRE(snap.level_data.size() == kCells);
+  REQUIRE(
+      std::equal(snap.level_data.begin(), snap.level_data.end(), game.level.material_id.begin()));
+  // dirty_list must now be initialised (empty, since no SetPixel since tracking start).
+  REQUIRE(game.level.dirty_list.empty());  // RED gate: dirty_list doesn't exist yet
+
+  // Modify one cell.
+  int const kX = 42;
+  int const kY = 37;
+  int const kIdx = kX + kY * game.level.width;
+  unsigned char const kOldMat = game.level.material_id[kIdx];
+  unsigned char const kNewMat =
+      (kOldMat == 0) ? static_cast<unsigned char>(1) : static_cast<unsigned char>(0);
+  game.level.SetPixel(kX, kY, kNewMat, *game.common);
+  REQUIRE(game.level.dirty_list.size() == 1);
+
+  // Second save into a fresh slot: must capture the dirty cell.
+  GameSnapshot snap2;
+  snap2.Prepare(game);
+  game.SaveSnapshotFast(snap2);
+  REQUIRE(snap2.level_data[kIdx] == kNewMat);
+  // All other cells still hold their initial values.
+  for (std::size_t i = 0; i < kCells; ++i) {
+    if (static_cast<int>(i) != kIdx) {
+      REQUIRE(snap2.level_data[i] == snap.level_data[i]);
+    }
+  }
+
+  // Corrupt the live cell, restore from snap2, verify correctness.
+  game.level.material_id[kIdx] = kOldMat;
+  game.LoadSnapshotFast(snap2);
+  REQUIRE(game.level.material_id[kIdx] == kNewMat);
+  // materials must be consistent with material_id after restore (no level_materials in slot).
+  REQUIRE(game.level.materials[kIdx].flags == game.common->materials[kNewMat].flags);
+
+  // Restoring snap (taken before the modification) gives back the old cell value.
+  game.LoadSnapshotFast(snap);
+  REQUIRE(game.level.material_id[kIdx] == kOldMat);
+  REQUIRE(game.level.materials[kIdx].flags == game.common->materials[kOldMat].flags);
 }

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -287,6 +287,13 @@ TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollb
   std::size_t const kCells =
       static_cast<std::size_t>(game.level.width) * static_cast<std::size_t>(game.level.height);
 
+  // Populate a display layer so the sparse display_valid update path
+  // (SaveSnapshotFast) and its restore (LoadSnapshotFast) are exercised. The
+  // full-copy display_valid path is covered elsewhere; this case covers the
+  // dirty-cell branch, which writes display_valid only for cells in dirty_list.
+  game.level.display_data.assign(kCells, 0);
+  game.level.display_valid.assign(kCells, static_cast<uint8_t>(1));
+
   // snap_a: will be saved twice — before and after the modification.
   // snap_b: saved once, before the modification, to test restoring to initial state.
   GameSnapshot snap_a;
@@ -327,6 +334,15 @@ TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollb
       REQUIRE(snap_a.level_data[i] == initial_data[i]);
     }
   }
+  // SetPixel zeroed display_valid at the dirty cell; the sparse save must have
+  // propagated that into the slot while leaving every other cell at its
+  // first-save value of 1.
+  REQUIRE(snap_a.level_display_valid[static_cast<std::size_t>(kIdx)] == 0);
+  for (std::size_t i = 0; i < kCells; ++i) {
+    if (static_cast<int>(i) != kIdx) {
+      REQUIRE(snap_a.level_display_valid[i] == 1);
+    }
+  }
 
   // Fresh slot saved after the modification: first save → full copy of current state.
   GameSnapshot snap_c;
@@ -341,15 +357,20 @@ TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollb
 
   // Corrupt the live cell and restore from snap_a (post-modification snapshot).
   game.level.material_id[static_cast<std::size_t>(kIdx)] = kOldMat;
+  game.level.display_valid[static_cast<std::size_t>(kIdx)] = 1;
   game.LoadSnapshotFast(snap_a);
   REQUIRE(game.level.material_id[static_cast<std::size_t>(kIdx)] == kNewMat);
   // materials must be consistent with material_id after restore (no level_materials in slot).
   REQUIRE(game.level.materials[static_cast<std::size_t>(kIdx)].flags ==
           game.common->materials[kNewMat].flags);
+  // display_valid must reflect the post-modification snapshot (cell was zeroed).
+  REQUIRE(game.level.display_valid[static_cast<std::size_t>(kIdx)] == 0);
 
   // Restore from snap_b (saved before the modification) — should recover kOldMat.
   game.LoadSnapshotFast(snap_b);
   REQUIRE(game.level.material_id[static_cast<std::size_t>(kIdx)] == kOldMat);
   REQUIRE(game.level.materials[static_cast<std::size_t>(kIdx)].flags ==
           game.common->materials[kOldMat].flags);
+  // snap_b predates the modification, so display_valid restores to 1.
+  REQUIRE(game.level.display_valid[static_cast<std::size_t>(kIdx)] == 1);
 }


### PR DESCRIPTION
## Summary

- Adds dirty-cell tracking to the rollback ring buffer so that `SaveSnapshotFast` only writes modified level cells on each frame, instead of a full `memcpy` of the entire `material_id` array.
- Fixes a weapon-selection stall on large maps (4096×4096) introduced by the initial PR6 implementation: `Prepare()` was eagerly copying 16 MB × 8 slots = 128 MB during weapon-selection init, blocking the main loop. The fix defers each slot's baseline copy to its first `SaveSnapshotFast` call, spreading the cost across the first 8 gameplay frames.

### How it works

- `Level::dirty_bits` / `dirty_list` track every cell modified via `SetPixel` or the blit helpers (`BlitStone`, `BlitImageOnMap`, `DrawDirtEffect`) since tracking was initialised.
- `GameSnapshot::initialized` (new flag) is false after `Prepare()`. The first `SaveSnapshotFast` to a slot does a full copy and sets the flag; subsequent saves to that slot write only dirty cells.
- `Prepare()` is now allocation-only (no `memcpy`), eliminating the upfront 128 MB burst during weapon-selection setup on 4096² maps — the same class of freeze fixed for `display_data` in #876d2d4.
- `LoadSnapshotFast` restores `material_id` with a full `memcpy` and recomputes `materials` only for dirty cells (O(dirty) instead of O(W×H)).

### Tests

- New Catch2 test case: "Dirty-cell tracking: sparse save, correct restore" — verifies the sparse path (second save to same slot), fresh-slot full copy, and correct restore for both pre- and post-modification snapshots.
- All 250 tests pass. Binary smoke-launches clean.

## Test plan

- [x] `ctest --test-dir build/linux-x64 --build-config Release --output-on-failure` — 250/250 pass
- [x] Smoke-launch: `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/openliero` exits 124
- [x] Manual: online match on 4096×4096 map — weapon selection no longer stalls, keypresses register normally
- [x] `clang-format --dry-run -Werror` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)