### PR TITLE
fix: minimap dimension constants and FillRect tracking for 504x350 regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,10 @@ if(OPENLIERO_BUILD_TESTS)
   target_link_libraries(test_blit PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_blit DISCOVERY_MODE PRE_TEST)
 
+  add_executable(test_minimap src/tests/test_minimap.cpp)
+  target_link_libraries(test_minimap PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_minimap DISCOVERY_MODE PRE_TEST)
+
   add_executable(test_level_display src/tests/test_level_display.cpp)
   target_link_libraries(test_level_display PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_level_display

--- a/src/game/fileSelectorState.cpp
+++ b/src/game/fileSelectorState.cpp
@@ -86,6 +86,8 @@ void LevelSelectorState::Enter() {
   selector_->Select(gfx->settings->level_file);
 
   previewNode_ = nullptr;
+  prev_hud_cols_ = Level::kHudMinimapW;
+  prev_hud_rows_ = Level::kHudMinimapH;
 }
 
 bool LevelSelectorState::OnSelected(FileNode* node) {
@@ -113,16 +115,25 @@ void LevelSelectorState::DrawExtra() {
       if (level.load(common, *gfx->settings, r)) {
         int const kCenterX = gfx->single_screen_renderer.render_res_x / 2;
 
-        int const kHudStepX = std::max((level.width + 51) / 52, 1);
-        int const kHudStepY = std::max((level.height + 35) / 36, 1);
-        FillRect(gfx->frozen_screen, 134, 162, 52, 36, 0);
+        int const kHudStepX =
+            std::max((level.width + Level::kHudMinimapW - 1) / Level::kHudMinimapW, 1);
+        int const kHudStepY =
+            std::max((level.height + Level::kHudMinimapH - 1) / Level::kHudMinimapH, 1);
+        // Clear only what the previous minimap drew; Enter() initialises these to the
+        // maximum bounding box so the first switch always covers any residue.
+        FillRect(gfx->frozen_screen, 134, 162, prev_hud_cols_, prev_hud_rows_, 0);
         level.DrawMiniature(gfx->frozen_screen, 134, 162, kHudStepX, kHudStepY);
-        int const kSpecStepX = std::max((level.width + 251) / 252, 1);
-        int const kSpecStepY = std::max((level.height + 174) / 175, 1);
+        prev_hud_cols_ = (level.width + kHudStepX / 2) / kHudStepX;
+        prev_hud_rows_ = (level.height + kHudStepY / 2) / kHudStepY;
+        int const kSpecStepX =
+            std::max((level.width + Level::kSpecMinimapW - 1) / Level::kSpecMinimapW, 1);
+        int const kSpecStepY =
+            std::max((level.height + Level::kSpecMinimapH - 1) / Level::kSpecMinimapH, 1);
         int const kSpecY = gfx->single_screen_renderer.render_res_y - 208;
-        FillRect(gfx->frozen_spectator_screen, kCenterX - 126, kSpecY, 252, 175, 0);
-        level.DrawMiniature(gfx->frozen_spectator_screen, kCenterX - 126, kSpecY, kSpecStepX,
-                            kSpecStepY);
+        FillRect(gfx->frozen_spectator_screen, kCenterX - Level::kSpecMinimapW / 2, kSpecY,
+                 Level::kSpecMinimapW, Level::kSpecMinimapH, 0);
+        level.DrawMiniature(gfx->frozen_spectator_screen, kCenterX - Level::kSpecMinimapW / 2,
+                            kSpecY, kSpecStepX, kSpecStepY);
       }
     } catch (std::runtime_error&) {  // NOLINT(bugprone-empty-catch) — bad preview is non-fatal; we
                                      // just skip drawing it.

--- a/src/game/fileSelectorState.hpp
+++ b/src/game/fileSelectorState.hpp
@@ -41,6 +41,10 @@ struct LevelSelectorState : FileSelectorState {
  private:
   std::shared_ptr<FileNode> randomNode_;
   FileNode* previewNode_ = nullptr;
+  // Maximum columns/rows the HUD minimap can draw (Level::kHudMinimapW/H).
+  // Reset on Enter(); used to clear residue from a wider previous level.
+  int prev_hud_cols_ = 52;
+  int prev_hud_rows_ = 36;
 };
 
 // Replay selector

--- a/src/game/level.hpp
+++ b/src/game/level.hpp
@@ -23,6 +23,15 @@ struct ShadowQuery;
 struct Level {
   Level(Common& common) : zero_material(common.materials[0]) {}
 
+  // Minimap bounding-box targets used by all call sites.
+  // For a 504×350 level these produce the original Liero 1.36 step values:
+  //   HUD:       ceil(504/52)=10, ceil(350/36)=10  → 50×35 minimap
+  //   Spectator: ceil(504/252)=2, ceil(350/175)=2  → 252×175 minimap (exact fit)
+  static constexpr int kHudMinimapW = 52;
+  static constexpr int kHudMinimapH = 36;
+  static constexpr int kSpecMinimapW = 252;
+  static constexpr int kSpecMinimapH = 175;
+
   bool load(Common& common, Settings const& settings, io::Reader& r);
 
   void GenerateDirtPattern(Common& common, Rand& rand);

--- a/src/game/mainMenuState.cpp
+++ b/src/game/mainMenuState.cpp
@@ -131,9 +131,11 @@ void MainMenuState::Enter() {
   gfx->single_screen_renderer.Clear();
   if (gfx->controller->CurrentLevel()) {
     Level const* level = gfx->controller->CurrentLevel();
-    int const kMinimapStepX = std::max((level->width + 251) / 252, 1);
-    int const kMinimapStepY = std::max((level->height + 174) / 175, 1);
-    level->DrawMiniature(gfx->single_screen_renderer.bmp, kCenterX - 126,
+    int const kMinimapStepX =
+        std::max((level->width + Level::kSpecMinimapW - 1) / Level::kSpecMinimapW, 1);
+    int const kMinimapStepY =
+        std::max((level->height + Level::kSpecMinimapH - 1) / Level::kSpecMinimapH, 1);
+    level->DrawMiniature(gfx->single_screen_renderer.bmp, kCenterX - Level::kSpecMinimapW / 2,
                          gfx->single_screen_renderer.render_res_y - 208, kMinimapStepX,
                          kMinimapStepY);
   }

--- a/src/game/viewport.cpp
+++ b/src/game/viewport.cpp
@@ -594,9 +594,11 @@ void Viewport::Draw(Game& game, Renderer& renderer, GameState /*state*/, bool is
     int const kMapX = kCenterX - 26;
     int const kMapY = renderer.render_res_y - 38;
 
-    // Fit the minimap into a 52×36 pixel area regardless of map size.
-    int const kMinimapStepX = std::max((game.level.width + 51) / 52, 1);
-    int const kMinimapStepY = std::max((game.level.height + 35) / 36, 1);
+    // Fit the minimap into kHudMinimapW×kHudMinimapH pixels regardless of map size.
+    int const kMinimapStepX =
+        std::max((game.level.width + Level::kHudMinimapW - 1) / Level::kHudMinimapW, 1);
+    int const kMinimapStepY =
+        std::max((game.level.height + Level::kHudMinimapH - 1) / Level::kHudMinimapH, 1);
     game.level.DrawMiniature(renderer.bmp, kMapX, kMapY, kMinimapStepX, kMinimapStepY);
 
     for (auto& worm : game.worms) {

--- a/src/game/weapsel.cpp
+++ b/src/game/weapsel.cpp
@@ -125,12 +125,15 @@ void WeaponSelection::DrawSpectatorViewports(Renderer& renderer, GameState /*sta
     FillRect(renderer.bmp, kCenterX + kTextSize / 2 - 16, kCenterY + 23, 14, 14,
              Palette::kWormColorBlocks[1].base);
     common.font.DrawCenteredText(renderer.bmp, "WEAPON SELECTION", kCenterX, kCenterY + 48, 7, 2);
-    // Fit the minimap into a 252×175 pixel area regardless of map size.
-    int const kMinimapStepX = std::max((game.level.width + 251) / 252, 1);
-    int const kMinimapStepY = std::max((game.level.height + 174) / 175, 1);
-    FillRect(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208, 252, 175, 0);
-    game.level.DrawMiniature(renderer.bmp, kCenterX - 126, renderer.render_res_y - 208,
-                             kMinimapStepX, kMinimapStepY);
+    // Fit the minimap into kSpecMinimapW×kSpecMinimapH pixels regardless of map size.
+    int const kMinimapStepX =
+        std::max((game.level.width + Level::kSpecMinimapW - 1) / Level::kSpecMinimapW, 1);
+    int const kMinimapStepY =
+        std::max((game.level.height + Level::kSpecMinimapH - 1) / Level::kSpecMinimapH, 1);
+    FillRect(renderer.bmp, kCenterX - Level::kSpecMinimapW / 2, renderer.render_res_y - 208,
+             Level::kSpecMinimapW, Level::kSpecMinimapH, 0);
+    game.level.DrawMiniature(renderer.bmp, kCenterX - Level::kSpecMinimapW / 2,
+                             renderer.render_res_y - 208, kMinimapStepX, kMinimapStepY);
 
     gfx.frozen_spectator_screen.Copy(renderer.bmp);
     cached_spectator_background = true;

--- a/src/tests/test_minimap.cpp
+++ b/src/tests/test_minimap.cpp
@@ -1,0 +1,123 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstddef>
+
+#include "game/common.hpp"
+#include "game/gfx/blit.hpp"
+#include "game/gfx/renderer.hpp"
+#include "game/level.hpp"
+
+namespace {
+
+// Minimal fixture: a level of given dimensions with uniform material 1, rendered
+// into a bitmap sized to bmp_w × bmp_h pre-filled with a background colour so
+// drawn pixels are distinguishable from undrawn ones.
+struct MinimapFixture {
+  Common common;
+  Level level;
+  Renderer renderer;
+  int bmp_w;
+  int bmp_h;
+
+  MinimapFixture(int level_w, int level_h, int bitmap_w, int bitmap_h)
+      : level(common), bmp_w(bitmap_w), bmp_h(bitmap_h) {
+    level.width = level_w;
+    level.height = level_h;
+    // All level pixels use palette index 1 (foreground).
+    level.material_id.assign(static_cast<std::size_t>(level_w * level_h), 1);
+
+    renderer.Init(bitmap_w, bitmap_h);
+    renderer.pal.Clear();
+    // index 1 → red (foreground — written by DrawMiniature)
+    // index 2 → blue (background — pre-fill sentinel)
+    renderer.pal.entries[1] = {.r = 0xff, .g = 0x00, .b = 0x00, .unused = 0};
+    renderer.pal.entries[2] = {.r = 0x00, .g = 0x00, .b = 0xff, .unused = 0};
+    renderer.UpdatePal32();
+    Fill(renderer.bmp, 2);  // pre-fill with background sentinel
+  }
+
+  // Count columns in row y that received a foreground pixel.
+  int ColsInRow(int y) const {
+    int n = 0;
+    for (int x = 0; x < bmp_w; ++x) {
+      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+    }
+    return n;
+  }
+
+  // Count rows in column x that received a foreground pixel.
+  int RowsInCol(int x) const {
+    int n = 0;
+    for (int y = 0; y < bmp_h; ++y) {
+      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+    }
+    return n;
+  }
+
+  // Count all foreground pixels in the bitmap.
+  int TotalDrawn() const {
+    int n = 0;
+    for (int y = 0; y < bmp_h; ++y) {
+      for (int x = 0; x < bmp_w; ++x) {
+        if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+      }
+    }
+    return n;
+  }
+};
+
+}  // namespace
+
+// ── Step-formula tests (pure arithmetic) ──────────────────────────────────────
+// The call sites compute:  step = max((dim + target - 1) / target, 1)
+// These cases lock in that the constants produce the original hardcoded values
+// for a standard 504×350 level.
+
+TEST_CASE("hud minimap step formula yields 10 for a 504x350 level", "[minimap][step]") {
+  REQUIRE(std::max((504 + Level::kHudMinimapW - 1) / Level::kHudMinimapW, 1) == 10);
+  REQUIRE(std::max((350 + Level::kHudMinimapH - 1) / Level::kHudMinimapH, 1) == 10);
+}
+
+TEST_CASE("spectator minimap step formula yields 2 for a 504x350 level", "[minimap][step]") {
+  REQUIRE(std::max((504 + Level::kSpecMinimapW - 1) / Level::kSpecMinimapW, 1) == 2);
+  REQUIRE(std::max((350 + Level::kSpecMinimapH - 1) / Level::kSpecMinimapH, 1) == 2);
+}
+
+TEST_CASE("hud minimap step doubles for a 1008x700 level", "[minimap][step]") {
+  REQUIRE(std::max((1008 + Level::kHudMinimapW - 1) / Level::kHudMinimapW, 1) == 20);
+  REQUIRE(std::max((700 + Level::kHudMinimapH - 1) / Level::kHudMinimapH, 1) == 20);
+}
+
+TEST_CASE("spectator minimap step doubles for a 1008x700 level", "[minimap][step]") {
+  REQUIRE(std::max((1008 + Level::kSpecMinimapW - 1) / Level::kSpecMinimapW, 1) == 4);
+  REQUIRE(std::max((700 + Level::kSpecMinimapH - 1) / Level::kSpecMinimapH, 1) == 4);
+}
+
+// ── DrawMiniature dimension tests ─────────────────────────────────────────────
+// Verify that DrawMiniature draws the expected column and row counts for the
+// canonical 504×350 level — the numbers that match original Liero 1.36.
+
+TEST_CASE("drawminiature step=10 draws 50 cols and 35 rows for a 504x350 level",
+          "[minimap][drawminiature]") {
+  MinimapFixture f(504, 350, 52, 36);
+  f.level.DrawMiniature(f.renderer.bmp, 0, 0, 10, 10);
+  REQUIRE(f.ColsInRow(0) == 50);
+  REQUIRE(f.RowsInCol(0) == 35);
+}
+
+TEST_CASE("drawminiature step=2 draws 252 cols and 175 rows for a 504x350 level",
+          "[minimap][drawminiature]") {
+  MinimapFixture f(504, 350, 252, 175);
+  f.level.DrawMiniature(f.renderer.bmp, 0, 0, 2, 2);
+  REQUIRE(f.ColsInRow(0) == 252);
+  REQUIRE(f.RowsInCol(0) == 175);
+}
+
+TEST_CASE("drawminiature step=2 fills the spectator target exactly for a 504x350 level",
+          "[minimap][drawminiature]") {
+  // 504/2 = 252 and 350/2 = 175 — the spectator minimap has zero wasted pixels.
+  MinimapFixture f(504, 350, 252, 175);
+  f.level.DrawMiniature(f.renderer.bmp, 0, 0, 2, 2);
+  REQUIRE(f.TotalDrawn() == 252 * 175);
+}

--- a/src/tests/test_minimap.cpp
+++ b/src/tests/test_minimap.cpp
@@ -25,7 +25,7 @@ struct MinimapFixture {
     level.width = level_w;
     level.height = level_h;
     // All level pixels use palette index 1 (foreground).
-    level.material_id.assign(static_cast<std::size_t>(level_w * level_h), 1);
+    level.material_id.assign(static_cast<std::size_t>(level_w) * level_h, 1);
 
     renderer.Init(bitmap_w, bitmap_h);
     renderer.pal.Clear();
@@ -41,7 +41,9 @@ struct MinimapFixture {
   int ColsInRow(int y) const {
     int n = 0;
     for (int x = 0; x < bmp_w; ++x) {
-      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) {
+        ++n;
+      }
     }
     return n;
   }
@@ -50,7 +52,9 @@ struct MinimapFixture {
   int RowsInCol(int x) const {
     int n = 0;
     for (int y = 0; y < bmp_h; ++y) {
-      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+      if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) {
+        ++n;
+      }
     }
     return n;
   }
@@ -60,7 +64,9 @@ struct MinimapFixture {
     int n = 0;
     for (int y = 0; y < bmp_h; ++y) {
       for (int x = 0; x < bmp_w; ++x) {
-        if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) ++n;
+        if (renderer.bmp.GetPixel(x, y) == renderer.pal32[1]) {
+          ++n;
+        }
       }
     }
     return n;


### PR DESCRIPTION
## Summary

- Introduces four named constants on `Level` (`kHudMinimapW=52`, `kHudMinimapH=36`, `kSpecMinimapW=252`, `kSpecMinimapH=175`) to document the minimap bounding-box targets that produce the original Liero 1.36 step values for a 504×350 level.
- Replaces magic numbers with these constants across all call sites (`viewport.cpp`, `weapsel.cpp`, `mainMenuState.cpp`, `fileSelectorState.cpp`).
- Fixes a regression introduced in a634c3b (PR4 zooming spectator viewport): in the level-selector preview (`fileSelectorState.cpp`), `FillRect` was clearing a full 52×36 area but `DrawMiniature` with step=10 only draws 50×35 pixels, leaving a 2-column/1-row black fringe. Fixed by tracking the dimensions of the previous minimap draw and clearing only that exact area.
- Adds a `test_minimap` Catch2 suite (7 test cases) locking in the step formula and `DrawMiniature` pixel counts for the canonical 504×350 level and a 1008×700 double-size level.

## Test plan

- [x] `./build/linux-x64/Release/test_minimap` — all 7 cases pass
- [x] `scripts/clang-format-diff.sh` — clean
- [x] `scripts/clang-tidy-diff.sh build/linux-x64` — clean
- [x] Smoke-launch: `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/openliero` — exits 124

🤖 Generated with [Claude Code](https://claude.com/claude-code)