### PR TITLE
PR7: spectator rendering — GPU composite + downscaled world pass

### DIFF
--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -311,13 +311,29 @@ GPU composite makes that moot. **Not pursued.**
    (`Draw`/`Flip`/`OnWindowResize` + new texture members in `gfx.hpp`),
    `src/tests/test_spectator_zoom.cpp`. Sub-steps:
 
-   - **1a. Spike the SDL scaling path first.** The spectator renderer already runs
-     `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)` (gfx.cpp:407), which remaps
-     all render coordinates. Confirm whether a manual letterboxed `SDL_RenderTexture`
-     dest rect cooperates with that, or whether the spectator renderer must drop
-     logical presentation and compute the dest rect explicitly (via `FitScreen`-style
-     aspect math). Resolve this before building the rest — it dictates the dest-rect
-     math everywhere below.
+   - **1a. Spike the SDL scaling path first. — RESOLVED (2026-06-15): keep logical
+     presentation; manual dest rect cooperates.** The spectator renderer runs
+     `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)` (gfx.cpp:407). The question was
+     whether a manual letterboxed `SDL_RenderTexture` dest rect cooperates with that
+     or whether logical presentation must be dropped.
+     **Finding (empirical):** an SDL3 software-renderer spike replicating the
+     spectator setup (logical size == window pixel size, LETTERBOX) blitted a world
+     texture into a manually-computed centred dest rect and read pixels back: the
+     readback framebuffer is the logical size (1280×800), the world colour lands
+     pixel-exactly inside the manual dest rect, and `SDL_RenderClear` produces exact
+     black bars outside it. Because the logical size **equals** the window pixel size,
+     the logical→physical transform is uniform (identity modulo HiDPI), so there is
+     **no double-letterboxing**.
+     **Decision for 1b/1c:** keep `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)`
+     untouched; render coordinates are then in logical == window pixels. Reuse the
+     existing CPU-composite aspect math (`kOutX/kOutY/kOutW/kOutH`,
+     spectatorviewport.cpp:496-501) directly as the `SDL_RenderTexture` dstrect (as
+     `SDL_FRect`); `SDL_RenderClear` the spectator renderer to opaque black for the
+     bars before the world blit. No `FitScreen`-style manual letterbox is needed.
+     The "allocate world texture once at max size, upload only the used sub-rect, pass
+     that sub-rect as `srcrect`" approach (1b) is orthogonal to logical presentation
+     (standard `SDL_RenderTexture` srcrect semantics) and is low-risk — not separately
+     spiked. (Spike source kept out-of-tree under `/tmp/sdl_spike_1a.cpp`; not committed.)
    - **1b. World texture.** Add `sdl_spectator_world_texture` (STREAMING, ARGB8888).
      Allocate it **once at max size** — level dims clamped to a ceiling — in
      `OnWindowResize`/`SetVideoMode`, NOT per frame (scratch dims change with zoom).
@@ -404,7 +420,7 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 | Determinism regressions from PR1/PR3 sim touch | Medium | `test_determinism`/`test_rollback_*` on every PR |
 | Rollback snapshot too large for online play on big maps | High (4096²) | PR6 — dirty-cell tracking; PR2 already fixed correctness |
 | Spectator world-pass cost O((W×H)/zoom²) on large native windows | High | PR7 — GPU-scale world pass; frustum cull sprites |
-| PR7-1a: `SDL_SetRenderLogicalPresentation(LETTERBOX)` conflicts with manual dest-rect scaling | Medium | Spike (Task 1a) before building 1b/1c; fall back to explicit dest rect + no logical presentation |
+| PR7-1a: `SDL_SetRenderLogicalPresentation(LETTERBOX)` conflicts with manual dest-rect scaling | ~~Medium~~ **Resolved** | Spike (Task 1a, 2026-06-15) proved no conflict: logical size == window pixels ⇒ uniform transform, manual dest rect lands pixel-exact. Keep logical presentation. |
 | PR7-1b: per-frame world-texture upload (≤16 MB+, grows with scratch) becomes the new cost | Medium | Still ≪ 38 ms; cap world-texture max size; measure in Task 1f |
 | PR7-1c: HUD transparency/blend regressions (today's clear is opaque black) | Low | Clear HUD buffer to alpha 0; visual check; HUD is small |
 | PR7-1d: GPU path crashes/no-ops under dummy driver (CI smoke) or in single-screen-replay primary-renderer mode | Medium | Guard on live spectator renderer/window; keep `Gfx::Draw` CPU path for those modes |

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -197,21 +197,100 @@ findings that don't fit the scope (e.g. a major bottleneck in simulation,
 networking, or palette handling) are noted as follow-on work rather than
 stretching this PR.
 
-#### Known bottleneck: spectator world pass
+#### Profiling result (2026-06-15, 4096² level, 1280×800 spectator, worms apart)
 
-`SpectatorViewport::Draw` allocates a scratch bitmap sized to the visible world
-region:
+Tracy zones confirm the cost split inside `SpectatorViewport::Draw` (~45 ms):
+
+| Stage | Code | Cost |
+|---|---|---|
+| World pass → `scratch_bmp` (DrawLevel + shadows + sprites, 1:1) | `spectatorviewport.cpp:94-489` | DrawLevel **6 ms** + sprites |
+| **`ScaleDrawArea` CPU box-filter** scratch → `single_screen_renderer.bmp` (native res) | `spectatorviewport.cpp:521`, impl `blit.cpp:770-799` | **~38 ms** ← dominant |
+| `ScaleDraw` integer-magnify in `Gfx::Draw` (kMag=1 at native ⇒ plain copy) | `gfx.cpp:1013` | redundant |
+| `SDL_UpdateTexture`/`SDL_RenderTexture`/present | `gfx.cpp:1016-1019` | already GPU |
+
+`ScaleDrawArea` reads **every** source pixel with a per-output-pixel divide; at
+zoom 0.5 the source is 2560×1600 = 4M px/frame. Cost scales as
+`(render_w × render_h) / zoom²`. **The CPU composite — not the world drawing — is
+the bottleneck.** The world pass itself (DrawLevel 6 ms + sprites) is comparatively
+cheap, so shrinking or caching it is low-ROI; eliminating the composite is the win.
+
+#### Current presentation pipeline (the code being restructured)
+
+The spectator window goes through **two** CPU scaling passes today. Dataflow:
 
 ```
-scratch_w = min(render_w / zoom, level.width)
-scratch_h = min(render_h / zoom, level.height)
+SpectatorViewport::Draw(game, single_screen_renderer, ...)   spectatorviewport.cpp:82
+  ├─ world pass → scratch_bmp           1:1 world pixels, size capped to level
+  │                                      (spectatorviewport.cpp:94-489)
+  ├─ Composite: scratch_bmp ─ScaleDrawArea(box filter)→ single_screen_renderer.bmp
+  │                                      (spectatorviewport.cpp:491-524)  ← ~38 ms
+  │     • memcpy fast path when scratch dims == output dims (510-519)
+  │     • ScaleDrawArea otherwise (521)
+  │     • Fill(renderer.bmp, 0) clears letterbox bars OPAQUE black (503-505)
+  └─ HUD: drawn directly into single_screen_renderer.bmp at native res (526-664)
+
+Gfx::Flip()                                                   gfx.cpp:1024
+  ├─ Draw(*sdl_draw_surface, *sdl_texture, *sdl_renderer, *primary_renderer)        // main window
+  └─ Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture,
+          *sdl_spectator_renderer, single_screen_renderer)    // spectator window (1030-1033)
+
+Gfx::Draw(surface, texture, sdl_renderer, renderer)           gfx.cpp:983
+  ├─ ScaleDraw(renderer.bmp → surface, kMag)  integer magnify; kMag==1 at native ⇒ plain copy (1013)
+  ├─ SDL_UpdateTexture(texture, surface.pixels, ...)          (1016)
+  ├─ SDL_RenderClear / SDL_RenderTexture(texture, NULL, NULL) (1017-1018)
+  └─ SDL_RenderPresent                                        (1019)
 ```
 
-Every draw pass (level tiles, shadow pass, all sprite types) iterates over
-every pixel of the scratch bitmap.  At a 1280×800 native window with zoom = 0.5
-the scratch is 2560×1600 — 16× more pixels than the old fixed 640×400 case.
-The subsequent `ScaleDrawArea` box-filter is also O(scratch_w × scratch_h), so
-total cost scales as `(render_w × render_h) / zoom²`.
+Relevant SDL setup (`Gfx::OnWindowResize`, gfx.cpp:390-414): the spectator texture
+`sdl_spectator_texture` is `SDL_TEXTUREACCESS_STREAMING` sized to the **window**
+(w,h); `sdl_spectator_draw_surface` is a matching ARGB8888 surface; and
+`SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, w, h, LETTERBOX)` is
+already applied (gfx.cpp:407). `single_screen_renderer.bmp` is sized to the window
+via `SetRenderResolution(w,h)` (gfx.cpp:412).
+
+So today both the world downscale (`ScaleDrawArea`) and a redundant native-res copy
+(`ScaleDraw`, kMag=1) run on the CPU before the single GPU upload+present.
+
+#### Decision: GPU-scale the composite, keep the 1:1 world pass
+
+The earlier "cap scratch to render resolution" attempt was reverted (`8e1b028`,
+PR7 Task 1a) because the world pass blits at 1:1 — capping the scratch below the
+visible region merely clips the view. The corrected approach keeps the 1:1 world
+pass (its drawing cost was never the problem) and replaces the **CPU composite**
+with a **GPU scale**:
+
+1. World pass still renders into `scratch_bmp` at 1:1 (unchanged).
+2. Upload `scratch_bmp` to a dedicated SDL **streaming texture**, then
+   `SDL_RenderTexture` it to the letterboxed dest rect on the GPU
+   (`SDL_SCALEMODE_LINEAR`). This **deletes the ~38 ms `ScaleDrawArea` and the
+   redundant `ScaleDraw` copy**, replacing them with a texture upload (~16 MB DMA,
+   a few ms) plus a sub-ms GPU blit.
+3. HUD renders into a native-res layer with a **transparent background** → overlay
+   texture → second `SDL_RenderTexture` on top with alpha blend.
+
+To avoid recreating a texture every frame as zoom (and thus scratch size) changes,
+allocate the world texture **once at max size** (level dims clamped to a ceiling),
+upload only the used sub-rect, and pass that sub-rect as `SDL_RenderTexture`'s
+srcrect.
+
+`ScaleDrawArea` **stays** — `video_tool` renders offline with no GPU/window and
+still needs the CPU path. The GPU path is **spectator-window-only**, guarded on a
+live SDL renderer (must not crash under the dummy driver in CI smoke).
+
+#### Dirty-rectangle sharing — evaluated, declined
+
+Considered sharing the rollback dirty-tracking to lessen rendering. Finding:
+there is **no dirty-rect system in `RollbackController`**; the dirty tracking
+lives in **`Level`** (`level.hpp:94-106,199-200`: `dirty_bits` + `dirty_list`)
+and feeds `SaveSnapshotFast` (PR6). It is unsuitable for rendering reuse:
+
+- It is **cumulative and never cleared** (`level.hpp:197-198`) — it only grows;
+  rendering needs per-frame dirty regions.
+- It tracks **terrain cells only**. But terrain draw (`DrawLevel`) is just 6 ms,
+  not the bottleneck; sprites/shadows/worms move every frame and aren't tracked.
+
+At best it could cache the terrain layer (~6 ms) at real complexity cost, and the
+GPU composite makes that moot. **Not pursued.**
 
 #### Tasks
 
@@ -225,22 +304,54 @@ total cost scales as `(render_w × render_h) / zoom²`.
    outside the rendering pipeline (simulation tick, palette rebuild, network
    processing) open a separate follow-on issue rather than folding it here.
 
-1. **Cap the world-pass scratch at a fixed size and GPU-scale to the window.**
-   Render the world pass into a bitmap capped at `min(render_w, level.width) ×
-   min(render_h, level.height)` (i.e. never larger than the level itself,
-   regardless of zoom).  Upload it to an SDL streaming texture and let
-   `SDL_RenderTexture` with `SDL_SCALEMODE_LINEAR` (or `NEAREST` for the chunky
-   pixel look) scale it to the native window on the GPU.  Draw the HUD overlay
-   afterwards at native resolution via a second texture or directly into the
-   renderer surface.  This decouples world-pass cost from native window size
-   entirely and is expected to be the highest-ROI fix.
+1. **GPU-scale the world composite (keep the 1:1 world pass).** ← see Decision above
+   Do NOT cap the scratch below the visible region (that was Task 1a, reverted in
+   `8e1b028` — it clips the view). Highest-ROI fix (removes the ~38 ms composite +
+   redundant copy). Files: `spectatorviewport.{hpp,cpp}`, `gfx.{hpp,cpp}`
+   (`Draw`/`Flip`/`OnWindowResize` + new texture members in `gfx.hpp`),
+   `src/tests/test_spectator_zoom.cpp`. Sub-steps:
 
-2. **Frustum-cull the sprite and shadow passes.**
-   Currently every worm, wobject, nobject, bonus, and sobject is visited even
-   when off-screen after zoom-out.  Add a cheap AABB check against the visible
-   world rect `[x, x+scratch_w) × [y, y+scratch_h)` before each
-   `BlitImage` / `BlitShadowImage` call.  On large maps with many off-screen
-   objects this can cut the sprite-pass cost significantly.
+   - **1a. Spike the SDL scaling path first.** The spectator renderer already runs
+     `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)` (gfx.cpp:407), which remaps
+     all render coordinates. Confirm whether a manual letterboxed `SDL_RenderTexture`
+     dest rect cooperates with that, or whether the spectator renderer must drop
+     logical presentation and compute the dest rect explicitly (via `FitScreen`-style
+     aspect math). Resolve this before building the rest — it dictates the dest-rect
+     math everywhere below.
+   - **1b. World texture.** Add `sdl_spectator_world_texture` (STREAMING, ARGB8888).
+     Allocate it **once at max size** — level dims clamped to a ceiling — in
+     `OnWindowResize`/`SetVideoMode`, NOT per frame (scratch dims change with zoom).
+     Each frame, `SDL_UpdateTexture` only the used `kScrW×kScrH` sub-rect, then
+     `SDL_RenderTexture` with that sub-rect as **srcrect** and the letterboxed
+     output rect (from 1a) as dstrect, `SDL_SCALEMODE_LINEAR`. This replaces the
+     `ScaleDrawArea`/memcpy composite block (spectatorviewport.cpp:491-524).
+   - **1c. HUD overlay.** The HUD currently draws into the same
+     `single_screen_renderer.bmp` as the world (spectatorviewport.cpp:526-664). Split
+     it onto a transparent layer: clear the HUD buffer to **alpha 0** (today's
+     `Fill(renderer.bmp, 0)` writes opaque black `0xFF000000` — change to a
+     transparent clear for the HUD buffer), draw the HUD into it, upload to a
+     native-res overlay texture with `SDL_BLENDMODE_BLEND`, and `SDL_RenderTexture`
+     it on top of the world. Decide where the HUD buffer lives — reuse
+     `single_screen_renderer.bmp` (now HUD-only, still native-res) or a dedicated
+     bitmap. Bars/text helpers (`DrawBar`, `font.DrawString`, `FillRect`) already
+     write through `pal32` ARGB so they keep working once the clear is transparent.
+   - **1d. Scope the GPU path correctly.** Apply it only to the real spectator
+     window. `single_screen_renderer` doubles as the **main-window primary renderer
+     during single-screen replay** (gfx.cpp:411) — in that mode the existing
+     `Gfx::Draw` CPU path must remain. Guard on a live SDL renderer / spectator
+     window so the dummy video driver (CI smoke) and the videotool don't hit it.
+   - **1e. Retain `ScaleDrawArea`.** `video_tool` renders offline with no
+     GPU/window and still calls the CPU composite — leave that path intact;
+     `test_blit` continues to cover it.
+   - **1f. Profile to confirm.** Re-measure with Tracy at 1280×800 and 1920×1080 on
+     the 4096² level: composite zone should drop to ~0; capture the new
+     texture-upload cost; verify total `SpectatorViewport::Draw` + `Gfx::Flip` is
+     within the 14 ms budget.
+
+2. **Frustum-cull the sprite and shadow passes.** — **DONE** (`bd8cb77`, PR7 Task 2)
+   Every worm, wobject, nobject, bonus, and sobject now gets a cheap AABB check
+   against the visible world rect `[x, x+scratch_w) × [y, y+scratch_h)` before each
+   `BlitImage` / `BlitShadowImage`.
 
 3. **SIMD / vectorised `ScaleDrawArea`.**
    If the CPU downscale path is retained (e.g. for the videotool offline
@@ -293,6 +404,10 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 | Determinism regressions from PR1/PR3 sim touch | Medium | `test_determinism`/`test_rollback_*` on every PR |
 | Rollback snapshot too large for online play on big maps | High (4096²) | PR6 — dirty-cell tracking; PR2 already fixed correctness |
 | Spectator world-pass cost O((W×H)/zoom²) on large native windows | High | PR7 — GPU-scale world pass; frustum cull sprites |
+| PR7-1a: `SDL_SetRenderLogicalPresentation(LETTERBOX)` conflicts with manual dest-rect scaling | Medium | Spike (Task 1a) before building 1b/1c; fall back to explicit dest rect + no logical presentation |
+| PR7-1b: per-frame world-texture upload (≤16 MB+, grows with scratch) becomes the new cost | Medium | Still ≪ 38 ms; cap world-texture max size; measure in Task 1f |
+| PR7-1c: HUD transparency/blend regressions (today's clear is opaque black) | Low | Clear HUD buffer to alpha 0; visual check; HUD is small |
+| PR7-1d: GPU path crashes/no-ops under dummy driver (CI smoke) or in single-screen-replay primary-renderer mode | Medium | Guard on live spectator renderer/window; keep `Gfx::Draw` CPU path for those modes |
 
 ## Acceptance
 

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -161,7 +161,7 @@ Delivered on branch `arbitrary-map-sizes-pr4`:
 - **Validate**: render a replay at 1280×720 and 1920×1080, spectator + normal
   mode; confirm output dimensions and no scaler mismatch.
 
-### PR 6 — Rollback snapshot optimization: dirty-cell tracking for large levels
+### PR 6 — Rollback snapshot optimization: dirty-cell tracking for large levels — **DONE** ([#108](https://github.com/openliero/openliero/pull/108))
 
 Online play on large maps (e.g. 4096×4096) is slow because `SaveSnapshotFast`
 memcpys ~48 MB per rollback frame (material_id + material flags + display_valid),
@@ -432,6 +432,6 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 - [x] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
 - [x] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes; native-resolution spectator window.
 - [x] PR5: videotool output resolution selectable; scaler input dynamic.
-- [ ] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
+- [x] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
 - [ ] PR7: spectator viewport frame time within budget at ≥1280×800 with worms at maximum separation on a 4096² level.
 - [ ] Determinism/rollback suites + format checks pass on every PR.

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -370,12 +370,45 @@ GPU composite makes that moot. **Not pursued.**
      `bmp` via `ScaleDrawArea`; `test_blit` unchanged (83 assertions, green).
      Note: videotool is off by default (needs system ffmpeg) so it wasn't
      rebuilt; its `ScaleDrawArea` caller is untouched.
-   - **1f. Profile to confirm. — PENDING (needs a real display).** Re-measure
-     with Tracy at 1280×800 and 1920×1080 on the 4096² level: composite zone
-     should drop to ~0; capture the new texture-upload cost; verify total
-     `SpectatorViewport::Draw` + `Gfx::Flip` is within the 14 ms budget. Cannot be
-     run in the headless dev environment — the GPU path is guarded off under the
-     dummy driver. Hand to a display-capable machine.
+   - **1f. Profile to confirm. — DONE (2026-06-15, on real hardware).** Tracy on
+     the 4096² level, worms at max separation:
+     - GPU composite alone (`cc0ae79`): the ~38 ms CPU composite zone dropped to
+       ~0, but the 1:1 world pass + 64 MB texture upload remained → **~34 ms**
+       total at 1280×800 (`local:draw` 21 ms incl. `DrawLevel` 5.9 ms; `Gfx::Flip`
+       11 ms incl. the upload). Over budget.
+     - Downscaled world pass (`e0a0d6c`, see 1g): **~20 ms** at 3440×1440 (4.95 Mpx
+       window) at max zoom-out. The world pass and its upload are now bounded by
+       the window, not the level; the residual is dominated by the two
+       full-window texture uploads (world + HUD overlay) + present, which scale
+       with window pixels.
+     - **Outcome:** a large improvement (≈34→20 ms) but **still above the 14 ms
+       budget at very large windows**. Accepted for now per playtest. Further
+       gains would come from shrinking/scoping the per-frame uploads (HUD
+       dirty-region upload, or capping the spectator render resolution
+       independently of window size) — tracked as a follow-on, not blocking.
+   - **1g. Downscaled world pass. — DONE (2026-06-15, `e0a0d6c`).** Render the
+     world pass at ~output resolution when `zoom < 1` instead of 1:1, so its CPU
+     cost and texture upload are bounded by the window rather than the level
+     area. `ComputeWorldPassScratch` (unit-tested) gives `scale = min(1, zoom)`
+     and a scratch ≤ the render surface; new `DrawLevelScaled` / `BlitImageScaled`
+     (nearest-neighbour) render terrain and sprites scaled down. `zoom ≥ 1` keeps
+     the existing 1:1 path byte-for-byte (no change for small maps). The
+     downscaled path draws the visually-significant world (terrain, worms +
+     ninjarope, bonuses, s/w/n-objects, blood) and **omits** detail that is
+     sub-pixel/illegible at that zoom (shadows, text labels, fire cones, laser
+     sight, aim crosshair, AI debug). The world texture is now window-bounded, so
+     `SpectatorWorldTextureSize`/the 4096 ceiling were removed.
+   - **1h. Spectator presentation bug fixes (found on real hardware).**
+     - **Pause crash / blank (`703af23`).** `MainMenuState::Enter` calls `Flip()`
+       directly (outside `RunOneFrame`), so a stale `gpu_world_src` from the last
+       gameplay frame drove `DrawSpectatorGpu` against the just-resized menu
+       layout → heap overread. Fixed by making `gpu_world_src` a strict one-shot
+       (gated on, and cleared by, every Flip); non-gameplay frames fall back to
+       the CPU present.
+     - **Black spectator at start / pause until resize (`4f7a187`).** The GPU
+       fade `SDL_SetTextureColorMod` leaked onto the shared `sdl_spectator_texture`
+       (at fade 0 → multiply-by-black); the CPU present path never reset it.
+       Fixed by restoring neutral colormod after each GPU present.
 
 2. **Frustum-cull the sprite and shadow passes.** — **DONE** (`bd8cb77`, PR7 Task 2)
    Every worm, wobject, nobject, bonus, and sobject now gets a cheap AABB check
@@ -446,5 +479,9 @@ scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 - [x] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes; native-resolution spectator window.
 - [x] PR5: videotool output resolution selectable; scaler input dynamic.
 - [x] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
-- [ ] PR7: spectator viewport frame time within budget at ≥1280×800 with worms at maximum separation on a 4096² level.
+- [~] PR7: spectator frame time greatly improved (≈34→20 ms) via GPU composite +
+  downscaled world pass; pause/start spectator bugs fixed. **Not strictly within
+  the 14 ms budget** at very large windows (≈20 ms at 3440×1440, max zoom-out) —
+  the residual is the two full-window texture uploads, accepted for now. Frustum
+  cull (Task 2) done; Tasks 3/4 (SIMD, min-zoom cap) left as optional follow-ons.
 - [ ] Determinism/rollback suites + format checks pass on every PR.

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -334,35 +334,48 @@ GPU composite makes that moot. **Not pursued.**
      that sub-rect as `srcrect`" approach (1b) is orthogonal to logical presentation
      (standard `SDL_RenderTexture` srcrect semantics) and is low-risk — not separately
      spiked. (Spike source kept out-of-tree under `/tmp/sdl_spike_1a.cpp`; not committed.)
-   - **1b. World texture.** Add `sdl_spectator_world_texture` (STREAMING, ARGB8888).
-     Allocate it **once at max size** — level dims clamped to a ceiling — in
-     `OnWindowResize`/`SetVideoMode`, NOT per frame (scratch dims change with zoom).
-     Each frame, `SDL_UpdateTexture` only the used `kScrW×kScrH` sub-rect, then
-     `SDL_RenderTexture` with that sub-rect as **srcrect** and the letterboxed
-     output rect (from 1a) as dstrect, `SDL_SCALEMODE_LINEAR`. This replaces the
-     `ScaleDrawArea`/memcpy composite block (spectatorviewport.cpp:491-524).
-   - **1c. HUD overlay.** The HUD currently draws into the same
-     `single_screen_renderer.bmp` as the world (spectatorviewport.cpp:526-664). Split
-     it onto a transparent layer: clear the HUD buffer to **alpha 0** (today's
-     `Fill(renderer.bmp, 0)` writes opaque black `0xFF000000` — change to a
-     transparent clear for the HUD buffer), draw the HUD into it, upload to a
-     native-res overlay texture with `SDL_BLENDMODE_BLEND`, and `SDL_RenderTexture`
-     it on top of the world. Decide where the HUD buffer lives — reuse
-     `single_screen_renderer.bmp` (now HUD-only, still native-res) or a dedicated
-     bitmap. Bars/text helpers (`DrawBar`, `font.DrawString`, `FillRect`) already
-     write through `pal32` ARGB so they keep working once the clear is transparent.
-   - **1d. Scope the GPU path correctly.** Apply it only to the real spectator
-     window. `single_screen_renderer` doubles as the **main-window primary renderer
-     during single-screen replay** (gfx.cpp:411) — in that mode the existing
-     `Gfx::Draw` CPU path must remain. Guard on a live SDL renderer / spectator
-     window so the dummy video driver (CI smoke) and the videotool don't hit it.
-   - **1e. Retain `ScaleDrawArea`.** `video_tool` renders offline with no
-     GPU/window and still calls the CPU composite — leave that path intact;
-     `test_blit` continues to cover it.
-   - **1f. Profile to confirm.** Re-measure with Tracy at 1280×800 and 1920×1080 on
-     the 4096² level: composite zone should drop to ~0; capture the new
-     texture-upload cost; verify total `SpectatorViewport::Draw` + `Gfx::Flip` is
-     within the 14 ms budget.
+   - **1b. World texture. — DONE (2026-06-15, `cc0ae79`).** Added
+     `sdl_spectator_world_texture` (STREAMING, ARGB8888), allocated **once per
+     level** at the level size clamped to `kSpectatorWorldTextureMax` (4096) via
+     the pure, unit-tested `SpectatorWorldTextureSize`. Implemented as a lazy
+     `EnsureSpectatorWorldTexture(need_w, need_h)` (grows only; no per-frame
+     realloc) rather than in `OnWindowResize`, because the world texture is
+     level-sized and window-resize-independent (the spectator renderer persists
+     across window resizes; only `SetVideoMode`'s renderer-destroy invalidates
+     it, where it's nulled for lazy rebuild). Each frame `SDL_UpdateTexture`
+     uploads only the used `kScrW×kScrH` sub-rect, then `Gfx::DrawSpectatorGpu`
+     `SDL_RenderTexture`s it (sub-rect srcrect → letterboxed dstrect from the
+     shared `ComputeSpectatorDstRect`, `SDL_SCALEMODE_LINEAR`). Replaced the
+     `ScaleDrawArea`/memcpy composite block in `SpectatorViewport::Draw`.
+   - **1c. HUD overlay. — DONE (2026-06-15, `cc0ae79`).** In the GPU path the
+     world-pass clear of `renderer.bmp` switched from `Fill(renderer.bmp, 0)`
+     (opaque `pal32[0]`) to the new `FillTransparent` (ARGB `0x00000000`); the
+     HUD draws into that same native-res `single_screen_renderer.bmp` (now
+     HUD-only) and uploads to the existing `sdl_spectator_texture` (now
+     `SDL_BLENDMODE_BLEND`), `SDL_RenderTexture`d on top of the world. Bars/text
+     helpers write opaque `pal32` ARGB and keep working. `ScaleDraw`'s
+     per-channel fade is reproduced via `SDL_SetTextureColorMod` on both layers
+     so the spectator fade-in survives.
+   - **1d. Scope the GPU path correctly. — DONE (2026-06-15, `cc0ae79`).**
+     `Gfx::SpectatorGpuComposite()` enables the path only when `spectator_window`
+     is set, a live `sdl_spectator_renderer`/`sdl_spectator_texture` exist, and
+     `primary_renderer != &single_screen_renderer` (so single-screen replay to
+     the main window keeps the CPU `Gfx::Draw` path). The flag is set per frame
+     before each spectator-viewport draw and `gpu_world_src` reset, so a frame
+     that doesn't redraw the viewport (menu over a frozen game) falls back to the
+     CPU present. The dummy driver / videotool never satisfy the guard. Headless
+     smoke (dummy driver) launches clean.
+   - **1e. Retain `ScaleDrawArea`. — DONE (kept intact).** The CPU composite
+     branch (videotool / single-screen replay) still box-filters the scratch into
+     `bmp` via `ScaleDrawArea`; `test_blit` unchanged (83 assertions, green).
+     Note: videotool is off by default (needs system ffmpeg) so it wasn't
+     rebuilt; its `ScaleDrawArea` caller is untouched.
+   - **1f. Profile to confirm. — PENDING (needs a real display).** Re-measure
+     with Tracy at 1280×800 and 1920×1080 on the 4096² level: composite zone
+     should drop to ~0; capture the new texture-upload cost; verify total
+     `SpectatorViewport::Draw` + `Gfx::Flip` is within the 14 ms budget. Cannot be
+     run in the headless dev environment — the GPU path is guarded off under the
+     dummy driver. Hand to a display-capable machine.
 
 2. **Frustum-cull the sprite and shadow passes.** — **DONE** (`bd8cb77`, PR7 Task 2)
    Every worm, wobject, nobject, bonus, and sobject now gets a cheap AABB check

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -296,6 +296,11 @@ void Gfx::SetVideoMode() {
   if (sdl_spectator_renderer) {
     SDL_DestroyRenderer(sdl_spectator_renderer);
     sdl_spectator_renderer = nullptr;
+    // SDL_DestroyRenderer frees the renderer's textures; drop the dangling
+    // world-texture handle so EnsureSpectatorWorldTexture rebuilds it lazily.
+    sdl_spectator_world_texture = nullptr;
+    sdl_spectator_world_texture_w = 0;
+    sdl_spectator_world_texture_h = 0;
   }
   if (settings->spectator_window) {
     if (!sdl_spectator_window) {
@@ -403,6 +408,9 @@ void Gfx::OnWindowResize(uint32_t window_id) {
       SDL_GetWindowSize(sdl_spectator_window, &w, &h);
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
                                                 SDL_TEXTUREACCESS_STREAMING, w, h);
+      // Blend so the GPU HUD overlay (PR7 Task 1c) composites over the world;
+      // harmless for the CPU present path, whose frames are fully opaque.
+      SDL_SetTextureBlendMode(sdl_spectator_texture, SDL_BLENDMODE_BLEND);
       sdl_spectator_draw_surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_ARGB8888);
       SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, w, h,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);
@@ -1021,6 +1029,81 @@ void Gfx::Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_ren
   last_update_rect = update_rect;
 }
 
+bool Gfx::SpectatorGpuComposite() const {
+  // The GPU composite is spectator-window-only (Task 1d). It needs a live
+  // spectator renderer + overlay texture, and must not fire when the
+  // single-screen renderer is currently the main window's primary renderer
+  // (single-screen replay) — that frame is presented via the CPU Draw path.
+  return settings->spectator_window && sdl_spectator_renderer != nullptr &&
+         sdl_spectator_texture != nullptr && primary_renderer != &single_screen_renderer;
+}
+
+void Gfx::EnsureSpectatorWorldTexture(int need_w, int need_h) {
+  if (!sdl_spectator_renderer || need_w <= 0 || need_h <= 0) {
+    return;
+  }
+  if (sdl_spectator_world_texture && sdl_spectator_world_texture_w >= need_w &&
+      sdl_spectator_world_texture_h >= need_h) {
+    return;  // already big enough — allocated once per level, not per frame
+  }
+  if (sdl_spectator_world_texture) {
+    SDL_DestroyTexture(sdl_spectator_world_texture);
+    sdl_spectator_world_texture = nullptr;
+  }
+  sdl_spectator_world_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
+                                                  SDL_TEXTUREACCESS_STREAMING, need_w, need_h);
+  sdl_spectator_world_texture_w = need_w;
+  sdl_spectator_world_texture_h = need_h;
+  if (sdl_spectator_world_texture) {
+    // Linear scaling is the whole point: the world is downscaled to the
+    // letterboxed dest rect on the GPU. Opaque base layer — no blend.
+    SDL_SetTextureScaleMode(sdl_spectator_world_texture, SDL_SCALEMODE_LINEAR);
+    SDL_SetTextureBlendMode(sdl_spectator_world_texture, SDL_BLENDMODE_NONE);
+  }
+}
+
+void Gfx::DrawSpectatorGpu(Renderer& renderer) {
+  ZoneScopedN("Gfx::DrawSpectatorGpu");
+  EnsureSpectatorWorldTexture(renderer.gpu_world_max_w, renderer.gpu_world_max_h);
+  if (!sdl_spectator_world_texture) {
+    // Allocation failed; present via the CPU path so the window isn't black.
+    Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer, renderer);
+    return;
+  }
+
+  Bitmap const& world = *renderer.gpu_world_src;
+  // Upload only the used sub-rect; the scratch content is anchored at (0,0).
+  SDL_Rect const kUsed{
+      .x = 0, .y = 0, .w = renderer.gpu_world_used_w, .h = renderer.gpu_world_used_h};
+  SDL_UpdateTexture(sdl_spectator_world_texture, &kUsed, world.pixels,
+                    static_cast<int>(world.pitch * sizeof(uint32_t)));
+  // HUD overlay: native-res, transparent background, opaque HUD pixels.
+  SDL_UpdateTexture(sdl_spectator_texture, nullptr, renderer.bmp.pixels,
+                    static_cast<int>(renderer.bmp.pitch * sizeof(uint32_t)));
+
+  // Replicate ScaleDraw's per-channel fade ((v*fade)>>5, fade 0..32) via RGB
+  // texture modulation so the spectator fade-in survives; alpha is left intact
+  // so the HUD overlay still blends.
+  Uint8 const kMod =
+      renderer.fade_value >= 32 ? 255 : static_cast<Uint8>((renderer.fade_value * 255) >> 5);
+  SDL_SetTextureColorMod(sdl_spectator_world_texture, kMod, kMod, kMod);
+  SDL_SetTextureColorMod(sdl_spectator_texture, kMod, kMod, kMod);
+
+  SDL_SetRenderDrawColor(sdl_spectator_renderer, 0, 0, 0, 255);
+  SDL_RenderClear(sdl_spectator_renderer);  // opaque-black letterbox bars
+  SDL_FRect const kSrc{.x = 0.0F,
+                       .y = 0.0F,
+                       .w = static_cast<float>(renderer.gpu_world_used_w),
+                       .h = static_cast<float>(renderer.gpu_world_used_h)};
+  SDL_FRect const kDst{.x = static_cast<float>(renderer.gpu_world_dst_x),
+                       .y = static_cast<float>(renderer.gpu_world_dst_y),
+                       .w = static_cast<float>(renderer.gpu_world_dst_w),
+                       .h = static_cast<float>(renderer.gpu_world_dst_h)};
+  SDL_RenderTexture(sdl_spectator_renderer, sdl_spectator_world_texture, &kSrc, &kDst);
+  SDL_RenderTexture(sdl_spectator_renderer, sdl_spectator_texture, nullptr, nullptr);
+  SDL_RenderPresent(sdl_spectator_renderer);
+}
+
 void Gfx::Flip() {
   ZoneScopedN("Gfx::Flip");
   // draw into the play window. This uses either the normal split screen renderer
@@ -1028,8 +1111,12 @@ void Gfx::Flip() {
   // is turned on
   Draw(*sdl_draw_surface, *sdl_texture, *sdl_renderer, *primary_renderer);
   if (settings->spectator_window) {
-    Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer,
-         single_screen_renderer);
+    if (single_screen_renderer.gpu_world_composite && single_screen_renderer.gpu_world_src) {
+      DrawSpectatorGpu(single_screen_renderer);
+    } else {
+      Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer,
+           single_screen_renderer);
+    }
   }
 
   static unsigned int const kDelay = 14U;
@@ -1313,6 +1400,8 @@ void Gfx::InitFrameStepping() {
   play_renderer.Clear();
   controller->Draw(this->play_renderer, /*use_spectator_viewports=*/false);
   single_screen_renderer.Clear();
+  single_screen_renderer.gpu_world_composite = SpectatorGpuComposite();
+  single_screen_renderer.gpu_world_src = nullptr;
   controller->Draw(this->single_screen_renderer, /*use_spectator_viewports=*/true);
 
   // Push the initial menu state
@@ -1468,6 +1557,8 @@ bool Gfx::RunOneFrame() {
       play_renderer.Clear();
       controller->Draw(this->play_renderer, /*use_spectator_viewports=*/false);
       single_screen_renderer.Clear();
+      single_screen_renderer.gpu_world_composite = SpectatorGpuComposite();
+      single_screen_renderer.gpu_world_src = nullptr;
       controller->Draw(this->single_screen_renderer, /*use_spectator_viewports=*/true);
 
       auto new_menu = std::make_unique<MainMenuState>();
@@ -1484,6 +1575,12 @@ bool Gfx::RunOneFrame() {
   if (kUseMenuFlip) {
     UpdateMenuPalettes(kMenuFadingOut);
   }
+
+  // Decide per frame whether the spectator viewport hands its world to the GPU
+  // (Task 1b/1d); reset the handoff so a frame that doesn't redraw the viewport
+  // (e.g. a menu over a frozen game) falls back to the CPU present path.
+  single_screen_renderer.gpu_world_composite = SpectatorGpuComposite();
+  single_screen_renderer.gpu_world_src = nullptr;
 
   state_stack.Draw();
 

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1102,6 +1102,15 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
   SDL_RenderTexture(sdl_spectator_renderer, sdl_spectator_world_texture, &kSrc, &kDst);
   SDL_RenderTexture(sdl_spectator_renderer, sdl_spectator_texture, nullptr, nullptr);
   SDL_RenderPresent(sdl_spectator_renderer);
+
+  // sdl_spectator_texture is shared with the CPU present path (menus, pause,
+  // weapon select), which applies fade itself via ScaleDraw and expects a
+  // neutral texture. Restore the modulation so this frame's fade value doesn't
+  // leak — at fade 0 it would otherwise leave the texture multiplying by black
+  // and the CPU path would render an all-black spectator window until a resize
+  // recreated the texture.
+  SDL_SetTextureColorMod(sdl_spectator_world_texture, 255, 255, 255);
+  SDL_SetTextureColorMod(sdl_spectator_texture, 255, 255, 255);
 }
 
 void Gfx::Flip() {

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1111,12 +1111,18 @@ void Gfx::Flip() {
   // is turned on
   Draw(*sdl_draw_surface, *sdl_texture, *sdl_renderer, *primary_renderer);
   if (settings->spectator_window) {
-    if (single_screen_renderer.gpu_world_composite && single_screen_renderer.gpu_world_src) {
+    // gpu_world_src is a strict one-shot: it is non-null only for the single
+    // Flip that immediately follows the SpectatorViewport::Draw which set it.
+    // Any other frame — a menu/pause/weapon-select frame, or a direct Flip()
+    // such as MainMenuState::Enter's — finds it null and presents bmp via the
+    // CPU path, so a stale handoff can never blit a freed/mismatched buffer.
+    if (single_screen_renderer.gpu_world_src) {
       DrawSpectatorGpu(single_screen_renderer);
     } else {
       Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer,
            single_screen_renderer);
     }
+    single_screen_renderer.gpu_world_src = nullptr;
   }
 
   static unsigned int const kDelay = 14U;

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -127,6 +127,19 @@ struct Gfx {
   // draws a given surface onto an SDL texture/renderer, using a given Renderer
   void Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_renderer,
             Renderer& renderer);
+  // Spectator-window-only GPU present (PR7 Task 1b/1c): upload the 1:1 world
+  // pass recorded on `renderer` to a streaming texture, scale it on the GPU
+  // into the letterboxed dest rect, then blend the transparent HUD overlay on
+  // top — replacing the CPU box-filter composite.
+  void DrawSpectatorGpu(Renderer& renderer);
+  // (Re)allocates `sdl_spectator_world_texture` to at least need_w×need_h. A
+  // no-op when the current texture already covers the size, so it allocates
+  // once per level rather than per frame.
+  void EnsureSpectatorWorldTexture(int need_w, int need_h);
+  // Whether this frame's spectator present should use the GPU composite. False
+  // for the CPU paths (Task 1d): no spectator window / renderer, or the
+  // single-screen renderer is currently the main window's primary renderer.
+  bool SpectatorGpuComposite() const;
   void Flip();
   // Per-frame menu palette rebuild (fade step, rotation, worm colours).
   // Runs before state drawing so blits resolve through fresh pal32.
@@ -327,6 +340,13 @@ struct Gfx {
   SDL_Texture* sdl_texture = nullptr;
   // full spectator window size texture that represents the spectator window
   SDL_Texture* sdl_spectator_texture = nullptr;
+  // Streaming texture holding the spectator world pass for the GPU composite
+  // (PR7 Task 1b). Allocated once at the level size (clamped to the ceiling);
+  // each frame only the used sub-rect is uploaded. Belongs to
+  // sdl_spectator_renderer.
+  SDL_Texture* sdl_spectator_world_texture = nullptr;
+  int sdl_spectator_world_texture_w = 0;
+  int sdl_spectator_world_texture_h = 0;
   // a software surface to do the actual drawing into
   SDL_Surface* sdl_draw_surface = nullptr;
   // a software surface to do the actual drawing of the spectator view into

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -769,6 +769,7 @@ void ScaleDraw(uint32_t const* src, int w, int h, std::size_t src_pitch, uint8_t
 
 void ScaleDrawArea(uint32_t const* src, int src_w, int src_h, std::size_t src_pitch, uint32_t* dest,
                    int dest_w, int dest_h, std::size_t dest_pitch) {
+  ZoneScopedN("ScaleDrawArea");
   for (int dy = 0; dy < dest_h; ++dy) {
     int const kSy1 = dy * src_h / dest_h;
     int const kSy2 = (dy + 1) * src_h / dest_h;

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <map>
@@ -40,6 +41,52 @@ void Fill(Bitmap& scr, int color) {
 }
 
 void FillTransparent(Bitmap& scr) { std::fill(scr.pixels, scr.pixels + scr.pitch * scr.h, 0U); }
+
+void DrawLevelScaled(Bitmap& scr, Level const& level, int view_x, int view_y, float scale) {
+  float const kInv = 1.0F / scale;
+  for (int py = 0; py < scr.h; ++py) {
+    int const kWy = view_y + static_cast<int>(static_cast<float>(py) * kInv);
+    if (kWy < 0 || kWy >= level.height) {
+      continue;
+    }
+    uint32_t* row = scr.pixels + static_cast<std::size_t>(py) * scr.pitch;
+    int const kBase = kWy * level.width;
+    for (int px = 0; px < scr.w; ++px) {
+      int const kWx = view_x + static_cast<int>(static_cast<float>(px) * kInv);
+      if (kWx < 0 || kWx >= level.width) {
+        continue;
+      }
+      row[px] = level.AppearanceAt(kBase + kWx, scr.mode, scr.pal32, scr.cycles);
+    }
+  }
+}
+
+void BlitImageScaled(Bitmap& scr, Sprite spr, int x, int y, float scale) {
+  int const kDw =
+      std::max(1, static_cast<int>(std::lroundf(static_cast<float>(spr.width) * scale)));
+  int const kDh =
+      std::max(1, static_cast<int>(std::lroundf(static_cast<float>(spr.height) * scale)));
+  float const kInv = 1.0F / scale;
+  for (int dy = 0; dy < kDh; ++dy) {
+    int const kPy = y + dy;
+    if (kPy < scr.clip_rect.y1 || kPy >= scr.clip_rect.y2) {
+      continue;
+    }
+    PalIdx const* srcrow =
+        spr.mem + static_cast<std::size_t>(static_cast<float>(dy) * kInv) * spr.pitch;
+    uint32_t* dstrow = scr.pixels + static_cast<std::size_t>(kPy) * scr.pitch;
+    for (int dx = 0; dx < kDw; ++dx) {
+      int const kPx = x + dx;
+      if (kPx < scr.clip_rect.x1 || kPx >= scr.clip_rect.x2) {
+        continue;
+      }
+      PalIdx const kC = srcrow[static_cast<int>(static_cast<float>(dx) * kInv)];
+      if (kC) {
+        dstrow[kPx] = scr.pal32[kC];
+      }
+    }
+  }
+}
 
 void DrawBar(Bitmap& scr, int x, int y, int width, int color) {
   DrawBar(scr, x, y, width, 2, color);

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -39,6 +39,8 @@ void Fill(Bitmap& scr, int color) {
   std::fill(scr.pixels, scr.pixels + scr.pitch * scr.h, scr.pal32[color]);
 }
 
+void FillTransparent(Bitmap& scr) { std::fill(scr.pixels, scr.pixels + scr.pitch * scr.h, 0U); }
+
 void DrawBar(Bitmap& scr, int x, int y, int width, int color) {
   DrawBar(scr, x, y, width, 2, color);
 }

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -16,6 +16,11 @@ void Vline(Bitmap& scr, int x, int y1, int y2, int color);
 
 void FillRect(Bitmap& scr, int x, int y, int w, int h, int color);
 void Fill(Bitmap& scr, int color);
+// Clears `scr` to fully transparent (ARGB 0x00000000) rather than to a palette
+// colour. Used for the spectator HUD overlay layer (PR7 Task 1c), which must
+// blend over the GPU-scaled world: only the drawn HUD pixels (opaque pal32)
+// show, everything else is see-through.
+void FillTransparent(Bitmap& scr);
 void DrawBar(Bitmap& scr, int x, int y, int width, int color);
 void DrawBar(Bitmap& scr, int x, int y, int width, int height, int color);
 void DrawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width);

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -27,6 +27,17 @@ void DrawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width)
 void DrawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int height);
 // Paints the level's appearance into the screen (the terrain draw).
 void DrawLevel(Bitmap& scr, Level const& level, int x, int y);
+
+// Downscaled terrain render for the zoomed-out spectator world pass (PR7
+// Task 1): fills `scr` (sized to ~output resolution) by nearest-sampling the
+// level, so terrain cost is bounded by the window, not the level area. Scratch
+// pixel (px,py) samples world ((view_x,view_y) + (px,py)/scale). `scale` < 1.
+void DrawLevelScaled(Bitmap& scr, Level const& level, int view_x, int view_y, float scale);
+
+// Nearest-neighbour scaled sprite blit (transparent: palette index 0 skipped)
+// for the downscaled spectator world pass. (x,y) is the already-scaled
+// top-left in `scr`; the sprite is drawn at `scale` of its native size.
+void BlitImageScaled(Bitmap& scr, Sprite spr, int x, int y, float scale);
 // ARGB rectangle copy at identical coordinates (frozen_screen restores).
 void BlitBitmap(Bitmap& scr, Bitmap const& src, int x, int y, int width, int height);
 void BlitImage(Bitmap& scr, Sprite spr, int x, int y);

--- a/src/game/gfx/renderer.hpp
+++ b/src/game/gfx/renderer.hpp
@@ -37,4 +37,28 @@ struct Renderer {
   // setRenderResolution() to ensure that the bitmap is re-allocated
   int render_res_x = 320;
   int render_res_y = 200;
+
+  // ── Spectator GPU world composite (PR7 Task 1b/1c) ────────────────────────
+  // When true, the spectator viewport hands its 1:1 world pass to the GPU for
+  // scaling instead of running the ~38 ms CPU box-filter into `bmp`, and clears
+  // `bmp` to a transparent HUD-only overlay. Gfx sets this only for the live
+  // spectator window (Task 1d); it stays false for the CPU paths (videotool,
+  // single-screen replay, dummy driver), which keep compositing into `bmp`.
+  bool gpu_world_composite = false;
+  // The 1:1 world pass for the GPU composite, owned by the SpectatorViewport
+  // (valid until its next Draw). Null when no world layer was emitted this
+  // frame — Gfx then falls back to the CPU present path.
+  Bitmap const* gpu_world_src = nullptr;
+  // Used sub-rect of `gpu_world_src` actually drawn (≤ the texture size).
+  int gpu_world_used_w = 0;
+  int gpu_world_used_h = 0;
+  // Texture size to allocate (level dims clamped to the ceiling, once per
+  // level). See SpectatorWorldTextureSize.
+  int gpu_world_max_w = 0;
+  int gpu_world_max_h = 0;
+  // Centred, letterboxed destination rect for the world blit (window pixels).
+  int gpu_world_dst_x = 0;
+  int gpu_world_dst_y = 0;
+  int gpu_world_dst_w = 0;
+  int gpu_world_dst_h = 0;
 };

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -161,6 +161,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto br = game.bonuses.All();
       for (Bonus const* i = nullptr; (i = br.Next());) {
+        int const kBx = Ftoi(i->x) - 3 + kOx;
+        int const kBy = Ftoi(i->y) - 3 + kOy;
+        if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
+          continue;
+        }
         if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
           int const kF = common.bonus_frames[i->frame];
           BlitShadowImage(kShadow, scratch_bmp, common.small_sprites.SpritePtr(kF),
@@ -172,6 +177,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto sr = game.sobjects.All();
       for (SObject const* i = nullptr; (i = sr.Next());) {
+        int const kSx = i->x + kOx;
+        int const kSy = i->y + kOy;
+        if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
+          continue;
+        }
         SObjectType const& t = common.sobject_types[i->id];
         int const kFrame = i->cur_frame + t.start_frame;
         BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame),
@@ -182,6 +192,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto wr = game.wobjects.All();
       for (WObject const* i = nullptr; (i = wr.Next());) {
+        int const kWx = Ftoi(i->pos.x) - 3 + kOx;
+        int const kWy = Ftoi(i->pos.y) - 3 + kOy;
+        if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
+          continue;
+        }
         Weapon const& w = *i->type;
         if (w.start_frame > -1) {
           int cur_frame = i->cur_frame;
@@ -227,6 +242,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto nr = game.nobjects.All();
       for (NObject const* i = nullptr; (i = nr.Next());) {
+        int const kNx = Ftoi(i->pos.x) - 3 + kOx;
+        int const kNy = Ftoi(i->pos.y) - 3 + kOy;
+        if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
+          continue;
+        }
         NObjectType const& t = *i->type;
         if (t.start_frame > 0) {
           auto pos = Ftoi(i->pos) - IVec2(3, 3);
@@ -252,6 +272,9 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       if (w.visible) {
         int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
         int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
+        if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
+          continue;
+        }
         if (w.ninjarope.out) {
           int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
           int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
@@ -285,10 +308,14 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto br = game.bonuses.All();
       for (Bonus const* i = nullptr; (i = br.Next());) {
+        int const kBx = Ftoi(i->x) - 3 + kOx;
+        int const kBy = Ftoi(i->y) - 3 + kOy;
+        if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
+          continue;
+        }
         if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
           int const kF = common.bonus_frames[i->frame];
-          BlitImage(scratch_bmp, common.small_sprites[kF], Ftoi(i->x) - 3 + kOx,
-                    Ftoi(i->y) - 3 + kOy);
+          BlitImage(scratch_bmp, common.small_sprites[kF], kBx, kBy);
           if (game.settings->names_on_bonuses && i->frame == 0) {
             std::string const& name = common.weapons[i->weapon].name;
             int const kLen = static_cast<int>(name.size()) * 4;
@@ -302,16 +329,25 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto sr = game.sobjects.All();
       for (SObject const* i = nullptr; (i = sr.Next());) {
+        int const kSx = i->x + kOx;
+        int const kSy = i->y + kOy;
+        if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
+          continue;
+        }
         SObjectType const& t = common.sobject_types[i->id];
         int const kFrame = i->cur_frame + t.start_frame;
-        BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), i->x + kOx,
-                   i->y + kOy, 16, 16);
+        BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), kSx, kSy, 16, 16);
       }
     }
 
     {
       auto wr = game.wobjects.All();
       for (WObject* i = nullptr; (i = wr.Next());) {
+        int const kWx = Ftoi(i->pos.x) - 3 + kOx;
+        int const kWy = Ftoi(i->pos.y) - 3 + kOy;
+        if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
+          continue;
+        }
         Weapon const& w = *i->type;
         if (w.start_frame > -1) {
           int cur_frame = i->cur_frame;
@@ -362,6 +398,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto nr = game.nobjects.All();
       for (NObject const* i = nullptr; (i = nr.Next());) {
+        int const kNx = Ftoi(i->pos.x) - 3 + kOx;
+        int const kNy = Ftoi(i->pos.y) - 3 + kOy;
+        if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
+          continue;
+        }
         NObjectType const& t = *i->type;
         if (t.start_frame > 0) {
           auto pos = Ftoi(i->pos) - IVec2(3, 3);
@@ -383,6 +424,9 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       if (w.visible) {
         int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
         int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
+        if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
+          continue;
+        }
         int const kAngleFrame = w.AngleFrame();
         if (w.weapons[w.current_weapon].Available()) {
           int const kHotspotX = w.hotspot_x + kOx;
@@ -423,6 +467,9 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
         auto temp = Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
         temp.x += kOx;
         temp.y += kOy;
+        if (temp.x + 7 < 0 || temp.x >= kScrW || temp.y + 7 < 0 || temp.y >= kScrH) {
+          continue;
+        }
         BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
                   temp.y);
         if (worm.Pressed(Worm::kChange)) {

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -28,6 +28,20 @@ float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, i
   return std::clamp(std::min(kZoomX, kZoomY), kLevelFillZoom, kMaxZoom);
 }
 
+WorldTextureSize SpectatorWorldTextureSize(int level_w, int level_h) {
+  return {.w = std::min(level_w, kSpectatorWorldTextureMax),
+          .h = std::min(level_h, kSpectatorWorldTextureMax)};
+}
+
+SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, int scr_h,
+                                         float zoom) {
+  int const kOutW =
+      std::min(static_cast<int>(std::lroundf(static_cast<float>(scr_w) * zoom)), render_w);
+  int const kOutH =
+      std::min(static_cast<int>(std::lroundf(static_cast<float>(scr_h) * zoom)), render_h);
+  return {.x = (render_w - kOutW) / 2, .y = (render_h - kOutH) / 2, .w = kOutW, .h = kOutH};
+}
+
 void SpectatorViewport::Process(Game& game) {
   int const kRenderW = render_w;
   int const kRenderH = render_h;
@@ -489,25 +503,40 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   }  // end SpritePass zone
 
   // ── Composite scratch → renderer ─────────────────────────────────────────
-  {
-    ZoneScopedN("Spectator::Composite");
-    // Scale the scratch into a centred output rect that preserves the level's
-    // aspect ratio; any remaining bars are filled black.
-    int const kOutW =
-        std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrW) * zoom)), render_w);
-    int const kOutH =
-        std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrH) * zoom)), render_h);
-    int const kOutX = (render_w - kOutW) / 2;
-    int const kOutY = (render_h - kOutH) / 2;
+  // Centred output rect that preserves the level's aspect ratio; any remaining
+  // bars are filled black. Shared by the CPU and GPU composite paths.
+  SpectatorDstRect const kDst = ComputeSpectatorDstRect(render_w, render_h, kScrW, kScrH, zoom);
 
-    if (kOutX > 0 || kOutY > 0) {
+  if (renderer.gpu_world_composite) {
+    // GPU path (PR7 Task 1b): hand the 1:1 world pass to Gfx, which uploads the
+    // used sub-rect to a streaming texture and scales it on the GPU
+    // (SDL_RenderTexture), deleting the ~38 ms CPU box-filter. `bmp` becomes a
+    // transparent HUD-only overlay (Task 1c) blended on top of the world.
+    ZoneScopedN("Spectator::Composite::GpuHandoff");
+    WorldTextureSize const kTex = SpectatorWorldTextureSize(game.level.width, game.level.height);
+    renderer.gpu_world_src = &scratch_bmp;
+    renderer.gpu_world_used_w = kScrW;
+    renderer.gpu_world_used_h = kScrH;
+    renderer.gpu_world_max_w = kTex.w;
+    renderer.gpu_world_max_h = kTex.h;
+    renderer.gpu_world_dst_x = kDst.x;
+    renderer.gpu_world_dst_y = kDst.y;
+    renderer.gpu_world_dst_w = kDst.w;
+    renderer.gpu_world_dst_h = kDst.h;
+    FillTransparent(renderer.bmp);
+  } else {
+    // CPU path (videotool, single-screen replay, dummy driver): box-filter the
+    // scratch straight into `bmp` as before. Retains ScaleDrawArea (Task 1e).
+    ZoneScopedN("Spectator::Composite");
+    renderer.gpu_world_src = nullptr;
+    if (kDst.x > 0 || kDst.y > 0) {
       Fill(renderer.bmp, 0);
     }
 
     uint32_t* const kDest = renderer.bmp.pixels +
-                            static_cast<std::size_t>(kOutY) * renderer.bmp.pitch +
-                            static_cast<std::size_t>(kOutX);
-    if (kScrW == kOutW && kScrH == kOutH) {
+                            static_cast<std::size_t>(kDst.y) * renderer.bmp.pitch +
+                            static_cast<std::size_t>(kDst.x);
+    if (kScrW == kDst.w && kScrH == kDst.h) {
       // BlitBitmap reads from src at position (x,y), not (0,0) — wrong for a
       // scratch bitmap whose content always starts at (0,0). Copy row-by-row.
       uint32_t const* src_row = scratch_bmp.pixels;
@@ -518,7 +547,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
         src_row += scratch_bmp.pitch;
       }
     } else {
-      ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, kDest, kOutW, kOutH,
+      ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, kDest, kDst.w, kDst.h,
                     renderer.bmp.pitch);
     }
   }  // end Composite zone

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -28,10 +28,6 @@ float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, i
   return std::clamp(std::min(kZoomX, kZoomY), kLevelFillZoom, kMaxZoom);
 }
 
-ScratchDims ComputeScratchDims(int render_w, int render_h, int level_w, int level_h) {
-  return {.w = std::min(render_w, level_w), .h = std::min(render_h, level_h)};
-}
-
 void SpectatorViewport::Process(Game& game) {
   int const kRenderW = render_w;
   int const kRenderH = render_h;
@@ -92,12 +88,13 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   int const kCenterX = render_w / 2;
 
   // ── World pass ────────────────────────────────────────────────────────────
-  // Scratch bitmap sized to the visible world region, capped to render
-  // resolution. Capping here prevents the scratch from growing to
-  // render_w/zoom x render_h/zoom (up to 4x the pixel count at zoom=0.5).
-  auto const kScr = ComputeScratchDims(render_w, render_h, game.level.width, game.level.height);
-  int const kScrW = kScr.w;
-  int const kScrH = kScr.h;
+  // Scratch bitmap holds the visible world region at 1:1 pixel scale, capped
+  // to the level dimensions. At zoom < 1 this can be as large as the full
+  // level; the GPU path (Task 1e) will replace this with SDL_RenderTexture.
+  int const kScrW =
+      std::min(static_cast<int>(static_cast<float>(render_w) / zoom), game.level.width);
+  int const kScrH =
+      std::min(static_cast<int>(static_cast<float>(render_h) / zoom), game.level.height);
 
   scratch_bmp.Alloc(kScrW, kScrH);
   scratch_bmp.pal32 = renderer.pal32;

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -9,6 +9,7 @@
 #include "gfx/renderer.hpp"
 #include "gfx/shadow_query.hpp"
 #include "math.hpp"
+#include "profiling.hpp"
 #include "text.hpp"
 
 float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, int level_w,
@@ -25,6 +26,10 @@ float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, i
   // fits from shrinking when worms reach the edges.
   float const kMaxZoom = std::max(1.0F, kLevelFillZoom);
   return std::clamp(std::min(kZoomX, kZoomY), kLevelFillZoom, kMaxZoom);
+}
+
+ScratchDims ComputeScratchDims(int render_w, int render_h, int level_w, int level_h) {
+  return {.w = std::min(render_w, level_w), .h = std::min(render_h, level_h)};
 }
 
 void SpectatorViewport::Process(Game& game) {
@@ -79,6 +84,7 @@ void SpectatorViewport::Process(Game& game) {
 }
 
 void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bool /*is_replay*/) {
+  ZoneScopedN("SpectatorViewport::Draw");
   Common& common = *game.common;
   render_w = renderer.render_res_x;
   render_h = renderer.render_res_y;
@@ -86,11 +92,12 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   int const kCenterX = render_w / 2;
 
   // ── World pass ────────────────────────────────────────────────────────────
-  // Scratch bitmap sized to the visible world region, capped to map dimensions.
-  int const kScrW =
-      std::min(static_cast<int>(static_cast<float>(render_w) / zoom), game.level.width);
-  int const kScrH =
-      std::min(static_cast<int>(static_cast<float>(render_h) / zoom), game.level.height);
+  // Scratch bitmap sized to the visible world region, capped to render
+  // resolution. Capping here prevents the scratch from growing to
+  // render_w/zoom x render_h/zoom (up to 4x the pixel count at zoom=0.5).
+  auto const kScr = ComputeScratchDims(render_w, render_h, game.level.width, game.level.height);
+  int const kScrW = kScr.w;
+  int const kScrH = kScr.h;
 
   scratch_bmp.Alloc(kScrW, kScrH);
   scratch_bmp.pal32 = renderer.pal32;
@@ -110,7 +117,10 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
                             .mode = renderer.mode,
                             .cycles = game.cycles};
 
-  DrawLevel(scratch_bmp, game.level, kOx, kOy);
+  {
+    ZoneScopedN("Spectator::WorldPass::DrawLevel");
+    DrawLevel(scratch_bmp, game.level, kOx, kOy);
+  }
 
   if (game.settings->game_mode == Settings::kGmHoldazone) {
     bool const kTimingOut = game.holdazone.timeout_left < 70 * 4;
@@ -147,6 +157,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
   // Pass 1: all shadows before any sprite.
   if (game.settings->shadow) {
+    ZoneScopedN("Spectator::WorldPass::ShadowPass");
     {
       auto br = game.bonuses.All();
       for (Bonus const* i = nullptr; (i = br.Next());) {
@@ -270,328 +281,341 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
 
   // Pass 2: all sprites on top of the fully-composited shadow layer.
   {
-    auto br = game.bonuses.All();
-    for (Bonus const* i = nullptr; (i = br.Next());) {
-      if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
-        int const kF = common.bonus_frames[i->frame];
-        BlitImage(scratch_bmp, common.small_sprites[kF], Ftoi(i->x) - 3 + kOx,
-                  Ftoi(i->y) - 3 + kOy);
-        if (game.settings->names_on_bonuses && i->frame == 0) {
-          std::string const& name = common.weapons[i->weapon].name;
+    ZoneScopedN("Spectator::WorldPass::SpritePass");
+    {
+      auto br = game.bonuses.All();
+      for (Bonus const* i = nullptr; (i = br.Next());) {
+        if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
+          int const kF = common.bonus_frames[i->frame];
+          BlitImage(scratch_bmp, common.small_sprites[kF], Ftoi(i->x) - 3 + kOx,
+                    Ftoi(i->y) - 3 + kOy);
+          if (game.settings->names_on_bonuses && i->frame == 0) {
+            std::string const& name = common.weapons[i->weapon].name;
+            int const kLen = static_cast<int>(name.size()) * 4;
+            common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOx,
+                                 Ftoi(i->y) - 10 + kOy);
+          }
+        }
+      }
+    }
+
+    {
+      auto sr = game.sobjects.All();
+      for (SObject const* i = nullptr; (i = sr.Next());) {
+        SObjectType const& t = common.sobject_types[i->id];
+        int const kFrame = i->cur_frame + t.start_frame;
+        BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), i->x + kOx,
+                   i->y + kOy, 16, 16);
+      }
+    }
+
+    {
+      auto wr = game.wobjects.All();
+      for (WObject* i = nullptr; (i = wr.Next());) {
+        Weapon const& w = *i->type;
+        if (w.start_frame > -1) {
+          int cur_frame = i->cur_frame;
+          int const kShotType = w.shot_type;
+          if (kShotType == 2) {
+            cur_frame += 4;
+            cur_frame >>= 3;
+            if (cur_frame < 0) {
+              cur_frame = 16;
+            } else if (cur_frame > 15) {
+              cur_frame -= 16;
+            }
+          } else if (kShotType == 3) {
+            if (cur_frame > 64) {
+              --cur_frame;
+            }
+            cur_frame -= 12;
+            cur_frame >>= 3;
+            if (cur_frame < 0) {
+              cur_frame = 0;
+            } else if (cur_frame > 12) {
+              cur_frame = 12;
+            }
+          }
+          int const kPosX = Ftoi(i->pos.x) - 3;
+          int const kPosY = Ftoi(i->pos.y) - 3;
+          BlitImage(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOx,
+                    kPosY + kOy);
+        } else if (i->cur_frame > 0) {
+          int const kPosX = Ftoi(i->pos.x) + kOx;
+          int const kPosY = Ftoi(i->pos.y) + kOy;
+          scratch_bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
+        }
+        if (!common.h[HRemExp] && i->type - common.weapons.data() == 34 &&
+            game.settings->names_on_bonuses) {
+          if (i->cur_frame == 0) {
+            int const kNameNum =
+                static_cast<int>(&*i - game.wobjects.arr) % static_cast<int>(common.weapons.size());
+            std::string const& name = common.weapons[kNameNum].name;
+            int const kWidth = static_cast<int>(name.size()) * 4;
+            common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOx,
+                                 Ftoi(i->pos.y) - 10 + kOy);
+          }
+        }
+      }
+    }
+
+    {
+      auto nr = game.nobjects.All();
+      for (NObject const* i = nullptr; (i = nr.Next());) {
+        NObjectType const& t = *i->type;
+        if (t.start_frame > 0) {
+          auto pos = Ftoi(i->pos) - IVec2(3, 3);
+          BlitImage(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOx,
+                    pos.y + kOy);
+        } else if (i->cur_frame > 1) {
+          auto pos = Ftoi(i->pos);
+          pos.x += kOx;
+          pos.y += kOy;
+          if (scratch_bmp.clip_rect.Encloses(pos)) {
+            scratch_bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
+          }
+        }
+      }
+    }
+
+    for (std::size_t i = 0; i < game.worms.size(); ++i) {
+      Worm const& w = *game.worms[i];
+      if (w.visible) {
+        int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
+        int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
+        int const kAngleFrame = w.AngleFrame();
+        if (w.weapons[w.current_weapon].Available()) {
+          int const kHotspotX = w.hotspot_x + kOx;
+          int const kHotspotY = w.hotspot_y + kOy;
+          WormWeapon const& ww = w.weapons[w.current_weapon];
+          Weapon const& weapon = *ww.type;
+          if (weapon.laser_sight) {
+            DrawLaserSight(scratch_bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
+          }
+          if (ww.type - common.weapons.data() == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
+            DrawLine(scratch_bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4,
+                     weapon.color_bullets);
+          }
+        }
+        if (w.ninjarope.out) {
+          int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
+          int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
+          DrawNinjarope(common, scratch_bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
+          BlitImage(scratch_bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
+        }
+        if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
+          BlitFireCone(scratch_bmp, w.fire_cone / 2,
+                       common.FireConeSprite(kAngleFrame, w.direction),
+                       Common::fire_cone_offset[w.direction][kAngleFrame][0] + kTempX,
+                       Common::fire_cone_offset[w.direction][kAngleFrame][1] + kTempY);
+        }
+        BlitImage(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), kTempX,
+                  kTempY);
+      }
+      if (w.ai) {
+        w.ai->DrawDebug(game, w, renderer, kOx, kOy);
+      }
+    }
+
+    for (auto& i : game.worms) {
+      Worm const& worm = *i;
+      if (worm.visible) {
+        auto temp = Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
+        temp.x += kOx;
+        temp.y += kOy;
+        BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
+                  temp.y);
+        if (worm.Pressed(Worm::kChange)) {
+          std::string const& name = worm.weapons[worm.current_weapon].type->name;
           int const kLen = static_cast<int>(name.size()) * 4;
-          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOx,
-                               Ftoi(i->y) - 10 + kOy);
+          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOx,
+                               Ftoi(worm.pos.y) - 10 + kOy);
         }
       }
     }
-  }
 
-  {
-    auto sr = game.sobjects.All();
-    for (SObject const* i = nullptr; (i = sr.Next());) {
-      SObjectType const& t = common.sobject_types[i->id];
-      int const kFrame = i->cur_frame + t.start_frame;
-      BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), i->x + kOx,
-                 i->y + kOy, 16, 16);
-    }
-  }
-
-  {
-    auto wr = game.wobjects.All();
-    for (WObject* i = nullptr; (i = wr.Next());) {
-      Weapon const& w = *i->type;
-      if (w.start_frame > -1) {
-        int cur_frame = i->cur_frame;
-        int const kShotType = w.shot_type;
-        if (kShotType == 2) {
-          cur_frame += 4;
-          cur_frame >>= 3;
-          if (cur_frame < 0) {
-            cur_frame = 16;
-          } else if (cur_frame > 15) {
-            cur_frame -= 16;
-          }
-        } else if (kShotType == 3) {
-          if (cur_frame > 64) {
-            --cur_frame;
-          }
-          cur_frame -= 12;
-          cur_frame >>= 3;
-          if (cur_frame < 0) {
-            cur_frame = 0;
-          } else if (cur_frame > 12) {
-            cur_frame = 12;
-          }
-        }
-        int const kPosX = Ftoi(i->pos.x) - 3;
-        int const kPosY = Ftoi(i->pos.y) - 3;
-        BlitImage(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOx,
-                  kPosY + kOy);
-      } else if (i->cur_frame > 0) {
-        int const kPosX = Ftoi(i->pos.x) + kOx;
-        int const kPosY = Ftoi(i->pos.y) + kOy;
-        scratch_bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
-      }
-      if (!common.h[HRemExp] && i->type - common.weapons.data() == 34 &&
-          game.settings->names_on_bonuses) {
-        if (i->cur_frame == 0) {
-          int const kNameNum =
-              static_cast<int>(&*i - game.wobjects.arr) % static_cast<int>(common.weapons.size());
-          std::string const& name = common.weapons[kNameNum].name;
-          int const kWidth = static_cast<int>(name.size()) * 4;
-          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOx,
-                               Ftoi(i->pos.y) - 10 + kOy);
-        }
+    for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
+      auto ipos = Ftoi(i->pos);
+      ipos.x += kOx;
+      ipos.y += kOy;
+      if (scratch_bmp.clip_rect.Encloses(ipos)) {
+        scratch_bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
       }
     }
-  }
-
-  {
-    auto nr = game.nobjects.All();
-    for (NObject const* i = nullptr; (i = nr.Next());) {
-      NObjectType const& t = *i->type;
-      if (t.start_frame > 0) {
-        auto pos = Ftoi(i->pos) - IVec2(3, 3);
-        BlitImage(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOx,
-                  pos.y + kOy);
-      } else if (i->cur_frame > 1) {
-        auto pos = Ftoi(i->pos);
-        pos.x += kOx;
-        pos.y += kOy;
-        if (scratch_bmp.clip_rect.Encloses(pos)) {
-          scratch_bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
-        }
-      }
-    }
-  }
-
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& w = *game.worms[i];
-    if (w.visible) {
-      int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
-      int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
-      int const kAngleFrame = w.AngleFrame();
-      if (w.weapons[w.current_weapon].Available()) {
-        int const kHotspotX = w.hotspot_x + kOx;
-        int const kHotspotY = w.hotspot_y + kOy;
-        WormWeapon const& ww = w.weapons[w.current_weapon];
-        Weapon const& weapon = *ww.type;
-        if (weapon.laser_sight) {
-          DrawLaserSight(scratch_bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
-        }
-        if (ww.type - common.weapons.data() == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
-          DrawLine(scratch_bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4, weapon.color_bullets);
-        }
-      }
-      if (w.ninjarope.out) {
-        int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
-        int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
-        DrawNinjarope(common, scratch_bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
-        BlitImage(scratch_bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
-      }
-      if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
-        BlitFireCone(scratch_bmp, w.fire_cone / 2, common.FireConeSprite(kAngleFrame, w.direction),
-                     Common::fire_cone_offset[w.direction][kAngleFrame][0] + kTempX,
-                     Common::fire_cone_offset[w.direction][kAngleFrame][1] + kTempY);
-      }
-      BlitImage(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), kTempX,
-                kTempY);
-    }
-    if (w.ai) {
-      w.ai->DrawDebug(game, w, renderer, kOx, kOy);
-    }
-  }
-
-  for (auto& i : game.worms) {
-    Worm const& worm = *i;
-    if (worm.visible) {
-      auto temp = Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
-      temp.x += kOx;
-      temp.y += kOy;
-      BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x, temp.y);
-      if (worm.Pressed(Worm::kChange)) {
-        std::string const& name = worm.weapons[worm.current_weapon].type->name;
-        int const kLen = static_cast<int>(name.size()) * 4;
-        common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOx,
-                             Ftoi(worm.pos.y) - 10 + kOy);
-      }
-    }
-  }
-
-  for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
-    auto ipos = Ftoi(i->pos);
-    ipos.x += kOx;
-    ipos.y += kOy;
-    if (scratch_bmp.clip_rect.Encloses(ipos)) {
-      scratch_bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
-    }
-  }
+  }  // end SpritePass zone
 
   // ── Composite scratch → renderer ─────────────────────────────────────────
-  // Scale the scratch into a centred output rect that preserves the level's
-  // aspect ratio; any remaining bars are filled black.
-  int const kOutW =
-      std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrW) * zoom)), render_w);
-  int const kOutH =
-      std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrH) * zoom)), render_h);
-  int const kOutX = (render_w - kOutW) / 2;
-  int const kOutY = (render_h - kOutH) / 2;
+  {
+    ZoneScopedN("Spectator::Composite");
+    // Scale the scratch into a centred output rect that preserves the level's
+    // aspect ratio; any remaining bars are filled black.
+    int const kOutW =
+        std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrW) * zoom)), render_w);
+    int const kOutH =
+        std::min(static_cast<int>(std::lroundf(static_cast<float>(kScrH) * zoom)), render_h);
+    int const kOutX = (render_w - kOutW) / 2;
+    int const kOutY = (render_h - kOutH) / 2;
 
-  if (kOutX > 0 || kOutY > 0) {
-    Fill(renderer.bmp, 0);
-  }
-
-  uint32_t* const kDest = renderer.bmp.pixels +
-                          static_cast<std::size_t>(kOutY) * renderer.bmp.pitch +
-                          static_cast<std::size_t>(kOutX);
-  if (kScrW == kOutW && kScrH == kOutH) {
-    // BlitBitmap reads from src at position (x,y), not (0,0) — wrong for a
-    // scratch bitmap whose content always starts at (0,0). Copy row-by-row.
-    uint32_t const* src_row = scratch_bmp.pixels;
-    uint32_t* dst_row = kDest;
-    for (int row = 0; row < kScrH; ++row) {
-      std::memcpy(dst_row, src_row, sizeof(uint32_t) * static_cast<std::size_t>(kScrW));
-      dst_row += renderer.bmp.pitch;
-      src_row += scratch_bmp.pitch;
+    if (kOutX > 0 || kOutY > 0) {
+      Fill(renderer.bmp, 0);
     }
-  } else {
-    ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, kDest, kOutW, kOutH,
-                  renderer.bmp.pitch);
-  }
+
+    uint32_t* const kDest = renderer.bmp.pixels +
+                            static_cast<std::size_t>(kOutY) * renderer.bmp.pitch +
+                            static_cast<std::size_t>(kOutX);
+    if (kScrW == kOutW && kScrH == kOutH) {
+      // BlitBitmap reads from src at position (x,y), not (0,0) — wrong for a
+      // scratch bitmap whose content always starts at (0,0). Copy row-by-row.
+      uint32_t const* src_row = scratch_bmp.pixels;
+      uint32_t* dst_row = kDest;
+      for (int row = 0; row < kScrH; ++row) {
+        std::memcpy(dst_row, src_row, sizeof(uint32_t) * static_cast<std::size_t>(kScrW));
+        dst_row += renderer.bmp.pitch;
+        src_row += scratch_bmp.pitch;
+      }
+    } else {
+      ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, kDest, kOutW, kOutH,
+                    renderer.bmp.pitch);
+    }
+  }  // end Composite zone
 
   // ── HUD overlay (native resolution, drawn on top) ─────────────────────────
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    int const kHudX = worm.stats_x * kMultiplier;
-    int const kOffsetWeaponListX = kCenterX - 15 + (i == 0 ? -90 : 60);
+  {
+    ZoneScopedN("Spectator::HUD");
+    for (std::size_t i = 0; i < game.worms.size(); ++i) {
+      Worm const& worm = *game.worms[i];
+      int const kHudX = worm.stats_x * kMultiplier;
+      int const kOffsetWeaponListX = kCenterX - 15 + (i == 0 ? -90 : 60);
 
-    if (worm.visible) {
-      int const kLifebarWidth = worm.health * 100 / worm.settings->health;
-      DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, kLifebarWidth,
-              kLifebarWidth / 10 + 234);
-    } else {
-      int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
-      if (lifebar_width > 0) {
-        lifebar_width = std::min(lifebar_width, 100);
-        DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, lifebar_width,
-                lifebar_width / 10 + 234);
-      }
-    }
-
-    WormWeapon const& ww = worm.weapons[worm.current_weapon];
-    if (ww.Available()) {
-      if (ww.ammo > 0) {
-        int const kAmmoBarWidth = ww.ammo * 100 / ww.type->ammo;
-        if (kAmmoBarWidth > 0) {
-          DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, kAmmoBarWidth,
-                  kAmmoBarWidth / 10 + 245);
+      if (worm.visible) {
+        int const kLifebarWidth = worm.health * 100 / worm.settings->health;
+        DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, kLifebarWidth,
+                kLifebarWidth / 10 + 234);
+      } else {
+        int lifebar_width = 100 - (worm.killed_timer * 25) / 37;
+        if (lifebar_width > 0) {
+          lifebar_width = std::min(lifebar_width, 100);
+          DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 39, lifebar_width,
+                  lifebar_width / 10 + 234);
         }
       }
-    } else {
-      int ammo_bar_width = 0;
-      if (ww.type->loading_time != 0) {
-        int const kComputedLoadingTime = ww.type->ComputedLoadingTime(*game.settings);
-        ammo_bar_width = 100 - ww.loading_left * 100 / kComputedLoadingTime;
-      } else {
-        ammo_bar_width = 100 - ww.loading_left * 100;
-      }
-      if (ammo_bar_width > 0) {
-        DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, ammo_bar_width,
-                ammo_bar_width / 10 + 245);
-      }
-      if ((game.cycles % 20) > 10 && worm.visible) {
-        common.font.DrawString(renderer.bmp, LS(Reloading), kHudX, 164, 50);
-      }
-    }
 
-    common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)), kHudX,
-                           renderer.render_res_y - 29, 10);
-    common.font.DrawString(renderer.bmp, worm.settings->name, kHudX, renderer.render_res_y - 15, 7);
-    FillRect(renderer.bmp, kHudX - 1, renderer.render_res_y - 7 - 1, 8, 8, 7);
-    FillRect(renderer.bmp, kHudX, renderer.render_res_y - 7, 6, 6, worm.settings->color);
-    // FIXME: only draw this once, not once per worm
-    common.font.DrawString(
-        renderer.bmp,
-        TimeToStringEx(game.cycles * 14, /*force_hours=*/false, /*force_minutes=*/true),
-        kCenterX - 15, renderer.render_res_y - 15, 7);
-
-    if (state == kStateGame) {
-      for (int j = 0; j < 5; j++) {
-        WormWeapon const& wwj = worm.weapons[j];
-        if (wwj.ammo > 0) {
-          int const kAmmoBarWidth = wwj.ammo * 60 / wwj.type->ammo;
+      WormWeapon const& ww = worm.weapons[worm.current_weapon];
+      if (ww.Available()) {
+        if (ww.ammo > 0) {
+          int const kAmmoBarWidth = ww.ammo * 100 / ww.type->ammo;
           if (kAmmoBarWidth > 0) {
-            DrawBar(renderer.bmp, kOffsetWeaponListX, renderer.render_res_y - 40 + j * 8,
-                    kAmmoBarWidth, 5, kAmmoBarWidth / 6 + 245);
+            DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, kAmmoBarWidth,
+                    kAmmoBarWidth / 10 + 245);
           }
         }
-        if (worm.current_weapon == j) {
-          common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
-                                 renderer.render_res_y - 40 + j * 8, 187);
-        } else {
-          common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
-                                 renderer.render_res_y - 40 + j * 8, 185);
-        }
-      }
-    }
-
-    int const kStateColours[2][2] = {{6, 10}, {79, 4}};
-    switch (game.settings->game_mode) {
-      case Settings::kGmKillEmAll:
-      case Settings::kGmScalesOfJustice: {
-        common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)), kHudX,
-                               renderer.render_res_y - 22, 6);
-      } break;
-      case Settings::kGmHoldazone: {
-        int hstate = 0;
-        for (auto const& w : game.worms) {
-          if (w.get() != &worm && w->timer <= worm.timer) {
-            hstate = 1;
-          }
-        }
-        int const kColor = kStateColours[game.holdazone.holder_idx != worm.index][hstate];
-        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                               renderer.render_res_y - 39, kColor);
-      } break;
-      case Settings::kGmGameOfTag: {
-        int gstate = 0;
-        for (auto const& w : game.worms) {
-          if (w.get() != &worm && w->timer >= worm.timer) {
-            gstate = 1;
-          }
-        }
-        int const kColor = kStateColours[game.last_killed_idx != worm.index][gstate];
-        common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
-                               renderer.render_res_y - 39, kColor);
-      } break;
-      default:
-        break;
-    }
-  }
-
-  // ── Banner messages ───────────────────────────────────────────────────────
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    if (banner_y > -8 && worm.health <= 0) {
-      if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
-        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
-      }
-    }
-  }
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    if (worm.health <= 0 && banner_y > -8) {
-      if (worm.last_killed_by_idx == worm.index) {
-        std::string const kMsg(worm.settings->name + LS(CommittedSuicideMsg));
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
       } else {
-        std::string const kMsg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
-                               worm.settings->name);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
-        common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
+        int ammo_bar_width = 0;
+        if (ww.type->loading_time != 0) {
+          int const kComputedLoadingTime = ww.type->ComputedLoadingTime(*game.settings);
+          ammo_bar_width = 100 - ww.loading_left * 100 / kComputedLoadingTime;
+        } else {
+          ammo_bar_width = 100 - ww.loading_left * 100;
+        }
+        if (ammo_bar_width > 0) {
+          DrawBar(renderer.bmp, kHudX, renderer.render_res_y - 34, ammo_bar_width,
+                  ammo_bar_width / 10 + 245);
+        }
+        if ((game.cycles % 20) > 10 && worm.visible) {
+          common.font.DrawString(renderer.bmp, LS(Reloading), kHudX, 164, 50);
+        }
+      }
+
+      common.font.DrawString(renderer.bmp, (LS(Kills) + ToString(worm.kills)), kHudX,
+                             renderer.render_res_y - 29, 10);
+      common.font.DrawString(renderer.bmp, worm.settings->name, kHudX, renderer.render_res_y - 15,
+                             7);
+      FillRect(renderer.bmp, kHudX - 1, renderer.render_res_y - 7 - 1, 8, 8, 7);
+      FillRect(renderer.bmp, kHudX, renderer.render_res_y - 7, 6, 6, worm.settings->color);
+      // FIXME: only draw this once, not once per worm
+      common.font.DrawString(
+          renderer.bmp,
+          TimeToStringEx(game.cycles * 14, /*force_hours=*/false, /*force_minutes=*/true),
+          kCenterX - 15, renderer.render_res_y - 15, 7);
+
+      if (state == kStateGame) {
+        for (int j = 0; j < 5; j++) {
+          WormWeapon const& wwj = worm.weapons[j];
+          if (wwj.ammo > 0) {
+            int const kAmmoBarWidth = wwj.ammo * 60 / wwj.type->ammo;
+            if (kAmmoBarWidth > 0) {
+              DrawBar(renderer.bmp, kOffsetWeaponListX, renderer.render_res_y - 40 + j * 8,
+                      kAmmoBarWidth, 5, kAmmoBarWidth / 6 + 245);
+            }
+          }
+          if (worm.current_weapon == j) {
+            common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
+                                   renderer.render_res_y - 40 + j * 8, 187);
+          } else {
+            common.font.DrawString(renderer.bmp, worm.weapons[j].type->name, kOffsetWeaponListX,
+                                   renderer.render_res_y - 40 + j * 8, 185);
+          }
+        }
+      }
+
+      int const kStateColours[2][2] = {{6, 10}, {79, 4}};
+      switch (game.settings->game_mode) {
+        case Settings::kGmKillEmAll:
+        case Settings::kGmScalesOfJustice: {
+          common.font.DrawString(renderer.bmp, (LS(Lives) + ToString(worm.lives)), kHudX,
+                                 renderer.render_res_y - 22, 6);
+        } break;
+        case Settings::kGmHoldazone: {
+          int hstate = 0;
+          for (auto const& w : game.worms) {
+            if (w.get() != &worm && w->timer <= worm.timer) {
+              hstate = 1;
+            }
+          }
+          int const kColor = kStateColours[game.holdazone.holder_idx != worm.index][hstate];
+          common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                                 renderer.render_res_y - 39, kColor);
+        } break;
+        case Settings::kGmGameOfTag: {
+          int gstate = 0;
+          for (auto const& w : game.worms) {
+            if (w.get() != &worm && w->timer >= worm.timer) {
+              gstate = 1;
+            }
+          }
+          int const kColor = kStateColours[game.last_killed_idx != worm.index][gstate];
+          common.font.DrawString(renderer.bmp, TimeToString(worm.timer), 5, 106 + 84 * worm.index,
+                                 renderer.render_res_y - 39, kColor);
+        } break;
+        default:
+          break;
       }
     }
-  }
+
+    // ── Banner messages ───────────────────────────────────────────────────────
+    for (std::size_t i = 0; i < game.worms.size(); ++i) {
+      Worm const& worm = *game.worms[i];
+      if (banner_y > -8 && worm.health <= 0) {
+        if (game.settings->game_mode == Settings::kGmGameOfTag && game.got_changed) {
+          common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 3, banner_y + 1, 0);
+          common.font.DrawString(renderer.bmp, LS(YoureIt), rect.x1 + 2, banner_y, 50);
+        }
+      }
+    }
+    for (std::size_t i = 0; i < game.worms.size(); ++i) {
+      Worm const& worm = *game.worms[i];
+      if (worm.health <= 0 && banner_y > -8) {
+        if (worm.last_killed_by_idx == worm.index) {
+          std::string const kMsg(worm.settings->name + LS(CommittedSuicideMsg));
+          common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
+          common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
+        } else {
+          std::string const kMsg(game.worms[worm.last_killed_by_idx]->settings->name + " killed " +
+                                 worm.settings->name);
+          common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 3, banner_y + 1, 0);
+          common.font.DrawString(renderer.bmp, kMsg, rect.x1 + 2, banner_y, 50);
+        }
+      }
+    }
+  }  // end HUD zone
 }

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -28,11 +28,6 @@ float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, i
   return std::clamp(std::min(kZoomX, kZoomY), kLevelFillZoom, kMaxZoom);
 }
 
-WorldTextureSize SpectatorWorldTextureSize(int level_w, int level_h) {
-  return {.w = std::min(level_w, kSpectatorWorldTextureMax),
-          .h = std::min(level_h, kSpectatorWorldTextureMax)};
-}
-
 SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, int scr_h,
                                          float zoom) {
   int const kOutW =
@@ -40,6 +35,17 @@ SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, 
   int const kOutH =
       std::min(static_cast<int>(std::lroundf(static_cast<float>(scr_h) * zoom)), render_h);
   return {.x = (render_w - kOutW) / 2, .y = (render_h - kOutH) / 2, .w = kOutW, .h = kOutH};
+}
+
+WorldPassScratch ComputeWorldPassScratch(int render_w, int render_h, float zoom, int level_w,
+                                         int level_h) {
+  float const kScale = std::min(1.0F, zoom);
+  // Visible world region at 1:1 (same as the legacy scratch size).
+  int const kViewW = std::min(static_cast<int>(static_cast<float>(render_w) / zoom), level_w);
+  int const kViewH = std::min(static_cast<int>(static_cast<float>(render_h) / zoom), level_h);
+  int const kW = std::max(1, static_cast<int>(std::lroundf(static_cast<float>(kViewW) * kScale)));
+  int const kH = std::max(1, static_cast<int>(std::lroundf(static_cast<float>(kViewH) * kScale)));
+  return {.w = kW, .h = kH, .scale = kScale};
 }
 
 void SpectatorViewport::Process(Game& game) {
@@ -102,85 +108,60 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   int const kCenterX = render_w / 2;
 
   // ── World pass ────────────────────────────────────────────────────────────
-  // Scratch bitmap holds the visible world region at 1:1 pixel scale, capped
-  // to the level dimensions. At zoom < 1 this can be as large as the full
-  // level; the GPU path (Task 1e) will replace this with SDL_RenderTexture.
-  int const kScrW =
+  // kViewW/kViewH is the visible world region at 1:1. When the level fits
+  // (zoom >= 1) the scratch is that region and the world is drawn 1:1 (the GPU
+  // upscales it). When zoomed out (zoom < 1) the world is instead rendered at
+  // ~output resolution into a smaller scratch (PR7 Task 1, downscaled pass), so
+  // the world pass and its texture upload are bounded by the window, not the
+  // level area.
+  int const kViewW =
       std::min(static_cast<int>(static_cast<float>(render_w) / zoom), game.level.width);
-  int const kScrH =
+  int const kViewH =
       std::min(static_cast<int>(static_cast<float>(render_h) / zoom), game.level.height);
+  WorldPassScratch const kWp =
+      ComputeWorldPassScratch(render_w, render_h, zoom, game.level.width, game.level.height);
 
-  scratch_bmp.Alloc(kScrW, kScrH);
+  scratch_bmp.Alloc(kWp.w, kWp.h);
   scratch_bmp.pal32 = renderer.pal32;
   scratch_bmp.mode = renderer.mode;
   scratch_bmp.cycles = game.cycles;
   Fill(scratch_bmp, 0);
 
-  // Offset: world pixel (x, y) maps to scratch pixel (0, 0).
-  int const kOx = -x;
-  int const kOy = -y;
+  if (kWp.scale < 1.0F) {
+    // ── Downscaled overview (zoom < 1) ──────────────────────────────────────
+    // Render the visually-significant world at ~output resolution. Detail that
+    // is sub-pixel or illegible at this zoom — shadows, text labels, fire
+    // cones, laser sights, the aim crosshair, AI debug — is intentionally
+    // omitted; it cannot be seen and is what made the 1:1 path expensive.
+    ZoneScopedN("Spectator::WorldPass::Downscaled");
+    float const kScale = kWp.scale;
+    auto sx = [&](int wx) {
+      return static_cast<int>(std::lroundf(static_cast<float>(wx - x) * kScale));
+    };
+    auto sy = [&](int wy) {
+      return static_cast<int>(std::lroundf(static_cast<float>(wy - y) * kScale));
+    };
+    // World-space AABB cull against the visible region [x, x+kViewW) x [y, y+kViewH).
+    auto in_view = [&](int wx, int wy, int sz) {
+      return wx + sz >= x && wx < x + kViewW && wy + sz >= y && wy < y + kViewH;
+    };
 
-  ShadowQuery const kShadow{.common = common,
-                            .level = game.level,
-                            .pal32 = renderer.pal32,
-                            .world_offset_x = x,
-                            .world_offset_y = y,
-                            .mode = renderer.mode,
-                            .cycles = game.cycles};
-
-  {
-    ZoneScopedN("Spectator::WorldPass::DrawLevel");
-    DrawLevel(scratch_bmp, game.level, kOx, kOy);
-  }
-
-  if (game.settings->game_mode == Settings::kGmHoldazone) {
-    bool const kTimingOut = game.holdazone.timeout_left < 70 * 4;
-    int const kColor = kTimingOut ? 168 : 50;
-    int contender_color = 0;
-    if (game.holdazone.contender_idx >= 0) {
-      Worm const* contender = game.WormByIdx(game.holdazone.contender_idx);
-      if (kTimingOut) {
-        contender_color = contender->MinimapColor();
-      } else {
-        contender_color = Palette::kWormColorBlocks[contender->index].colour_index + 5;
-      }
-    } else {
-      contender_color = kColor;
+    {
+      ZoneScopedN("Spectator::WorldPass::DrawLevel");
+      DrawLevelScaled(scratch_bmp, game.level, x, y, kScale);
     }
-    DrawDashedLineBox(scratch_bmp, game.holdazone.rect.x1 + kOx, game.holdazone.rect.y1 + kOy,
-                      kColor, contender_color, game.holdazone.contender_frames,
-                      Settings::kZoneCaptureTime, game.holdazone.rect.Width(),
-                      game.holdazone.rect.Height(), game.cycles / 10);
-  }
 
-  for (std::size_t i = 0; i < game.worms.size(); ++i) {
-    Worm const& worm = *game.worms[i];
-    if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
-      if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
-        int const kTempX = Ftoi(worm.pos.x) - 7 + kOx;
-        int const kTempY = Ftoi(worm.pos.y) - 5 + kOy;
-        BlitImageTrans(scratch_bmp,
-                       common.WormSpriteObj(worm.current_frame, worm.direction, worm.index), kTempX,
-                       kTempY, game.cycles);
-      }
-    }
-  }
-
-  // Pass 1: all shadows before any sprite.
-  if (game.settings->shadow) {
-    ZoneScopedN("Spectator::WorldPass::ShadowPass");
     {
       auto br = game.bonuses.All();
       for (Bonus const* i = nullptr; (i = br.Next());) {
-        int const kBx = Ftoi(i->x) - 3 + kOx;
-        int const kBy = Ftoi(i->y) - 3 + kOy;
-        if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
+        int const kWx = Ftoi(i->x) - 3;
+        int const kWy = Ftoi(i->y) - 3;
+        if (!in_view(kWx, kWy, 7)) {
           continue;
         }
         if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
-          int const kF = common.bonus_frames[i->frame];
-          BlitShadowImage(kShadow, scratch_bmp, common.small_sprites.SpritePtr(kF),
-                          Ftoi(i->x) - 5 + kOx, Ftoi(i->y) - 1 + kOy, 7, 7);
+          BlitImageScaled(scratch_bmp, common.small_sprites[common.bonus_frames[i->frame]], sx(kWx),
+                          sy(kWy), kScale);
         }
       }
     }
@@ -188,24 +169,21 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto sr = game.sobjects.All();
       for (SObject const* i = nullptr; (i = sr.Next());) {
-        int const kSx = i->x + kOx;
-        int const kSy = i->y + kOy;
-        if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
+        if (!in_view(i->x, i->y, 16)) {
           continue;
         }
         SObjectType const& t = common.sobject_types[i->id];
-        int const kFrame = i->cur_frame + t.start_frame;
-        BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame),
-                        i->x + kOx - 3, i->y + kOy + 3, 16, 16);
+        BlitImageScaled(scratch_bmp, common.large_sprites[i->cur_frame + t.start_frame], sx(i->x),
+                        sy(i->y), kScale);
       }
     }
 
     {
       auto wr = game.wobjects.All();
       for (WObject const* i = nullptr; (i = wr.Next());) {
-        int const kWx = Ftoi(i->pos.x) - 3 + kOx;
-        int const kWy = Ftoi(i->pos.y) - 3 + kOy;
-        if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
+        int const kWx = Ftoi(i->pos.x) - 3;
+        int const kWy = Ftoi(i->pos.y) - 3;
+        if (!in_view(kWx, kWy, 7)) {
           continue;
         }
         Weapon const& w = *i->type;
@@ -213,8 +191,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
           int cur_frame = i->cur_frame;
           int const kShotType = w.shot_type;
           if (kShotType == 2) {
-            cur_frame += 4;
-            cur_frame >>= 3;
+            cur_frame = (cur_frame + 4) >> 3;
             if (cur_frame < 0) {
               cur_frame = 16;
             } else if (cur_frame > 15) {
@@ -224,28 +201,14 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
             if (cur_frame > 64) {
               --cur_frame;
             }
-            cur_frame -= 12;
-            cur_frame >>= 3;
-            if (cur_frame < 0) {
-              cur_frame = 0;
-            } else if (cur_frame > 12) {
-              cur_frame = 12;
-            }
+            cur_frame = (cur_frame - 12) >> 3;
+            cur_frame = std::clamp(cur_frame, 0, 12);
           }
-          int const kPosX = Ftoi(i->pos.x) - 3;
-          int const kPosY = Ftoi(i->pos.y) - 3;
-          if (w.shadow) {
-            BlitShadowImage(kShadow, scratch_bmp,
-                            common.small_sprites.SpritePtr(w.start_frame + cur_frame),
-                            kPosX - 3 + kOx, kPosY + 3 + kOy, 7, 7);
-          }
+          BlitImageScaled(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], sx(kWx),
+                          sy(kWy), kScale);
         } else if (i->cur_frame > 0) {
-          int const kPosX = Ftoi(i->pos.x) + kOx - 3;
-          int const kPosY = Ftoi(i->pos.y) + kOy + 3;
-          uint32_t const kShadowed = kShadow.ShadowedArgb(kPosX, kPosY);
-          if (kShadowed != 0 && scratch_bmp.clip_rect.Inside(kPosX, kPosY)) {
-            scratch_bmp.GetPixel(kPosX, kPosY) = kShadowed;
-          }
+          scratch_bmp.SetPixel(sx(Ftoi(i->pos.x)), sy(Ftoi(i->pos.y)),
+                               static_cast<PalIdx>(i->cur_frame));
         }
       }
     }
@@ -253,272 +216,458 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     {
       auto nr = game.nobjects.All();
       for (NObject const* i = nullptr; (i = nr.Next());) {
-        int const kNx = Ftoi(i->pos.x) - 3 + kOx;
-        int const kNy = Ftoi(i->pos.y) - 3 + kOy;
-        if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
+        int const kWx = Ftoi(i->pos.x) - 3;
+        int const kWy = Ftoi(i->pos.y) - 3;
+        if (!in_view(kWx, kWy, 7)) {
           continue;
         }
         NObjectType const& t = *i->type;
         if (t.start_frame > 0) {
-          auto pos = Ftoi(i->pos) - IVec2(3, 3);
-          BlitShadowImage(kShadow, scratch_bmp,
-                          common.small_sprites.SpritePtr(t.start_frame + i->cur_frame),
-                          pos.x - 3 + kOx, pos.y + 3 + kOy, 7, 7);
+          BlitImageScaled(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], sx(kWx),
+                          sy(kWy), kScale);
         } else if (i->cur_frame > 1) {
-          auto pos = Ftoi(i->pos);
-          pos.x += kOx - 3;
-          pos.y += kOy + 3;
-          if (scratch_bmp.clip_rect.Encloses(pos)) {
-            uint32_t const kShadowed = kShadow.ShadowedArgb(pos.x, pos.y);
-            if (kShadowed != 0) {
-              scratch_bmp.GetPixel(pos.x, pos.y) = kShadowed;
-            }
-          }
+          scratch_bmp.SetPixel(sx(Ftoi(i->pos.x)), sy(Ftoi(i->pos.y)),
+                               static_cast<PalIdx>(i->cur_frame));
         }
       }
     }
 
     for (auto const& worm_ptr : game.worms) {
       Worm const& w = *worm_ptr;
-      if (w.visible) {
-        int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
-        int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
-        if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
-          continue;
-        }
-        if (w.ninjarope.out) {
-          int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
-          int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
-          DrawShadowLine(kShadow, scratch_bmp, kNinjaropeX - 3, kNinjaropeY + 3, kTempX + 7 - 3,
-                         kTempY + 4 + 3);
-          BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(84), kNinjaropeX - 4,
-                          kNinjaropeY + 2, 16, 16);
-        }
-        BlitShadowImage(kShadow, scratch_bmp,
-                        common.WormSprite(w.current_frame, w.direction, w.index), kTempX - 3,
-                        kTempY + 3, 16, 16);
+      if (!w.visible) {
+        continue;
       }
+      int const kWx = Ftoi(w.pos.x) - 7;
+      int const kWy = Ftoi(w.pos.y) - 5;
+      if (!in_view(kWx, kWy, 16)) {
+        continue;
+      }
+      if (w.ninjarope.out) {
+        DrawNinjarope(common, scratch_bmp, sx(Ftoi(w.ninjarope.pos.x)), sy(Ftoi(w.ninjarope.pos.y)),
+                      sx(Ftoi(w.pos.x)), sy(Ftoi(w.pos.y) - 1));
+        BlitImageScaled(scratch_bmp, common.large_sprites[84], sx(Ftoi(w.ninjarope.pos.x) - 1),
+                        sy(Ftoi(w.ninjarope.pos.y) - 1), kScale);
+      }
+      BlitImageScaled(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index),
+                      sx(kWx), sy(kWy), kScale);
     }
 
     for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
       auto ipos = Ftoi(i->pos);
-      ipos.x += kOx - 3;
-      ipos.y += kOy + 3;
-      if (scratch_bmp.clip_rect.Encloses(ipos)) {
-        uint32_t const kShadowed = kShadow.ShadowedArgb(ipos.x, ipos.y);
-        if (kShadowed != 0) {
-          scratch_bmp.GetPixel(ipos.x, ipos.y) = kShadowed;
-        }
-      }
+      scratch_bmp.SetPixel(sx(ipos.x), sy(ipos.y), static_cast<PalIdx>(i->color));
     }
-  }
+  } else {
+    int const kScrW = kWp.w;
+    int const kScrH = kWp.h;
+    // Offset: world pixel (x, y) maps to scratch pixel (0, 0).
+    int const kOx = -x;
+    int const kOy = -y;
 
-  // Pass 2: all sprites on top of the fully-composited shadow layer.
-  {
-    ZoneScopedN("Spectator::WorldPass::SpritePass");
-    {
-      auto br = game.bonuses.All();
-      for (Bonus const* i = nullptr; (i = br.Next());) {
-        int const kBx = Ftoi(i->x) - 3 + kOx;
-        int const kBy = Ftoi(i->y) - 3 + kOy;
-        if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
-          continue;
-        }
-        if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
-          int const kF = common.bonus_frames[i->frame];
-          BlitImage(scratch_bmp, common.small_sprites[kF], kBx, kBy);
-          if (game.settings->names_on_bonuses && i->frame == 0) {
-            std::string const& name = common.weapons[i->weapon].name;
-            int const kLen = static_cast<int>(name.size()) * 4;
-            common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOx,
-                                 Ftoi(i->y) - 10 + kOy);
-          }
-        }
-      }
-    }
+    ShadowQuery const kShadow{.common = common,
+                              .level = game.level,
+                              .pal32 = renderer.pal32,
+                              .world_offset_x = x,
+                              .world_offset_y = y,
+                              .mode = renderer.mode,
+                              .cycles = game.cycles};
 
     {
-      auto sr = game.sobjects.All();
-      for (SObject const* i = nullptr; (i = sr.Next());) {
-        int const kSx = i->x + kOx;
-        int const kSy = i->y + kOy;
-        if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
-          continue;
-        }
-        SObjectType const& t = common.sobject_types[i->id];
-        int const kFrame = i->cur_frame + t.start_frame;
-        BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), kSx, kSy, 16, 16);
-      }
+      ZoneScopedN("Spectator::WorldPass::DrawLevel");
+      DrawLevel(scratch_bmp, game.level, kOx, kOy);
     }
 
-    {
-      auto wr = game.wobjects.All();
-      for (WObject* i = nullptr; (i = wr.Next());) {
-        int const kWx = Ftoi(i->pos.x) - 3 + kOx;
-        int const kWy = Ftoi(i->pos.y) - 3 + kOy;
-        if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
-          continue;
+    if (game.settings->game_mode == Settings::kGmHoldazone) {
+      bool const kTimingOut = game.holdazone.timeout_left < 70 * 4;
+      int const kColor = kTimingOut ? 168 : 50;
+      int contender_color = 0;
+      if (game.holdazone.contender_idx >= 0) {
+        Worm const* contender = game.WormByIdx(game.holdazone.contender_idx);
+        if (kTimingOut) {
+          contender_color = contender->MinimapColor();
+        } else {
+          contender_color = Palette::kWormColorBlocks[contender->index].colour_index + 5;
         }
-        Weapon const& w = *i->type;
-        if (w.start_frame > -1) {
-          int cur_frame = i->cur_frame;
-          int const kShotType = w.shot_type;
-          if (kShotType == 2) {
-            cur_frame += 4;
-            cur_frame >>= 3;
-            if (cur_frame < 0) {
-              cur_frame = 16;
-            } else if (cur_frame > 15) {
-              cur_frame -= 16;
-            }
-          } else if (kShotType == 3) {
-            if (cur_frame > 64) {
-              --cur_frame;
-            }
-            cur_frame -= 12;
-            cur_frame >>= 3;
-            if (cur_frame < 0) {
-              cur_frame = 0;
-            } else if (cur_frame > 12) {
-              cur_frame = 12;
-            }
-          }
-          int const kPosX = Ftoi(i->pos.x) - 3;
-          int const kPosY = Ftoi(i->pos.y) - 3;
-          BlitImage(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOx,
-                    kPosY + kOy);
-        } else if (i->cur_frame > 0) {
-          int const kPosX = Ftoi(i->pos.x) + kOx;
-          int const kPosY = Ftoi(i->pos.y) + kOy;
-          scratch_bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
-        }
-        if (!common.h[HRemExp] && i->type - common.weapons.data() == 34 &&
-            game.settings->names_on_bonuses) {
-          if (i->cur_frame == 0) {
-            int const kNameNum =
-                static_cast<int>(&*i - game.wobjects.arr) % static_cast<int>(common.weapons.size());
-            std::string const& name = common.weapons[kNameNum].name;
-            int const kWidth = static_cast<int>(name.size()) * 4;
-            common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOx,
-                                 Ftoi(i->pos.y) - 10 + kOy);
-          }
-        }
+      } else {
+        contender_color = kColor;
       }
-    }
-
-    {
-      auto nr = game.nobjects.All();
-      for (NObject const* i = nullptr; (i = nr.Next());) {
-        int const kNx = Ftoi(i->pos.x) - 3 + kOx;
-        int const kNy = Ftoi(i->pos.y) - 3 + kOy;
-        if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
-          continue;
-        }
-        NObjectType const& t = *i->type;
-        if (t.start_frame > 0) {
-          auto pos = Ftoi(i->pos) - IVec2(3, 3);
-          BlitImage(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOx,
-                    pos.y + kOy);
-        } else if (i->cur_frame > 1) {
-          auto pos = Ftoi(i->pos);
-          pos.x += kOx;
-          pos.y += kOy;
-          if (scratch_bmp.clip_rect.Encloses(pos)) {
-            scratch_bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
-          }
-        }
-      }
+      DrawDashedLineBox(scratch_bmp, game.holdazone.rect.x1 + kOx, game.holdazone.rect.y1 + kOy,
+                        kColor, contender_color, game.holdazone.contender_frames,
+                        Settings::kZoneCaptureTime, game.holdazone.rect.Width(),
+                        game.holdazone.rect.Height(), game.cycles / 10);
     }
 
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
-      Worm const& w = *game.worms[i];
-      if (w.visible) {
-        int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
-        int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
-        if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
-          continue;
-        }
-        int const kAngleFrame = w.AngleFrame();
-        if (w.weapons[w.current_weapon].Available()) {
-          int const kHotspotX = w.hotspot_x + kOx;
-          int const kHotspotY = w.hotspot_y + kOy;
-          WormWeapon const& ww = w.weapons[w.current_weapon];
-          Weapon const& weapon = *ww.type;
-          if (weapon.laser_sight) {
-            DrawLaserSight(scratch_bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
-          }
-          if (ww.type - common.weapons.data() == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
-            DrawLine(scratch_bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4,
-                     weapon.color_bullets);
-          }
-        }
-        if (w.ninjarope.out) {
-          int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
-          int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
-          DrawNinjarope(common, scratch_bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
-          BlitImage(scratch_bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
-        }
-        if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
-          BlitFireCone(scratch_bmp, w.fire_cone / 2,
-                       common.FireConeSprite(kAngleFrame, w.direction),
-                       Common::fire_cone_offset[w.direction][kAngleFrame][0] + kTempX,
-                       Common::fire_cone_offset[w.direction][kAngleFrame][1] + kTempY);
-        }
-        BlitImage(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index), kTempX,
-                  kTempY);
-      }
-      if (w.ai) {
-        w.ai->DrawDebug(game, w, renderer, kOx, kOy);
-      }
-    }
-
-    for (auto& i : game.worms) {
-      Worm const& worm = *i;
-      if (worm.visible) {
-        auto temp = Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
-        temp.x += kOx;
-        temp.y += kOy;
-        if (temp.x + 7 < 0 || temp.x >= kScrW || temp.y + 7 < 0 || temp.y >= kScrH) {
-          continue;
-        }
-        BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
-                  temp.y);
-        if (worm.Pressed(Worm::kChange)) {
-          std::string const& name = worm.weapons[worm.current_weapon].type->name;
-          int const kLen = static_cast<int>(name.size()) * 4;
-          common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOx,
-                               Ftoi(worm.pos.y) - 10 + kOy);
+      Worm const& worm = *game.worms[i];
+      if (!worm.visible && worm.killed_timer <= 0 && !worm.ready) {
+        if (game.settings->allow_viewing_spawn_point && worm.Pressed(Worm::kChange)) {
+          int const kTempX = Ftoi(worm.pos.x) - 7 + kOx;
+          int const kTempY = Ftoi(worm.pos.y) - 5 + kOy;
+          BlitImageTrans(scratch_bmp,
+                         common.WormSpriteObj(worm.current_frame, worm.direction, worm.index),
+                         kTempX, kTempY, game.cycles);
         }
       }
     }
 
-    for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
-      auto ipos = Ftoi(i->pos);
-      ipos.x += kOx;
-      ipos.y += kOy;
-      if (scratch_bmp.clip_rect.Encloses(ipos)) {
-        scratch_bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
+    // Pass 1: all shadows before any sprite.
+    if (game.settings->shadow) {
+      ZoneScopedN("Spectator::WorldPass::ShadowPass");
+      {
+        auto br = game.bonuses.All();
+        for (Bonus const* i = nullptr; (i = br.Next());) {
+          int const kBx = Ftoi(i->x) - 3 + kOx;
+          int const kBy = Ftoi(i->y) - 3 + kOy;
+          if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
+            continue;
+          }
+          if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
+            int const kF = common.bonus_frames[i->frame];
+            BlitShadowImage(kShadow, scratch_bmp, common.small_sprites.SpritePtr(kF),
+                            Ftoi(i->x) - 5 + kOx, Ftoi(i->y) - 1 + kOy, 7, 7);
+          }
+        }
+      }
+
+      {
+        auto sr = game.sobjects.All();
+        for (SObject const* i = nullptr; (i = sr.Next());) {
+          int const kSx = i->x + kOx;
+          int const kSy = i->y + kOy;
+          if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
+            continue;
+          }
+          SObjectType const& t = common.sobject_types[i->id];
+          int const kFrame = i->cur_frame + t.start_frame;
+          BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame),
+                          i->x + kOx - 3, i->y + kOy + 3, 16, 16);
+        }
+      }
+
+      {
+        auto wr = game.wobjects.All();
+        for (WObject const* i = nullptr; (i = wr.Next());) {
+          int const kWx = Ftoi(i->pos.x) - 3 + kOx;
+          int const kWy = Ftoi(i->pos.y) - 3 + kOy;
+          if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
+            continue;
+          }
+          Weapon const& w = *i->type;
+          if (w.start_frame > -1) {
+            int cur_frame = i->cur_frame;
+            int const kShotType = w.shot_type;
+            if (kShotType == 2) {
+              cur_frame += 4;
+              cur_frame >>= 3;
+              if (cur_frame < 0) {
+                cur_frame = 16;
+              } else if (cur_frame > 15) {
+                cur_frame -= 16;
+              }
+            } else if (kShotType == 3) {
+              if (cur_frame > 64) {
+                --cur_frame;
+              }
+              cur_frame -= 12;
+              cur_frame >>= 3;
+              if (cur_frame < 0) {
+                cur_frame = 0;
+              } else if (cur_frame > 12) {
+                cur_frame = 12;
+              }
+            }
+            int const kPosX = Ftoi(i->pos.x) - 3;
+            int const kPosY = Ftoi(i->pos.y) - 3;
+            if (w.shadow) {
+              BlitShadowImage(kShadow, scratch_bmp,
+                              common.small_sprites.SpritePtr(w.start_frame + cur_frame),
+                              kPosX - 3 + kOx, kPosY + 3 + kOy, 7, 7);
+            }
+          } else if (i->cur_frame > 0) {
+            int const kPosX = Ftoi(i->pos.x) + kOx - 3;
+            int const kPosY = Ftoi(i->pos.y) + kOy + 3;
+            uint32_t const kShadowed = kShadow.ShadowedArgb(kPosX, kPosY);
+            if (kShadowed != 0 && scratch_bmp.clip_rect.Inside(kPosX, kPosY)) {
+              scratch_bmp.GetPixel(kPosX, kPosY) = kShadowed;
+            }
+          }
+        }
+      }
+
+      {
+        auto nr = game.nobjects.All();
+        for (NObject const* i = nullptr; (i = nr.Next());) {
+          int const kNx = Ftoi(i->pos.x) - 3 + kOx;
+          int const kNy = Ftoi(i->pos.y) - 3 + kOy;
+          if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
+            continue;
+          }
+          NObjectType const& t = *i->type;
+          if (t.start_frame > 0) {
+            auto pos = Ftoi(i->pos) - IVec2(3, 3);
+            BlitShadowImage(kShadow, scratch_bmp,
+                            common.small_sprites.SpritePtr(t.start_frame + i->cur_frame),
+                            pos.x - 3 + kOx, pos.y + 3 + kOy, 7, 7);
+          } else if (i->cur_frame > 1) {
+            auto pos = Ftoi(i->pos);
+            pos.x += kOx - 3;
+            pos.y += kOy + 3;
+            if (scratch_bmp.clip_rect.Encloses(pos)) {
+              uint32_t const kShadowed = kShadow.ShadowedArgb(pos.x, pos.y);
+              if (kShadowed != 0) {
+                scratch_bmp.GetPixel(pos.x, pos.y) = kShadowed;
+              }
+            }
+          }
+        }
+      }
+
+      for (auto const& worm_ptr : game.worms) {
+        Worm const& w = *worm_ptr;
+        if (w.visible) {
+          int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
+          int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
+          if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
+            continue;
+          }
+          if (w.ninjarope.out) {
+            int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
+            int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
+            DrawShadowLine(kShadow, scratch_bmp, kNinjaropeX - 3, kNinjaropeY + 3, kTempX + 7 - 3,
+                           kTempY + 4 + 3);
+            BlitShadowImage(kShadow, scratch_bmp, common.large_sprites.SpritePtr(84),
+                            kNinjaropeX - 4, kNinjaropeY + 2, 16, 16);
+          }
+          BlitShadowImage(kShadow, scratch_bmp,
+                          common.WormSprite(w.current_frame, w.direction, w.index), kTempX - 3,
+                          kTempY + 3, 16, 16);
+        }
+      }
+
+      for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
+        auto ipos = Ftoi(i->pos);
+        ipos.x += kOx - 3;
+        ipos.y += kOy + 3;
+        if (scratch_bmp.clip_rect.Encloses(ipos)) {
+          uint32_t const kShadowed = kShadow.ShadowedArgb(ipos.x, ipos.y);
+          if (kShadowed != 0) {
+            scratch_bmp.GetPixel(ipos.x, ipos.y) = kShadowed;
+          }
+        }
       }
     }
-  }  // end SpritePass zone
+
+    // Pass 2: all sprites on top of the fully-composited shadow layer.
+    {
+      ZoneScopedN("Spectator::WorldPass::SpritePass");
+      {
+        auto br = game.bonuses.All();
+        for (Bonus const* i = nullptr; (i = br.Next());) {
+          int const kBx = Ftoi(i->x) - 3 + kOx;
+          int const kBy = Ftoi(i->y) - 3 + kOy;
+          if (kBx + 7 < 0 || kBx >= kScrW || kBy + 7 < 0 || kBy >= kScrH) {
+            continue;
+          }
+          if (i->timer > LC(BonusFlickerTime) || (game.cycles & 3) == 0) {
+            int const kF = common.bonus_frames[i->frame];
+            BlitImage(scratch_bmp, common.small_sprites[kF], kBx, kBy);
+            if (game.settings->names_on_bonuses && i->frame == 0) {
+              std::string const& name = common.weapons[i->weapon].name;
+              int const kLen = static_cast<int>(name.size()) * 4;
+              common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->x) - kLen / 2 + kOx,
+                                   Ftoi(i->y) - 10 + kOy);
+            }
+          }
+        }
+      }
+
+      {
+        auto sr = game.sobjects.All();
+        for (SObject const* i = nullptr; (i = sr.Next());) {
+          int const kSx = i->x + kOx;
+          int const kSy = i->y + kOy;
+          if (kSx + 16 < 0 || kSx >= kScrW || kSy + 16 < 0 || kSy >= kScrH) {
+            continue;
+          }
+          SObjectType const& t = common.sobject_types[i->id];
+          int const kFrame = i->cur_frame + t.start_frame;
+          BlitImageR(kShadow, scratch_bmp, common.large_sprites.SpritePtr(kFrame), kSx, kSy, 16,
+                     16);
+        }
+      }
+
+      {
+        auto wr = game.wobjects.All();
+        for (WObject* i = nullptr; (i = wr.Next());) {
+          int const kWx = Ftoi(i->pos.x) - 3 + kOx;
+          int const kWy = Ftoi(i->pos.y) - 3 + kOy;
+          if (kWx + 7 < 0 || kWx >= kScrW || kWy + 7 < 0 || kWy >= kScrH) {
+            continue;
+          }
+          Weapon const& w = *i->type;
+          if (w.start_frame > -1) {
+            int cur_frame = i->cur_frame;
+            int const kShotType = w.shot_type;
+            if (kShotType == 2) {
+              cur_frame += 4;
+              cur_frame >>= 3;
+              if (cur_frame < 0) {
+                cur_frame = 16;
+              } else if (cur_frame > 15) {
+                cur_frame -= 16;
+              }
+            } else if (kShotType == 3) {
+              if (cur_frame > 64) {
+                --cur_frame;
+              }
+              cur_frame -= 12;
+              cur_frame >>= 3;
+              if (cur_frame < 0) {
+                cur_frame = 0;
+              } else if (cur_frame > 12) {
+                cur_frame = 12;
+              }
+            }
+            int const kPosX = Ftoi(i->pos.x) - 3;
+            int const kPosY = Ftoi(i->pos.y) - 3;
+            BlitImage(scratch_bmp, common.small_sprites[w.start_frame + cur_frame], kPosX + kOx,
+                      kPosY + kOy);
+          } else if (i->cur_frame > 0) {
+            int const kPosX = Ftoi(i->pos.x) + kOx;
+            int const kPosY = Ftoi(i->pos.y) + kOy;
+            scratch_bmp.SetPixel(kPosX, kPosY, static_cast<PalIdx>(i->cur_frame));
+          }
+          if (!common.h[HRemExp] && i->type - common.weapons.data() == 34 &&
+              game.settings->names_on_bonuses) {
+            if (i->cur_frame == 0) {
+              int const kNameNum = static_cast<int>(&*i - game.wobjects.arr) %
+                                   static_cast<int>(common.weapons.size());
+              std::string const& name = common.weapons[kNameNum].name;
+              int const kWidth = static_cast<int>(name.size()) * 4;
+              common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(i->pos.x) - kWidth / 2 + kOx,
+                                   Ftoi(i->pos.y) - 10 + kOy);
+            }
+          }
+        }
+      }
+
+      {
+        auto nr = game.nobjects.All();
+        for (NObject const* i = nullptr; (i = nr.Next());) {
+          int const kNx = Ftoi(i->pos.x) - 3 + kOx;
+          int const kNy = Ftoi(i->pos.y) - 3 + kOy;
+          if (kNx + 7 < 0 || kNx >= kScrW || kNy + 7 < 0 || kNy >= kScrH) {
+            continue;
+          }
+          NObjectType const& t = *i->type;
+          if (t.start_frame > 0) {
+            auto pos = Ftoi(i->pos) - IVec2(3, 3);
+            BlitImage(scratch_bmp, common.small_sprites[t.start_frame + i->cur_frame], pos.x + kOx,
+                      pos.y + kOy);
+          } else if (i->cur_frame > 1) {
+            auto pos = Ftoi(i->pos);
+            pos.x += kOx;
+            pos.y += kOy;
+            if (scratch_bmp.clip_rect.Encloses(pos)) {
+              scratch_bmp.SetPixel(pos.x, pos.y, static_cast<PalIdx>(i->cur_frame));
+            }
+          }
+        }
+      }
+
+      for (std::size_t i = 0; i < game.worms.size(); ++i) {
+        Worm const& w = *game.worms[i];
+        if (w.visible) {
+          int const kTempX = Ftoi(w.pos.x) - 7 + kOx;
+          int const kTempY = Ftoi(w.pos.y) - 5 + kOy;
+          if (kTempX + 16 < 0 || kTempX >= kScrW || kTempY + 16 < 0 || kTempY >= kScrH) {
+            continue;
+          }
+          int const kAngleFrame = w.AngleFrame();
+          if (w.weapons[w.current_weapon].Available()) {
+            int const kHotspotX = w.hotspot_x + kOx;
+            int const kHotspotY = w.hotspot_y + kOy;
+            WormWeapon const& ww = w.weapons[w.current_weapon];
+            Weapon const& weapon = *ww.type;
+            if (weapon.laser_sight) {
+              DrawLaserSight(scratch_bmp, rand, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4);
+            }
+            if (ww.type - common.weapons.data() == LC(LaserWeapon) - 1 && w.Pressed(Worm::kFire)) {
+              DrawLine(scratch_bmp, kHotspotX, kHotspotY, kTempX + 7, kTempY + 4,
+                       weapon.color_bullets);
+            }
+          }
+          if (w.ninjarope.out) {
+            int const kNinjaropeX = Ftoi(w.ninjarope.pos.x) + kOx;
+            int const kNinjaropeY = Ftoi(w.ninjarope.pos.y) + kOy;
+            DrawNinjarope(common, scratch_bmp, kNinjaropeX, kNinjaropeY, kTempX + 7, kTempY + 4);
+            BlitImage(scratch_bmp, common.large_sprites[84], kNinjaropeX - 1, kNinjaropeY - 1);
+          }
+          if (w.weapons[w.current_weapon].type->fire_cone > 0 && w.fire_cone > 0) {
+            BlitFireCone(scratch_bmp, w.fire_cone / 2,
+                         common.FireConeSprite(kAngleFrame, w.direction),
+                         Common::fire_cone_offset[w.direction][kAngleFrame][0] + kTempX,
+                         Common::fire_cone_offset[w.direction][kAngleFrame][1] + kTempY);
+          }
+          BlitImage(scratch_bmp, common.WormSpriteObj(w.current_frame, w.direction, w.index),
+                    kTempX, kTempY);
+        }
+        if (w.ai) {
+          w.ai->DrawDebug(game, w, renderer, kOx, kOy);
+        }
+      }
+
+      for (auto& i : game.worms) {
+        Worm const& worm = *i;
+        if (worm.visible) {
+          auto temp =
+              Ftoi(worm.pos) - IVec2(1, 2) + Ftoi(cossin_table[Ftoi(worm.aiming_angle)] * 16);
+          temp.x += kOx;
+          temp.y += kOy;
+          if (temp.x + 7 < 0 || temp.x >= kScrW || temp.y + 7 < 0 || temp.y >= kScrH) {
+            continue;
+          }
+          BlitImage(scratch_bmp, common.small_sprites[worm.make_sight_green ? 44 : 43], temp.x,
+                    temp.y);
+          if (worm.Pressed(Worm::kChange)) {
+            std::string const& name = worm.weapons[worm.current_weapon].type->name;
+            int const kLen = static_cast<int>(name.size()) * 4;
+            common.DrawTextSmall(scratch_bmp, name.c_str(), Ftoi(worm.pos.x) - kLen / 2 + 1 + kOx,
+                                 Ftoi(worm.pos.y) - 10 + kOy);
+          }
+        }
+      }
+
+      for (Game::BObjectList::Iterator i = game.bobjects.Begin(); i != game.bobjects.End(); ++i) {
+        auto ipos = Ftoi(i->pos);
+        ipos.x += kOx;
+        ipos.y += kOy;
+        if (scratch_bmp.clip_rect.Encloses(ipos)) {
+          scratch_bmp.SetPixel(ipos.x, ipos.y, static_cast<PalIdx>(i->color));
+        }
+      }
+    }  // end SpritePass zone
+  }  // end 1:1 world pass
 
   // ── Composite scratch → renderer ─────────────────────────────────────────
   // Centred output rect that preserves the level's aspect ratio; any remaining
-  // bars are filled black. Shared by the CPU and GPU composite paths.
-  SpectatorDstRect const kDst = ComputeSpectatorDstRect(render_w, render_h, kScrW, kScrH, zoom);
+  // bars are filled black. The dst rect is computed from the visible region at
+  // 1:1 (kViewW/kViewH) so it is independent of the scratch's render scale;
+  // shared by the CPU and GPU composite paths.
+  SpectatorDstRect const kDst = ComputeSpectatorDstRect(render_w, render_h, kViewW, kViewH, zoom);
 
   if (renderer.gpu_world_composite) {
-    // GPU path (PR7 Task 1b): hand the 1:1 world pass to Gfx, which uploads the
-    // used sub-rect to a streaming texture and scales it on the GPU
+    // GPU path (PR7 Task 1b): hand the world pass to Gfx, which uploads the used
+    // sub-rect to a streaming texture and scales it on the GPU
     // (SDL_RenderTexture), deleting the ~38 ms CPU box-filter. `bmp` becomes a
-    // transparent HUD-only overlay (Task 1c) blended on top of the world.
+    // transparent HUD-only overlay (Task 1c) blended on top of the world. The
+    // scratch is now bounded by the window, so the texture is sized to the
+    // render surface rather than the level.
     ZoneScopedN("Spectator::Composite::GpuHandoff");
-    WorldTextureSize const kTex = SpectatorWorldTextureSize(game.level.width, game.level.height);
     renderer.gpu_world_src = &scratch_bmp;
-    renderer.gpu_world_used_w = kScrW;
-    renderer.gpu_world_used_h = kScrH;
-    renderer.gpu_world_max_w = kTex.w;
-    renderer.gpu_world_max_h = kTex.h;
+    renderer.gpu_world_used_w = kWp.w;
+    renderer.gpu_world_used_h = kWp.h;
+    renderer.gpu_world_max_w = render_w;
+    renderer.gpu_world_max_h = render_h;
     renderer.gpu_world_dst_x = kDst.x;
     renderer.gpu_world_dst_y = kDst.y;
     renderer.gpu_world_dst_w = kDst.w;
@@ -536,18 +685,18 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     uint32_t* const kDest = renderer.bmp.pixels +
                             static_cast<std::size_t>(kDst.y) * renderer.bmp.pitch +
                             static_cast<std::size_t>(kDst.x);
-    if (kScrW == kDst.w && kScrH == kDst.h) {
+    if (kWp.w == kDst.w && kWp.h == kDst.h) {
       // BlitBitmap reads from src at position (x,y), not (0,0) — wrong for a
       // scratch bitmap whose content always starts at (0,0). Copy row-by-row.
       uint32_t const* src_row = scratch_bmp.pixels;
       uint32_t* dst_row = kDest;
-      for (int row = 0; row < kScrH; ++row) {
-        std::memcpy(dst_row, src_row, sizeof(uint32_t) * static_cast<std::size_t>(kScrW));
+      for (int row = 0; row < kWp.h; ++row) {
+        std::memcpy(dst_row, src_row, sizeof(uint32_t) * static_cast<std::size_t>(kWp.w));
         dst_row += renderer.bmp.pitch;
         src_row += scratch_bmp.pitch;
       }
     } else {
-      ScaleDrawArea(scratch_bmp.pixels, kScrW, kScrH, scratch_bmp.pitch, kDest, kDst.w, kDst.h,
+      ScaleDrawArea(scratch_bmp.pixels, kWp.w, kWp.h, scratch_bmp.pitch, kDest, kDst.w, kDst.h,
                     renderer.bmp.pitch);
     }
   }  // end Composite zone

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -15,20 +15,6 @@ struct Renderer;
 float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, int level_w,
                            int level_h);
 
-// Ceiling applied to the once-allocated spectator world texture so GPU memory
-// stays bounded on very large levels. Terrain itself is capped at this size, so
-// a level can never need a larger scratch than this.
-inline constexpr int kSpectatorWorldTextureMax = 4096;
-
-// Dimensions of the spectator world texture (PR7 Task 1b): the level size
-// clamped to kSpectatorWorldTextureMax. Allocated once per level — the scratch
-// for any zoom is at most the level size, so the per-frame upload only ever
-// writes a sub-rect of this. Pure so it can be unit-tested.
-struct WorldTextureSize {
-  int w, h;
-};
-WorldTextureSize SpectatorWorldTextureSize(int level_w, int level_h);
-
 // Centred, letterboxed destination rect (in window/logical pixels) for the
 // spectator world composite: the scratch (scr_w×scr_h) scaled by `zoom`, capped
 // to the render surface so it never overhangs. Pure so the CPU composite and
@@ -38,6 +24,19 @@ struct SpectatorDstRect {
 };
 SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, int scr_h,
                                          float zoom);
+
+// Render resolution of the spectator world pass (PR7 Task 1, downscaled pass).
+// `scale` is the world→scratch factor: 1.0 when zoom ≥ 1 (small maps render
+// 1:1, the GPU upscales) and `zoom` when zoomed out (the world is rendered at
+// ~output resolution so its CPU cost and texture upload are bounded by the
+// window, not the level area). `w`/`h` are the scratch size (the visible world
+// region scaled by `scale`). Pure so it can be unit-tested.
+struct WorldPassScratch {
+  int w, h;
+  float scale;
+};
+WorldPassScratch ComputeWorldPassScratch(int render_w, int render_h, float zoom, int level_w,
+                                         int level_h);
 
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -15,6 +15,15 @@ struct Renderer;
 float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, int level_w,
                            int level_h);
 
+// Dimensions of the world-pass scratch bitmap. Capped to render resolution so
+// the scratch never grows larger than the output — the old formula
+// (render_w / zoom) could reach 2x the pixel count at zoom=0.5.
+struct ScratchDims {
+  int w;
+  int h;
+};
+ScratchDims ComputeScratchDims(int render_w, int render_h, int level_w, int level_h);
+
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -15,15 +15,6 @@ struct Renderer;
 float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, int level_w,
                            int level_h);
 
-// Dimensions of the world-pass scratch bitmap. Capped to render resolution so
-// the scratch never grows larger than the output — the old formula
-// (render_w / zoom) could reach 2x the pixel count at zoom=0.5.
-struct ScratchDims {
-  int w;
-  int h;
-};
-ScratchDims ComputeScratchDims(int render_w, int render_h, int level_w, int level_h);
-
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -15,6 +15,30 @@ struct Renderer;
 float ComputeSpectatorZoom(int render_w, int render_h, int bbox_w, int bbox_h, int level_w,
                            int level_h);
 
+// Ceiling applied to the once-allocated spectator world texture so GPU memory
+// stays bounded on very large levels. Terrain itself is capped at this size, so
+// a level can never need a larger scratch than this.
+inline constexpr int kSpectatorWorldTextureMax = 4096;
+
+// Dimensions of the spectator world texture (PR7 Task 1b): the level size
+// clamped to kSpectatorWorldTextureMax. Allocated once per level — the scratch
+// for any zoom is at most the level size, so the per-frame upload only ever
+// writes a sub-rect of this. Pure so it can be unit-tested.
+struct WorldTextureSize {
+  int w, h;
+};
+WorldTextureSize SpectatorWorldTextureSize(int level_w, int level_h);
+
+// Centred, letterboxed destination rect (in window/logical pixels) for the
+// spectator world composite: the scratch (scr_w×scr_h) scaled by `zoom`, capped
+// to the render surface so it never overhangs. Pure so the CPU composite and
+// the GPU composite share one source of truth and it can be unit-tested.
+struct SpectatorDstRect {
+  int x, y, w, h;
+};
+SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, int scr_h,
+                                         float zoom);
+
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -83,38 +83,3 @@ TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator
   CHECK(kZoom > kFill);
   CHECK(kZoom < 1.0F);
 }
-
-// ---------------------------------------------------------------------------
-// Scratch dims tests (Task 1 — cap scratch to render resolution)
-// ---------------------------------------------------------------------------
-
-TEST_CASE("scratch dims capped to render resolution for level larger than window",
-          "[spectator][scratch]") {
-  // Large level, window 1280x800: scratch must not exceed render dims.
-  // Old formula (render_w/zoom x render_h/zoom) could reach 2560x1600 at
-  // zoom=0.5, wasting 4x pixels in ScaleDrawArea.
-  auto const kDims = ComputeScratchDims(1280, 800, 4096, 4096);
-  CHECK(kDims.w == 1280);
-  CHECK(kDims.h == 800);
-}
-
-TEST_CASE("scratch dims capped to level size for level smaller than window",
-          "[spectator][scratch]") {
-  // Small level inside large window: scratch is level-sized, not window-sized.
-  auto const kDims = ComputeScratchDims(1920, 1080, 504, 350);
-  CHECK(kDims.w == 504);
-  CHECK(kDims.h == 350);
-}
-
-TEST_CASE("scratch dims never exceed either render or level bound", "[spectator][scratch]") {
-  // Level wider than render but shorter: each axis is independently capped.
-  auto const kDims = ComputeScratchDims(800, 600, 1000, 400);
-  CHECK(kDims.w == 800);   // render-capped
-  CHECK(kDims.h == 400);   // level-capped
-}
-
-TEST_CASE("scratch dims equal render when level exactly matches window", "[spectator][scratch]") {
-  auto const kDims = ComputeScratchDims(1280, 800, 1280, 800);
-  CHECK(kDims.w == 1280);
-  CHECK(kDims.h == 800);
-}

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -117,6 +117,43 @@ TEST_CASE("spectator composite dest rect clamps to the render surface", "[specta
   CHECK(kDst.y == 150);
 }
 
+TEST_CASE("world pass renders 1:1 when not zoomed out", "[spectator][worldpass]") {
+  // zoom >= 1 (small map upscaled, or native): scale is 1.0 and the scratch is
+  // the visible world region at native pixels — the existing 1:1 path, so no
+  // behaviour change for small maps.
+  WorldPassScratch const kP = ComputeWorldPassScratch(1280, 800, 2.0F, 504, 350);
+  CHECK(kP.scale == Catch::Approx(1.0F));
+  // Visible region = min(render/zoom, level) = min(640, 504) x min(400, 350).
+  CHECK(kP.w == 504);
+  CHECK(kP.h == 350);
+}
+
+TEST_CASE("world pass downscales to output resolution when zoomed out",
+          "[spectator][worldpass]") {
+  // 4096^2 level, 1280x800 window, worms apart -> zoom ~0.195. The 1:1 scratch
+  // would be the whole 4096^2 (~16.7 Mpx); the downscaled pass renders at
+  // ~output resolution instead, bounding cost by the window.
+  float const kZoom = std::min(1280.0F / 4096.0F, 800.0F / 4096.0F);  // 0.195
+  WorldPassScratch const kP = ComputeWorldPassScratch(1280, 800, kZoom, 4096, 4096);
+  CHECK(kP.scale == Catch::Approx(kZoom));
+  // Scratch is the visible region (= whole level here) scaled by `scale`, so it
+  // is bounded by the render surface, not the level.
+  CHECK(kP.w <= 1280);
+  CHECK(kP.h <= 800);
+  CHECK(kP.w == static_cast<int>(std::lroundf(4096.0F * kZoom)));
+  // Far smaller than the 1:1 scratch it replaces.
+  CHECK(kP.w < 4096);
+  CHECK(kP.h < 4096);
+}
+
+TEST_CASE("world pass scratch never collapses below 1 pixel", "[spectator][worldpass]") {
+  // Degenerate guard: extreme zoom-out on a tiny region must still leave a
+  // 1x1 scratch the GPU can sample.
+  WorldPassScratch const kP = ComputeWorldPassScratch(1280, 800, 0.001F, 10, 10);
+  CHECK(kP.w >= 1);
+  CHECK(kP.h >= 1);
+}
+
 TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator][zoom]") {
   // Large level, bbox between "fits" and "whole level": zoom follows the
   // worm-framing value and sits strictly inside (fill, 1.0).

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -68,6 +68,55 @@ TEST_CASE("spectator zoom shows the whole level when a large level's worms are f
   CHECK(kZoom < 1.0F);
 }
 
+TEST_CASE("spectator world texture clamps level dims to the ceiling", "[spectator][composite]") {
+  // The world texture is allocated once at the level size so the per-frame
+  // upload only ever writes a sub-rect. On a level at or below the ceiling the
+  // dims pass straight through; past the ceiling they clamp so GPU memory stays
+  // bounded (terrain is capped at the same ceiling).
+  WorldTextureSize const kSmall = SpectatorWorldTextureSize(504, 350);
+  CHECK(kSmall.w == 504);
+  CHECK(kSmall.h == 350);
+
+  WorldTextureSize const kAtCeiling =
+      SpectatorWorldTextureSize(kSpectatorWorldTextureMax, kSpectatorWorldTextureMax);
+  CHECK(kAtCeiling.w == kSpectatorWorldTextureMax);
+  CHECK(kAtCeiling.h == kSpectatorWorldTextureMax);
+
+  WorldTextureSize const kOversized =
+      SpectatorWorldTextureSize(kSpectatorWorldTextureMax + 1000, kSpectatorWorldTextureMax + 1);
+  CHECK(kOversized.w == kSpectatorWorldTextureMax);
+  CHECK(kOversized.h == kSpectatorWorldTextureMax);
+}
+
+TEST_CASE("spectator composite dest rect fills the window at zoom 1", "[spectator][composite]") {
+  // Scratch exactly the render size, zoom 1 → no scaling, no letterbox bars.
+  SpectatorDstRect const kDst = ComputeSpectatorDstRect(1280, 800, 1280, 800, 1.0F);
+  CHECK(kDst.x == 0);
+  CHECK(kDst.y == 0);
+  CHECK(kDst.w == 1280);
+  CHECK(kDst.h == 800);
+}
+
+TEST_CASE("spectator composite dest rect centres a zoomed-out world", "[spectator][composite]") {
+  // 1000x1000 scratch at zoom 0.5 → 500x500 output centred in a 1280x800
+  // window: x=(1280-500)/2, y=(800-500)/2.
+  SpectatorDstRect const kDst = ComputeSpectatorDstRect(1280, 800, 1000, 1000, 0.5F);
+  CHECK(kDst.w == 500);
+  CHECK(kDst.h == 500);
+  CHECK(kDst.x == 390);
+  CHECK(kDst.y == 150);
+}
+
+TEST_CASE("spectator composite dest rect clamps to the render surface", "[spectator][composite]") {
+  // A computed output larger than the render surface is clamped to it (it must
+  // never overhang), pinning the corresponding offset to 0.
+  SpectatorDstRect const kDst = ComputeSpectatorDstRect(1280, 800, 4096, 1000, 0.5F);
+  CHECK(kDst.w == 1280);  // 4096*0.5 = 2048, clamped to 1280
+  CHECK(kDst.x == 0);
+  CHECK(kDst.h == 500);
+  CHECK(kDst.y == 150);
+}
+
 TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator][zoom]") {
   // Large level, bbox between "fits" and "whole level": zoom follows the
   // worm-framing value and sits strictly inside (fill, 1.0).

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -83,3 +83,38 @@ TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator
   CHECK(kZoom > kFill);
   CHECK(kZoom < 1.0F);
 }
+
+// ---------------------------------------------------------------------------
+// Scratch dims tests (Task 1 — cap scratch to render resolution)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("scratch dims capped to render resolution for level larger than window",
+          "[spectator][scratch]") {
+  // Large level, window 1280x800: scratch must not exceed render dims.
+  // Old formula (render_w/zoom x render_h/zoom) could reach 2560x1600 at
+  // zoom=0.5, wasting 4x pixels in ScaleDrawArea.
+  auto const kDims = ComputeScratchDims(1280, 800, 4096, 4096);
+  CHECK(kDims.w == 1280);
+  CHECK(kDims.h == 800);
+}
+
+TEST_CASE("scratch dims capped to level size for level smaller than window",
+          "[spectator][scratch]") {
+  // Small level inside large window: scratch is level-sized, not window-sized.
+  auto const kDims = ComputeScratchDims(1920, 1080, 504, 350);
+  CHECK(kDims.w == 504);
+  CHECK(kDims.h == 350);
+}
+
+TEST_CASE("scratch dims never exceed either render or level bound", "[spectator][scratch]") {
+  // Level wider than render but shorter: each axis is independently capped.
+  auto const kDims = ComputeScratchDims(800, 600, 1000, 400);
+  CHECK(kDims.w == 800);   // render-capped
+  CHECK(kDims.h == 400);   // level-capped
+}
+
+TEST_CASE("scratch dims equal render when level exactly matches window", "[spectator][scratch]") {
+  auto const kDims = ComputeScratchDims(1280, 800, 1280, 800);
+  CHECK(kDims.w == 1280);
+  CHECK(kDims.h == 800);
+}

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -68,26 +68,6 @@ TEST_CASE("spectator zoom shows the whole level when a large level's worms are f
   CHECK(kZoom < 1.0F);
 }
 
-TEST_CASE("spectator world texture clamps level dims to the ceiling", "[spectator][composite]") {
-  // The world texture is allocated once at the level size so the per-frame
-  // upload only ever writes a sub-rect. On a level at or below the ceiling the
-  // dims pass straight through; past the ceiling they clamp so GPU memory stays
-  // bounded (terrain is capped at the same ceiling).
-  WorldTextureSize const kSmall = SpectatorWorldTextureSize(504, 350);
-  CHECK(kSmall.w == 504);
-  CHECK(kSmall.h == 350);
-
-  WorldTextureSize const kAtCeiling =
-      SpectatorWorldTextureSize(kSpectatorWorldTextureMax, kSpectatorWorldTextureMax);
-  CHECK(kAtCeiling.w == kSpectatorWorldTextureMax);
-  CHECK(kAtCeiling.h == kSpectatorWorldTextureMax);
-
-  WorldTextureSize const kOversized =
-      SpectatorWorldTextureSize(kSpectatorWorldTextureMax + 1000, kSpectatorWorldTextureMax + 1);
-  CHECK(kOversized.w == kSpectatorWorldTextureMax);
-  CHECK(kOversized.h == kSpectatorWorldTextureMax);
-}
-
 TEST_CASE("spectator composite dest rect fills the window at zoom 1", "[spectator][composite]") {
   // Scratch exactly the render size, zoom 1 → no scaling, no letterbox bars.
   SpectatorDstRect const kDst = ComputeSpectatorDstRect(1280, 800, 1280, 800, 1.0F);
@@ -128,8 +108,7 @@ TEST_CASE("world pass renders 1:1 when not zoomed out", "[spectator][worldpass]"
   CHECK(kP.h == 350);
 }
 
-TEST_CASE("world pass downscales to output resolution when zoomed out",
-          "[spectator][worldpass]") {
+TEST_CASE("world pass downscales to output resolution when zoomed out", "[spectator][worldpass]") {
   // 4096^2 level, 1280x800 window, worms apart -> zoom ~0.195. The 1:1 scratch
   // would be the whole 4096^2 (~16.7 Mpx); the downscaled pass renders at
   // ~output resolution instead, bounding cost by the window.


### PR DESCRIPTION
## Summary

PR7 of the arbitrary-map-sizes series: makes the **zooming spectator viewport** affordable on large maps (4096²) and large native windows, where the old presentation pipeline blew past the frame budget.

Display-only — no changes to simulation, net protocol, or on-disk format.

## What changed

- **GPU-scale the composite (Tasks 1b/1c/1d).** Replaces the ~38 ms per-frame CPU box-filter (`ScaleDrawArea`) on the spectator path with a GPU scale: the world pass is uploaded to a streaming texture and `SDL_RenderTexture`'d into the letterboxed dest rect (`SDL_SCALEMODE_LINEAR`); the HUD becomes a transparent overlay blended on top. Guarded to the live spectator window only — videotool, single-screen replay, and the dummy driver keep the CPU `ScaleDrawArea` path (Task 1e, still covered by `test_blit`).
- **Downscaled world pass (Task 1g).** The world pass and its texture upload used to run at 1:1 full-level resolution (~16.7 Mpx / 64 MB per frame at full zoom-out). It now renders at ~output resolution when `zoom < 1`, bounded by the window not the level. `zoom ≥ 1` (small maps) keeps the existing 1:1 path byte-for-byte. New nearest-neighbour `DrawLevelScaled` / `BlitImageScaled`; `ComputeWorldPassScratch` is unit-tested. Detail that is sub-pixel/illegible at heavy zoom-out (shadows, text labels, fire cones, laser sight, aim crosshair, AI debug) is intentionally omitted in the downscaled path.
- **Frustum-cull sprites & shadows (Task 2).** AABB-cull each object against the visible world rect before blitting.
- **Bug fixes found on real hardware (Task 1h).**
  - One-shot the GPU world handoff so a stale pointer from `MainMenuState::Enter`'s direct `Flip()` can't drive `DrawSpectatorGpu` against a resized layout (pause crash).
  - Restore neutral spectator texture colormod after each GPU present so the GPU fade can't leak onto the CPU present path (black spectator at start/pause until resize).

## Performance (Tracy, 4096² level, worms at max separation)

| Stage | Before | After |
|---|---|---|
| 1280×800, GPU composite only | 38 ms CPU composite → ~34 ms total | — |
| 3440×1440, + downscaled world pass | — | **~20 ms** |

A large improvement (≈34→20 ms). **Honest caveat:** it is *not* strictly within the 14 ms budget at very large windows — at 3440×1440 (~5 Mpx) the residual ~20 ms is dominated by the two full-window texture uploads (world + HUD overlay) + present. Accepted for now; further gains (HUD dirty-region upload, or capping spectator render resolution independently of window size) are optional follow-ons, as are the plan's Task 3 (SIMD `ScaleDrawArea`) and Task 4 (min-zoom cap).

## Testing

- New unit tests: `test_spectator_zoom` `[composite]` + `[worldpass]` (`ComputeWorldPassScratch`, dst-rect math). `test_blit` unchanged.
- Full suite green (`ctest`: 261 tests pass); `test_determinism` + `test_rollback_correctness` + `test_rollback_desync` green (display-only change, but verified).
- Headless smoke (dummy driver) launches clean — GPU path correctly guarded off.
- `clang-format` + `clang-tidy` diff clean.
- GPU output (visuals, frame time) verified by the author on a real display; the headless CI environment cannot exercise the GPU path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)