### PR TITLE
PR8: spectator render-resolution cap + partial HUD present

### DIFF
--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -1,447 +1,216 @@
 # Plan: Arbitrary Map Sizes + Zooming Spectator Viewport + Configurable Videotool Resolution
 
-**Complexity**: Large (5 sequenced, independently-mergeable PRs)
+**Complexity**: Large (originally 5 sequenced PRs; PRs 1–7 landed, PR 8 is the active work)
 
 ## Summary
 
-Today the game only supports 504×350 maps and the spectator window assumes the
-whole map fits on screen. This plan adds: (1) arbitrary map sizes up to
-4096×4096 via a new sized on-disk level format (legacy headerless 504×350 still
-loads), (2) a spectator viewport that auto-zooms to keep both worms visible on
-large maps, and (3) a selectable output resolution for the videotool. Work is
-split into 5 PRs, each of which leaves master green and the game playable.
+Adds: (1) arbitrary map sizes up to 4096×4096 via a new sized on-disk level
+format (legacy headerless 504×350 still loads), (2) a spectator viewport that
+auto-zooms to keep both worms visible on large maps, and (3) a selectable output
+resolution for the videotool. PRs 1–7 are **merged to master**. The remaining
+work (**PR 8**) pushes the spectator frame time under the 14 ms budget on very
+large (4K-class) windows — see the dedicated section at the bottom; everything
+above it is background.
 
-## Decisions
+## Decisions (still load-bearing)
 
-- **D1** — New magic-prefixed on-disk format for sized maps; legacy headerless
-  504×350 files still load.
-- **D2** — Maximum map size **4096×4096** (matches the existing net wire-transfer cap).
-- **D3** — Spectator zoom via **render-to-scratch + area-downscale** (the world
-  pass renders 1:1 into a scratch bitmap, then downscales into the spectator
-  rect; HUD overlays draw on top at native resolution).
-- **D4** — **Sequenced PRs, each independently mergeable.**
-- **D5** — The 4096² test level is **generated on demand** (a tools script +
-  CMake/test fixture), NOT committed to git (~117 MB raw).
-- Random map-size option lives in **MATCH SETUP** (`SettingsMenu`).
-- `docs/modern-level-authoring.md`, the `tools/` level scripts, and a new 4096²
-  test-level generator all get updated.
+- **D2** — Maximum map size **4096×4096** (matches the net wire-transfer cap).
+- **D3** — Spectator zoom via **render-to-scratch + downscale**: the world pass
+  renders into a scratch bitmap, then is scaled into the spectator rect; HUD
+  overlays draw on top.
+- The simulation core is **size-agnostic** (`Level` stores layers as
+  `std::vector`, `Resize(w,h)` is dynamic; collision, snapshots, net transfer,
+  and `Viewport` all read `level.width/height`). Rendering/zoom never runs in
+  `processFrame`, and the spectator view is local display only (not
+  checksummed) — so **zoom math may use floats freely** without touching the
+  fixed-point determinism contract.
 
-## Key architecture findings
+## Status of merged work (PRs 1–7)
 
-The **simulation core is already size-agnostic**: `Level` stores layers as
-`std::vector`, `Resize(w,h)` is dynamic, and collision, spawning, blitting
-(`gfx/blit.cpp`), state-hashing, cereal + fast snapshots, replay level capture,
-and the network level transfer (already validates `0 < w,h ≤ 4096` and
-`Resize`s) all read `level.width/height` dynamically. `Viewport` already takes
-`(levwidth, levheight)`.
-
-Blockers (hardcoded 504×350 or fixed-size structures):
-
-| Blocker | Location | Issue |
+| PR | What shipped | Where the code lives |
 |---|---|---|
-| `Resize(504, 350)` | `level.cpp:214` (`load`), `level.cpp:12` (gen) | size baked in |
-| Legacy `.lev` has no size header | `level.cpp:222` reads `w*h` before knowing size | can't encode other sizes on disk |
-| Hardcoded viewport ctor | `localController.cpp:46-53`, `rollbackController.cpp:34-62`, `replayController.cpp:145-154`, `replay_to_video.cpp:60` | literal `504, 350` + `Rect(0,0,504+68,350)` |
-| Fixed AI arrays | `ai/dijkstra.hpp:153-162` (`kFullWidth/Height`, `cells[]`), `ai/predictive_ai.hpp:230-237` (`CellState[17][12]`) | out-of-bounds / overflow on large maps |
-| Fixed stats heatmaps | `stats_recorder.hpp:58-104` (`504/2,350/2,504,350`) | hardcoded dims |
-| No world→buffer downscale | `spectatorviewport.cpp:33-38` maps world→buffer 1:1; `ScaleDraw` (`blit.cpp`) only integer-*upscales* | zoom-out is new capability |
-| Videotool fixed dims | `replay_to_video.cpp:28-34,66-67` (640×400 render, 1280×720 out), `video_recorder.c:327` (sws scaler input hardcoded 640×400 — latent 320×200 bug) | no resolution selection |
+| **PR 1** ([#103]) | Refactor: all hardcoded 504×350 read `level.width/height` (viewport ctors, AI arrays in `ai/dijkstra.hpp` + `ai/predictive_ai.hpp`, stats heatmaps in `stats_recorder.hpp`). No behavior change. | controllers, `ai/`, `stats_recorder.hpp` |
+| **PR 2** | New `OLLEVEL2` sized on-disk format (8-byte magic + version + `width/height` u16 LE, then legacy body); legacy no-magic path unchanged. Tools (`lev_gen.py`, `lev_extract.py`, `gen_large_test.py`), 4096² generated-on-demand test level, `test_sized_level.cpp`, doc. | `level.cpp` (`Level::load`), `tools/`, `docs/modern-level-authoring.md` |
+| **PR 3** | Random map size in MATCH SETUP (`random_map_width/height` settings, config v5, menu items, `GenerateRandom` resize). | `settings.hpp`, `cereal_types.hpp`, `gfx.{hpp,cpp}` |
+| **PR 4** | Zooming spectator viewport: `ScaleDrawArea` CPU box-filter downscale; `SpectatorViewport::Draw` split into world pass → composite → HUD; zoom from worm bounding box; native-resolution spectator window. | `gfx/blit.{hpp,cpp}`, `spectatorviewport.{hpp,cpp}`, `gfx.cpp` |
+| **PR 5** | Configurable videotool output resolution (`-w/-h`/`--res WxH`); dynamic sws scaler input. | `tools_main.cpp`, `replay_to_video.{hpp,cpp}`, `video_recorder.c` |
+| **PR 6** ([#108]) | Rollback snapshot dirty-cell tracking so `SaveSnapshotFast` doesn't memcpy ~48 MB/frame on large maps. Dirty bitset in `Level`; `level.materials` dedup. Online-play-only. | `level.hpp` (`dirty_bits`/`dirty_list`), `fast_snapshot.hpp` |
+| **PR 7** ([#114]) | Spectator rendering optimisation — **the direct predecessor to PR 8**. Detailed below. | `spectatorviewport.{hpp,cpp}`, `gfx.{hpp,cpp}`, `gfx/renderer.hpp` |
 
-**Determinism note:** rendering/zoom never runs in `processFrame`, and the
-spectator view is local display only (not checksummed) — so zoom math may use
-floats freely without touching the fixed-point determinism contract.
+[#103]: https://github.com/openliero/openliero/pull/103
+[#108]: https://github.com/openliero/openliero/pull/108
+[#114]: https://github.com/openliero/openliero/pull/114
 
-## Patterns to mirror (verified in-tree)
+## PR 7 recap — the pipeline PR 8 builds on (merged, #114)
 
-| Concern | Source | Pattern |
-|---|---|---|
-| Numeric match-setup setting | `gfx.cpp:1129` | `new IntegerBehavior(common, gfx.settings->field, min, max, step)` |
-| Menu item registration | `gfx.cpp:457` + `gfx.hpp:72-98` enum | `AddItem(MenuItem(...))` + `kSi*` enum + `GetItemBehavior` case |
-| Settings field + persistence | `settings.hpp:71-88`, `cereal_types.hpp:161-189` | field default + `make_nvp` + `kConfigVersion` bump (→ v5) |
-| On-disk format extension | `level.cpp:230-332` | magic-probe blocks (`POWERLEVEL`/`MODERNLV`), `TryGet` tolerant reads |
-| Downscale blit | `blit.cpp` `ScaleDraw` | existing integer-upscale routine to extend with downscale |
-| Videotool CLI args | `tools_main.cpp:42-62` | `argv[i][1]` switch |
-
-## PRs
-
-### PR 1 — Foundation: make hardcoded 504×350 read `level.width/height` (pure refactor) — **DONE** ([#103](https://github.com/openliero/openliero/pull/103))
-No behavior change; level still loads at 504×350. De-risks everything downstream.
-- **Viewport construction**: replace literal `504, 350` in the controllers and
-  `replay_to_video.cpp:60` with `level.width/height`; decouple spectator `Rect`
-  from map size.
-- **AI**: `ai/dijkstra.hpp:153-162` (`kFullWidth/Height` statics + fixed
-  `cells[]`) → dynamic dims + heap buffer; `ai/predictive_ai.hpp:230-237`
-  (`CellState[17][12]`) → dynamic grid.
-- **Stats**: `stats_recorder.hpp:58-104` heatmaps → derive from `level.width/height`.
-- **Mergeable because**: everything still runs at 504×350; identical behavior.
-- **Validate**: full ctest + `test_determinism`/`test_rollback_*`; smoke-launch; clang-format/tidy diff.
-
-### PR 2 — New sized on-disk format + tools + 4096² test level — **DONE**
-- **Format**: `OLLEVEL2` 8-byte magic + `version:u8` + `width:u16 LE` + `height:u16 LE`
-  (13-byte header total), then the existing body (material bytes → optional
-  `POWERLEVEL` → optional `MODERNLV`). No magic ⇒ legacy 504×350 path.
-  4096 cap enforced in loader, `lev_gen.py`, and `lev_extract.py`.
-- **`Level::load`** (`level.cpp`): probes first 8 bytes via `TryGet`; on magic
-  match reads 5-byte header and calls `Resize(w,h)`; otherwise prepends the
-  probed bytes to the legacy material read (no seek on `io::Reader` needed).
-- **Tools**:
-  - `tools/lev_gen.py`: removed `--width`/`--height`; dims derived from `--mat`
-    image; `open_and_check()` validates all other images match; OLLEVEL2 header
-    written automatically for non-504×350 sizes.
-  - `tools/lev_extract.py`: detects OLLEVEL2 magic; bounds-checks parsed dims;
-    all MODERNLV parsing uses dynamic `cells = level_w * level_h`.
-  - `tools/gen_stage4_anim.py`: deleted (outlived its usefulness).
-  - `tools/gen_large_test.py` (new): generates a 4096×4096 OLLEVEL2 level with
-    MODERNLV animated band; output gitignored; not committed.
-- **Tests**: `src/tests/test_sized_level.cpp` — 12 Catch2 cases: legacy
-  regression, sized load, material round-trip, 4096 cap, zero-dim rejection,
-  MODERNLV at non-standard size, POWERLEVEL+MODERNLV combo, 1×1 boundary.
-- **Doc**: `docs/modern-level-authoring.md` updated — canvas size 1×1–4096×4096;
-  OLLEVEL2 header documented; lev_gen auto-dim detection; gen_large_test section;
-  appendix with both file layouts side-by-side.
-
-### PR 3 — Random map size in MATCH SETUP — **DONE**
-- **Settings**: added `int32_t random_map_width{504}; int32_t random_map_height{350};`
-  (`settings.hpp`), serialized in `SerializeSettingsScalars` (`cereal_types.hpp`),
-  bumped `kConfigVersion` **4 → 5**.
-- **Menu**: `kSiRandomMapWidth/Height` enum (`gfx.hpp`), items added near `kSiLevel`
-  (`gfx.cpp`), `IntegerBehavior(common, …, 64, 4096, 8)` cases in `GetItemBehavior`,
-  visibility gated on `gfx.settings->random_level` in `SettingsMenu::OnUpdate`.
-- **Generation**: `GenerateRandom` calls `Resize(settings.random_map_width,
-  settings.random_map_height)` instead of the hardcoded `Resize(504, 350)`.
-  Added a `kMaxTries = width * height` retry cap to the rock-placement loops to
-  prevent infinite spin on unusually small maps.
-- **Bug fix**: `LevelSelectorState::OnSelected` now calls
-  `gfx->settings_menu.UpdateItems()` after changing `random_level`, so MAP
-  WIDTH/HEIGHT items appear immediately when switching to random in the same
-  session (pre-existing gap, made visible by this PR).
-- **Bug fix**: `Level` tracks `old_random_map_width/height` alongside the existing
-  `old_random_level/old_level_file`; the new-game reuse condition in `gfx.cpp`
-  now includes them, so changing the map size triggers regeneration without
-  needing to toggle the REGENERATE LEVEL flag.
-- **Tests**: `src/tests/test_random_map_size.cpp` — 8 Catch2 cases: default values,
-  config version, TOML round-trip, backward-compat (missing keys fall back to
-  504×350), and `GenerateFromSettings` at non-default and default dimensions.
-
-### PR 4 — Zooming spectator viewport (render-to-scratch + downscale) — **DONE**
-
-Delivered on branch `arbitrary-map-sizes-pr4`:
-
-- `ScaleDrawArea` CPU box-filter downscale added to `gfx/blit.cpp`; 4 Catch2
-  cases in `src/tests/test_blit.cpp`.
-- `SpectatorViewport::Draw` split into world pass (scratch bitmap at visible
-  world region, 1:1 pixel scale) + `ScaleDrawArea` composite + HUD overlay at
-  native renderer resolution.
-- `SpectatorViewport::Process` computes zoom from both worms' bounding box +
-  60 px margin, clamped to 1.0× max (never zooms in past native pixels).
-- Controller viewport rects changed to `Rect(0, 0, 640, 400)`; the old
-  `504+68` centering hack removed.
-- `DrawMiniature` gains independent `step_x`/`step_y` axes (two-axis overload,
-  single-step wrapper kept for call-site compat) and is now `const`-qualified.
-  All minimap draw sites updated; `fileSelectorState.cpp` adds `FillRect` before
-  each draw to clear stale pixels when switching level previews.
-- Spectator window renders at native pixel resolution: `OnWindowResize` queries
-  `SDL_GetWindowSize` and calls `single_screen_renderer.SetRenderResolution(w,h)`;
-  `SpectatorViewport` caches `render_w`/`render_h` from the renderer so
-  `Process()` stays consistent without a `Renderer&` parameter. During
-  single-screen replay `single_screen_renderer` is reset to 640×400 (it doubles
-  as the main window primary renderer in that mode) and restored on game exit.
-
-> **Known limitation**: extreme CPU slowdown when worms move far apart and
-> zoom-out is triggered on a large native spectator window. Addressed in PR 7.
-
-### PR 5 — Configurable videotool output resolution — **DONE**
-- **`tools_main.cpp`**: add `-w/-h` (or `--res WxH`) parsing alongside `-d/-s/-r`.
-- **`replay_to_video.{hpp,cpp}`**: thread output dims through; remove hardcoded
-  `kW=1280/kH=720` (lines 66-67); set spectator render resolution from the
-  requested output.
-- **`video_recorder.c:327`**: make `sws_getContext` input size dynamic (also
-  fixes the latent 320×200 bug hardcoded to 640×400).
-- **Mergeable because**: absent the flags it defaults to today's behavior.
-- **Validate**: render a replay at 1280×720 and 1920×1080, spectator + normal
-  mode; confirm output dimensions and no scaler mismatch.
-
-### PR 6 — Rollback snapshot optimization: dirty-cell tracking for large levels — **DONE** ([#108](https://github.com/openliero/openliero/pull/108))
-
-Online play on large maps (e.g. 4096×4096) is slow because `SaveSnapshotFast`
-memcpys ~48 MB per rollback frame (material_id + material flags + display_valid),
-completely blowing out L3 cache every tick. Local play is unaffected (no rollback).
-
-- **Dirty-cell bitset**: maintain a per-level bitset (or small sorted list) of cells
-  modified since the last snapshot. Terrain destruction is already funneled through
-  `Level::Modify` / the two `SetMaterial` helpers in `level.hpp` — add a dirty-mark
-  there. Snapshot saves the full block on the first frame after `Prepare()`, then
-  saves only dirty cells (index + value pairs) on subsequent frames.
-- **Restore path**: restore full block from the last full snapshot, then apply
-  the forward delta chain (or store snapshots as full + delta in alternation).
-- **Alternatively**: store snapshots as always-full but skip `display_valid` cells
-  that haven't been touched, using a dirty-bitset to know which 64-byte cache lines
-  to copy. This keeps the restore path simple (one memcpy pass) at the cost of
-  slightly more complex save logic.
-- **`level.materials` deduplication**: `level.materials[i]` is always
-  `common.materials[level.material_id[i]]`; after restoring `material_id` we can
-  recompute `materials` in one O(W×H) pass and drop the 16 MB `level_materials`
-  slot entirely.
-- **Mergeable because**: snapshot is entirely in-memory; wire format and disk
-  format are unaffected; existing rollback tests verify correctness.
-- **Validate**: `test_rollback_correctness`, `test_rollback_desync`,
-  `test_snapshot_fast` (add a dirty-tracking round-trip case); confirm online play
-  on the 4096² level is no longer noticeably slower than local play.
-
-### PR 7 — Rendering pipeline optimisation
-
-With large maps and large native spectator windows, the rendering pipeline can
-exceed the 14 ms frame budget in several places.  This PR opens with a profiling
-pass to identify every hot path, then fixes them in priority order.  Any
-findings that don't fit the scope (e.g. a major bottleneck in simulation,
-networking, or palette handling) are noted as follow-on work rather than
-stretching this PR.
-
-#### Profiling result (2026-06-15, 4096² level, 1280×800 spectator, worms apart)
-
-Tracy zones confirm the cost split inside `SpectatorViewport::Draw` (~45 ms):
-
-| Stage | Code | Cost |
-|---|---|---|
-| World pass → `scratch_bmp` (DrawLevel + shadows + sprites, 1:1) | `spectatorviewport.cpp:94-489` | DrawLevel **6 ms** + sprites |
-| **`ScaleDrawArea` CPU box-filter** scratch → `single_screen_renderer.bmp` (native res) | `spectatorviewport.cpp:521`, impl `blit.cpp:770-799` | **~38 ms** ← dominant |
-| `ScaleDraw` integer-magnify in `Gfx::Draw` (kMag=1 at native ⇒ plain copy) | `gfx.cpp:1013` | redundant |
-| `SDL_UpdateTexture`/`SDL_RenderTexture`/present | `gfx.cpp:1016-1019` | already GPU |
-
-`ScaleDrawArea` reads **every** source pixel with a per-output-pixel divide; at
-zoom 0.5 the source is 2560×1600 = 4M px/frame. Cost scales as
-`(render_w × render_h) / zoom²`. **The CPU composite — not the world drawing — is
-the bottleneck.** The world pass itself (DrawLevel 6 ms + sprites) is comparatively
-cheap, so shrinking or caching it is low-ROI; eliminating the composite is the win.
-
-#### Current presentation pipeline (the code being restructured)
-
-The spectator window goes through **two** CPU scaling passes today. Dataflow:
+PR 7 replaced the CPU box-filter composite with a GPU scale and added a
+downscaled world pass. The resulting **current** spectator present path (the
+thing PR 8 optimises) is:
 
 ```
-SpectatorViewport::Draw(game, single_screen_renderer, ...)   spectatorviewport.cpp:82
-  ├─ world pass → scratch_bmp           1:1 world pixels, size capped to level
-  │                                      (spectatorviewport.cpp:94-489)
-  ├─ Composite: scratch_bmp ─ScaleDrawArea(box filter)→ single_screen_renderer.bmp
-  │                                      (spectatorviewport.cpp:491-524)  ← ~38 ms
-  │     • memcpy fast path when scratch dims == output dims (510-519)
-  │     • ScaleDrawArea otherwise (521)
-  │     • Fill(renderer.bmp, 0) clears letterbox bars OPAQUE black (503-505)
-  └─ HUD: drawn directly into single_screen_renderer.bmp at native res (526-664)
+SpectatorViewport::Draw(game, single_screen_renderer, …)      spectatorviewport.cpp:102
+  ├─ Fill(scratch_bmp, 0)                       full-scratch memset           :128
+  ├─ World pass → scratch_bmp                                                 :130-649
+  │     • zoom < 1  → DrawLevelScaled + BlitImageScaled at ~output res,
+  │                    shadows/text/fire/laser/crosshair OMITTED (illegible)  :130-258
+  │     • zoom >= 1 → 1:1 DrawLevel + shadow pass + sprite pass (byte-exact
+  │                    legacy path; small maps unchanged)                     :259-649
+  │     • all sprite/shadow loops are AABB frustum-culled (PR7 Task 2)
+  ├─ GPU composite handoff (renderer.gpu_world_composite == true)             :658-675
+  │     • stash scratch + used-rect + letterboxed dst-rect on the Renderer
+  │     • FillTransparent(renderer.bmp)         full-overlay memset           :675
+  └─ HUD overlay → renderer.bmp (native res, transparent bg)                  :704-842
 
-Gfx::Flip()                                                   gfx.cpp:1024
-  ├─ Draw(*sdl_draw_surface, *sdl_texture, *sdl_renderer, *primary_renderer)        // main window
-  └─ Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture,
-          *sdl_spectator_renderer, single_screen_renderer)    // spectator window (1030-1033)
+Gfx::Flip()                                                   gfx.cpp:1116
+  └─ if single_screen_renderer.gpu_world_src  → DrawSpectatorGpu(...)         :1128
+        gpu_world_src is a strict ONE-SHOT (set per spectator draw, cleared
+        every Flip) so menu/pause/direct-Flip frames fall back to CPU present.
 
-Gfx::Draw(surface, texture, sdl_renderer, renderer)           gfx.cpp:983
-  ├─ ScaleDraw(renderer.bmp → surface, kMag)  integer magnify; kMag==1 at native ⇒ plain copy (1013)
-  ├─ SDL_UpdateTexture(texture, surface.pixels, ...)          (1016)
-  ├─ SDL_RenderClear / SDL_RenderTexture(texture, NULL, NULL) (1017-1018)
-  └─ SDL_RenderPresent                                        (1019)
+Gfx::DrawSpectatorGpu(renderer)                               gfx.cpp:1065
+  ├─ EnsureSpectatorWorldTexture(max_w, max_h)  grow-only STREAMING texture   :1067
+  ├─ SDL_UpdateTexture(world, used_sub_rect, …) world DMA upload              :1078
+  ├─ SDL_UpdateTexture(hud,   FULL window,   …) HUD overlay DMA upload        :1081
+  ├─ SDL_SetTextureColorMod(both, fade)         reproduces ScaleDraw fade     :1089
+  ├─ SDL_RenderClear (opaque black bars)                                      :1093
+  ├─ SDL_RenderTexture(world, used → letterboxed dst, LINEAR)                 :1102
+  ├─ SDL_RenderTexture(hud,   full → full)      BLEND over world              :1103
+  ├─ SDL_RenderPresent                                                        :1104
+  └─ SDL_SetTextureColorMod(both, 255)          restore neutral (bug 4f7a187) :1112
 ```
 
-Relevant SDL setup (`Gfx::OnWindowResize`, gfx.cpp:390-414): the spectator texture
-`sdl_spectator_texture` is `SDL_TEXTUREACCESS_STREAMING` sized to the **window**
-(w,h); `sdl_spectator_draw_surface` is a matching ARGB8888 surface; and
-`SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, w, h, LETTERBOX)` is
-already applied (gfx.cpp:407). `single_screen_renderer.bmp` is sized to the window
-via `SetRenderResolution(w,h)` (gfx.cpp:412).
+Relevant setup: the spectator renderer runs
+`SDL_SetRenderLogicalPresentation(w, h, LETTERBOX)` with logical size **==**
+window pixel size (`gfx.cpp` `OnWindowResize`, ~:405-414), so the
+logical→physical transform is uniform and a manual letterboxed dst-rect lands
+pixel-exact (proven by spike in PR7 Task 1a). `single_screen_renderer` renders
+at the window size (`SetRenderResolution(w,h)`), and `render_res_x/y` on the
+`Renderer` (`gfx/renderer.hpp:38-39`) is that size.
 
-So today both the world downscale (`ScaleDrawArea`) and a redundant native-res copy
-(`ScaleDraw`, kMag=1) run on the CPU before the single GPU upload+present.
+Two spectator-presentation bugs were fixed and are easy to re-break — keep them
+in mind when touching this path:
+- **`703af23`** — `gpu_world_src` made a strict one-shot (a stale handoff drove
+  `DrawSpectatorGpu` against a resized menu layout → heap overread on pause).
+- **`4f7a187`** — the fade `SDL_SetTextureColorMod` leaked onto the shared
+  `sdl_spectator_texture`; the CPU present path never reset it → black spectator
+  until resize. Always restore neutral colormod after a GPU present.
 
-#### Decision: GPU-scale the composite, keep the 1:1 world pass
+**PR 7 outcome:** spectator frame time improved **≈45 → ≈20 ms** (4096² level,
+worms at max separation). Still **above the 14 ms budget at very large windows**
+(≈20 ms at 3440×1440, max zoom-out). PR 8 closes that gap.
 
-The earlier "cap scratch to render resolution" attempt was reverted (`8e1b028`,
-PR7 Task 1a) because the world pass blits at 1:1 — capping the scratch below the
-visible region merely clips the view. The corrected approach keeps the 1:1 world
-pass (its drawing cost was never the problem) and replaces the **CPU composite**
-with a **GPU scale**:
+---
 
-1. World pass still renders into `scratch_bmp` at 1:1 (unchanged).
-2. Upload `scratch_bmp` to a dedicated SDL **streaming texture**, then
-   `SDL_RenderTexture` it to the letterboxed dest rect on the GPU
-   (`SDL_SCALEMODE_LINEAR`). This **deletes the ~38 ms `ScaleDrawArea` and the
-   redundant `ScaleDraw` copy**, replacing them with a texture upload (~16 MB DMA,
-   a few ms) plus a sub-ms GPU blit.
-3. HUD renders into a native-res layer with a **transparent background** → overlay
-   texture → second `SDL_RenderTexture` on top with alpha blend.
+## PR 8 — Bound the spectator cost by a render-resolution cap (ACTIVE)
 
-To avoid recreating a texture every frame as zoom (and thus scratch size) changes,
-allocate the world texture **once at max size** (level dims clamped to a ceiling),
-upload only the used sub-rect, and pass that sub-rect as `SDL_RenderTexture`'s
-srcrect.
+**Goal:** spectator frame time within the 14 ms budget at 4K-class windows
+(3440×1440 and 3840×2160), 4096² level, worms at maximum separation (full
+zoom-out — the worst case).
 
-`ScaleDrawArea` **stays** — `video_tool` renders offline with no GPU/window and
-still needs the CPU path. The GPU path is **spectator-window-only**, guarded on a
-live SDL renderer (must not crash under the dummy driver in CI smoke).
+### Problem analysis (profiling-grounded; re-confirm before/after on real HW)
 
-#### Dirty-rectangle sharing — evaluated, declined
+After PR 7 every remaining cost in the spectator path **scales with the window
+pixel count**, not the map. At 3440×1440 each full-window ARGB buffer is
+~19.8 MB. Per spectator frame, zoomed out:
 
-Considered sharing the rollback dirty-tracking to lessen rendering. Finding:
-there is **no dirty-rect system in `RollbackController`**; the dirty tracking
-lives in **`Level`** (`level.hpp:94-106,199-200`: `dirty_bits` + `dirty_list`)
-and feeds `SaveSnapshotFast` (PR6). It is unsuitable for rendering reuse:
+| Step | Code | Cost driver |
+|---|---|---|
+| `Fill(scratch_bmp, 0)` | `spectatorviewport.cpp:128` | full-window memset (~20 MB) |
+| Downscaled world CPU draw | `spectatorviewport.cpp:130-258` | ~5 Mpx terrain + sprites |
+| `FillTransparent(renderer.bmp)` | `spectatorviewport.cpp:675` | full-window memset (~20 MB) |
+| `SDL_UpdateTexture(world, used)` | `gfx.cpp:1078` | ~20 MB CPU→GPU DMA |
+| `SDL_UpdateTexture(hud, full)` | `gfx.cpp:1081` | ~20 MB CPU→GPU DMA |
+| clear + 2× `RenderTexture` + present | `gfx.cpp:1092-1104` | GPU, cheap |
 
-- It is **cumulative and never cleared** (`level.hpp:197-198`) — it only grows;
-  rendering needs per-frame dirty regions.
-- It tracks **terrain cells only**. But terrain draw (`DrawLevel`) is just 6 ms,
-  not the bottleneck; sprites/shadows/worms move every frame and aren't tracked.
+So per frame: **two full-window memsets + two full-window uploads** (~80 MB CPU
+memory traffic + ~40 MB DMA), all sized to the *window*. At max zoom-out the
+spectator shows the whole 4096² map shrunk into the window — the source detail
+is already sub-pixel, so **there is no visual benefit to rendering or uploading
+at full 4K.** The window resolution, not the map, is the cost.
 
-At best it could cache the terrain layer (~6 ms) at real complexity cost, and the
-GPU composite makes that moot. **Not pursued.**
+### Key insight that makes the fix cheap
 
-#### Tasks
+`SpectatorViewport::Process` (`spectatorviewport.cpp:51-100`) computes zoom from
+the **worm bounding box**, and the visible world region is
+`kViewW = render_w / zoom` (≈ bbox width + margin). Both `render_w` and `zoom`
+scale together, so **the visible region is bbox-driven and independent of the
+render resolution.** Lowering the spectator's internal render resolution changes
+only the *sampling* resolution, not what is on screen. HUD coordinates are
+already `render_res`-relative, so they lay out in the reduced space and upscale
+consistently.
 
-0. **Profile first.**
-   Run with a 4096² level and the spectator window at a large native size (e.g.
-   1280×800), worms at maximum separation to force full zoom-out.  Use
-   `perf record` / Instruments / Tracy (or even a manual frame timer around the
-   key call sites) to confirm which functions actually dominate.  Let the profile
-   guide which of the tasks below to tackle and in what order; skip tasks that
-   don't appear in the hot path.  If the profiler surfaces a major bottleneck
-   outside the rendering pipeline (simulation tick, palette rebuild, network
-   processing) open a separate follow-on issue rather than folding it here.
+### Approach (in priority order)
 
-1. **GPU-scale the world composite (keep the 1:1 world pass).** ← see Decision above
-   Do NOT cap the scratch below the visible region (that was Task 1a, reverted in
-   `8e1b028` — it clips the view). Highest-ROI fix (removes the ~38 ms composite +
-   redundant copy). Files: `spectatorviewport.{hpp,cpp}`, `gfx.{hpp,cpp}`
-   (`Draw`/`Flip`/`OnWindowResize` + new texture members in `gfx.hpp`),
-   `src/tests/test_spectator_zoom.cpp`. Sub-steps:
+#### Task 1 — Cap the spectator internal render resolution (primary fix, low risk)
 
-   - **1a. Spike the SDL scaling path first. — RESOLVED (2026-06-15): keep logical
-     presentation; manual dest rect cooperates.** The spectator renderer runs
-     `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)` (gfx.cpp:407). The question was
-     whether a manual letterboxed `SDL_RenderTexture` dest rect cooperates with that
-     or whether logical presentation must be dropped.
-     **Finding (empirical):** an SDL3 software-renderer spike replicating the
-     spectator setup (logical size == window pixel size, LETTERBOX) blitted a world
-     texture into a manually-computed centred dest rect and read pixels back: the
-     readback framebuffer is the logical size (1280×800), the world colour lands
-     pixel-exactly inside the manual dest rect, and `SDL_RenderClear` produces exact
-     black bars outside it. Because the logical size **equals** the window pixel size,
-     the logical→physical transform is uniform (identity modulo HiDPI), so there is
-     **no double-letterboxing**.
-     **Decision for 1b/1c:** keep `SDL_SetRenderLogicalPresentation(w,h,LETTERBOX)`
-     untouched; render coordinates are then in logical == window pixels. Reuse the
-     existing CPU-composite aspect math (`kOutX/kOutY/kOutW/kOutH`,
-     spectatorviewport.cpp:496-501) directly as the `SDL_RenderTexture` dstrect (as
-     `SDL_FRect`); `SDL_RenderClear` the spectator renderer to opaque black for the
-     bars before the world blit. No `FitScreen`-style manual letterbox is needed.
-     The "allocate world texture once at max size, upload only the used sub-rect, pass
-     that sub-rect as `srcrect`" approach (1b) is orthogonal to logical presentation
-     (standard `SDL_RenderTexture` srcrect semantics) and is low-risk — not separately
-     spiked. (Spike source kept out-of-tree under `/tmp/sdl_spike_1a.cpp`; not committed.)
-   - **1b. World texture. — DONE (2026-06-15, `cc0ae79`).** Added
-     `sdl_spectator_world_texture` (STREAMING, ARGB8888), allocated **once per
-     level** at the level size clamped to `kSpectatorWorldTextureMax` (4096) via
-     the pure, unit-tested `SpectatorWorldTextureSize`. Implemented as a lazy
-     `EnsureSpectatorWorldTexture(need_w, need_h)` (grows only; no per-frame
-     realloc) rather than in `OnWindowResize`, because the world texture is
-     level-sized and window-resize-independent (the spectator renderer persists
-     across window resizes; only `SetVideoMode`'s renderer-destroy invalidates
-     it, where it's nulled for lazy rebuild). Each frame `SDL_UpdateTexture`
-     uploads only the used `kScrW×kScrH` sub-rect, then `Gfx::DrawSpectatorGpu`
-     `SDL_RenderTexture`s it (sub-rect srcrect → letterboxed dstrect from the
-     shared `ComputeSpectatorDstRect`, `SDL_SCALEMODE_LINEAR`). Replaced the
-     `ScaleDrawArea`/memcpy composite block in `SpectatorViewport::Draw`.
-   - **1c. HUD overlay. — DONE (2026-06-15, `cc0ae79`).** In the GPU path the
-     world-pass clear of `renderer.bmp` switched from `Fill(renderer.bmp, 0)`
-     (opaque `pal32[0]`) to the new `FillTransparent` (ARGB `0x00000000`); the
-     HUD draws into that same native-res `single_screen_renderer.bmp` (now
-     HUD-only) and uploads to the existing `sdl_spectator_texture` (now
-     `SDL_BLENDMODE_BLEND`), `SDL_RenderTexture`d on top of the world. Bars/text
-     helpers write opaque `pal32` ARGB and keep working. `ScaleDraw`'s
-     per-channel fade is reproduced via `SDL_SetTextureColorMod` on both layers
-     so the spectator fade-in survives.
-   - **1d. Scope the GPU path correctly. — DONE (2026-06-15, `cc0ae79`).**
-     `Gfx::SpectatorGpuComposite()` enables the path only when `spectator_window`
-     is set, a live `sdl_spectator_renderer`/`sdl_spectator_texture` exist, and
-     `primary_renderer != &single_screen_renderer` (so single-screen replay to
-     the main window keeps the CPU `Gfx::Draw` path). The flag is set per frame
-     before each spectator-viewport draw and `gpu_world_src` reset, so a frame
-     that doesn't redraw the viewport (menu over a frozen game) falls back to the
-     CPU present. The dummy driver / videotool never satisfy the guard. Headless
-     smoke (dummy driver) launches clean.
-   - **1e. Retain `ScaleDrawArea`. — DONE (kept intact).** The CPU composite
-     branch (videotool / single-screen replay) still box-filters the scratch into
-     `bmp` via `ScaleDrawArea`; `test_blit` unchanged (83 assertions, green).
-     Note: videotool is off by default (needs system ffmpeg) so it wasn't
-     rebuilt; its `ScaleDrawArea` caller is untouched.
-   - **1f. Profile to confirm. — DONE (2026-06-15, on real hardware).** Tracy on
-     the 4096² level, worms at max separation:
-     - GPU composite alone (`cc0ae79`): the ~38 ms CPU composite zone dropped to
-       ~0, but the 1:1 world pass + 64 MB texture upload remained → **~34 ms**
-       total at 1280×800 (`local:draw` 21 ms incl. `DrawLevel` 5.9 ms; `Gfx::Flip`
-       11 ms incl. the upload). Over budget.
-     - Downscaled world pass (`e0a0d6c`, see 1g): **~20 ms** at 3440×1440 (4.95 Mpx
-       window) at max zoom-out. The world pass and its upload are now bounded by
-       the window, not the level; the residual is dominated by the two
-       full-window texture uploads (world + HUD overlay) + present, which scale
-       with window pixels.
-     - **Outcome:** a large improvement (≈34→20 ms) but **still above the 14 ms
-       budget at very large windows**. Accepted for now per playtest. Further
-       gains would come from shrinking/scoping the per-frame uploads (HUD
-       dirty-region upload, or capping the spectator render resolution
-       independently of window size) — tracked as a follow-on, not blocking.
-   - **1g. Downscaled world pass. — DONE (2026-06-15, `e0a0d6c`).** Render the
-     world pass at ~output resolution when `zoom < 1` instead of 1:1, so its CPU
-     cost and texture upload are bounded by the window rather than the level
-     area. `ComputeWorldPassScratch` (unit-tested) gives `scale = min(1, zoom)`
-     and a scratch ≤ the render surface; new `DrawLevelScaled` / `BlitImageScaled`
-     (nearest-neighbour) render terrain and sprites scaled down. `zoom ≥ 1` keeps
-     the existing 1:1 path byte-for-byte (no change for small maps). The
-     downscaled path draws the visually-significant world (terrain, worms +
-     ninjarope, bonuses, s/w/n-objects, blood) and **omits** detail that is
-     sub-pixel/illegible at that zoom (shadows, text labels, fire cones, laser
-     sight, aim crosshair, AI debug). The world texture is now window-bounded, so
-     `SpectatorWorldTextureSize`/the 4096 ceiling were removed.
-   - **1h. Spectator presentation bug fixes (found on real hardware).**
-     - **Pause crash / blank (`703af23`).** `MainMenuState::Enter` calls `Flip()`
-       directly (outside `RunOneFrame`), so a stale `gpu_world_src` from the last
-       gameplay frame drove `DrawSpectatorGpu` against the just-resized menu
-       layout → heap overread. Fixed by making `gpu_world_src` a strict one-shot
-       (gated on, and cleared by, every Flip); non-gameplay frames fall back to
-       the CPU present.
-     - **Black spectator at start / pause until resize (`4f7a187`).** The GPU
-       fade `SDL_SetTextureColorMod` leaked onto the shared `sdl_spectator_texture`
-       (at fade 0 → multiply-by-black); the CPU present path never reset it.
-       Fixed by restoring neutral colormod after each GPU present.
+Decouple the spectator render resolution from the window size: render at
+`min(window, cap)` preserving aspect, and let the **existing**
+`SDL_SetRenderLogicalPresentation` upscale to the physical window (that
+mechanism is already in place at `gfx.cpp` ~:407). This bounds **all five**
+window-sized costs (both memsets, the world draw, both uploads) by a constant
+cap instead of the window.
 
-2. **Frustum-cull the sprite and shadow passes.** — **DONE** (`bd8cb77`, PR7 Task 2)
-   Every worm, wobject, nobject, bonus, and sobject now gets a cheap AABB check
-   against the visible world rect `[x, x+scratch_w) × [y, y+scratch_h)` before each
-   `BlitImage` / `BlitShadowImage`.
+- **Cap value:** start with **1920×1080**, exposed as a hidden-menu setting
+  (mirror an existing numeric setting — pattern: `IntegerBehavior`, `gfx.cpp`
+  ~:1129; settings field + cereal nvp + `kConfigVersion` bump, `settings.hpp` /
+  `cereal_types.hpp`). A single "max spectator render height" (derive width from
+  window aspect) is simpler than two axes and probably sufficient. Default the
+  cap so today's behavior is reproduced when window ≤ cap.
+- **Where to apply:** the spectator renderer's `SetRenderResolution` and the
+  paired `SDL_SetRenderLogicalPresentation` (both in `Gfx::OnWindowResize`,
+  `gfx.cpp` ~:405-414) take `min(window, cap)` instead of the raw window size.
+  `render_res_x/y` then carries the capped size; the world dst-rect math and HUD
+  layout follow automatically. The physical present (logical→window) upscales on
+  the GPU.
+- **Expected:** under 14 ms on its own at 4K.
+- **Cost / tradeoff:** HUD text is upscaled with the world and goes slightly
+  soft. Acceptable for an overview window; if not, add Task 2.
+- **Verify:** re-profile (Tracy zones already in place: `SpectatorViewport::Draw`,
+  `Spectator::WorldPass::*`, `Spectator::Composite::GpuHandoff`,
+  `Gfx::DrawSpectatorGpu`, `Gfx::Flip`) at 3440×1440 and 3840×2160, max
+  zoom-out. Confirm the memsets/uploads shrank to the cap. Visual check: small
+  maps (zoom ≥ 1, window ≤ cap) must be **byte-for-byte unchanged**. Smoke-launch
+  under the dummy driver (the GPU path is guarded off there — must still not
+  crash). `test_spectator_zoom` / `test_blit` stay green; add a unit case for the
+  capped-resolution computation (pure helper, mirror `ComputeWorldPassScratch`
+  in `test_spectator_zoom.cpp`).
 
-3. **SIMD / vectorised `ScaleDrawArea`.**
-   If the CPU downscale path is retained (e.g. for the videotool offline
-   render), the inner accumulation loop in `ScaleDrawArea` (`blit.cpp`) is a
-   natural auto-vectorisation candidate.  Only pursue this if tasks 1 and 2
-   leave a measurable remainder in the profile.
+#### Task 2 — Partial HUD upload + partial clear (optional, keeps HUD crisp)
 
-4. **Cap minimum zoom.**
-   A configurable floor (e.g. 0.25×) below which the viewport stops zooming out
-   and pans to the midpoint instead gives a hard upper bound on scratch size
-   independent of worm separation.  Expose as a hidden-menu option.  This is a
-   UX trade-off rather than a pure optimisation, so treat it as optional and
-   decide based on playtest feedback.
+Only needed if the soft HUD from Task 1 is unacceptable, or if Task 1 alone
+leaves a remainder. Keep the HUD overlay at native resolution but stop touching
+the whole buffer: track the HUD's dirty bands (bottom ~40 px strip; the banner
+near `banner_y`; the `y=164` "Reloading" text — see the HUD block
+`spectatorviewport.cpp:704-842`) and only `FillTransparent` + `SDL_UpdateTexture`
+those sub-rects. Cuts ~40 MB/frame of HUD traffic to ~1 MB. Stacks cleanly on
+Task 1 (crisp native HUD over a capped world). Watch: bands must cover the
+previous frame's HUD extent too, so moving text (banner scroll) doesn't leave
+stale pixels.
 
-5. **Audit and fix any other hot paths found in step 0.**
-   Document findings and fixes here as they are discovered.
+#### Task 3 — Render the world pass into a locked texture (optional, only if still over budget)
 
-#### Ordering
+`SDL_LockTexture` the world texture, render the **downscaled** pass straight into
+its pixels, unlock — removes the scratch→texture memcpy *and* the scratch memset.
+Medium risk: locked texture memory is typically write-combined (slow reads), so
+this is only safe because the downscaled pass omits shadows (the read-modify-write
+path). The 1:1 path (zoom ≥ 1, small maps) does RMW shadows and must **not** use
+the locked path. Reach for this last.
 
-Do step 0 first.  Steps 1 and 2 are independent; step 1 gives the larger
-speedup.  Steps 3 and 4 are conditional on profiling results.
+### Explicitly deferred / not pursued
 
-- **Mergeable because**: purely display-side; does not touch simulation, net
-  protocol, or on-disk format.
-- **Validate**: confirm frame time is within budget at 1280×800 and 1920×1080
-  with a 4096² level and worms at maximum separation.  Run `test_blit` to
-  confirm `ScaleDrawArea` correctness is unchanged.  Smoke-launch +
-  clang-format/tidy diff.
+- **SIMD `ScaleDrawArea`** (old PR7 Task 3): irrelevant to the GPU spectator path
+  — only the videotool/CPU composite (`spectatorviewport.cpp:676-702`) still uses
+  `ScaleDrawArea`. Leave it for an offline-render perf pass if ever needed.
+- **Minimum-zoom cap** (old PR7 Task 4): Task 1 already bounds cost, so a zoom
+  floor is now a pure UX/visibility choice, not a performance need.
+- **Dirty-rectangle sharing with rollback:** declined in PR 7 — `Level`'s dirty
+  tracking is cumulative/never-cleared and terrain-only; sprites move every frame
+  and aren't tracked. The GPU composite makes terrain caching moot.
+
+### Mergeable because
+
+Purely display-side: does not touch simulation, net protocol, or on-disk format.
+The cap is the only new user-visible surface (a hidden-menu setting + one config
+version bump).
 
 ## Validation (every PR)
 
@@ -454,34 +223,25 @@ SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 8 ./install/linux-x64/bin/op
 scripts/clang-format-diff.sh && scripts/clang-tidy-diff.sh build/linux-x64
 ```
 
-## Risks
+For PR 8, additionally re-profile with Tracy on real hardware at 3440×1440 and
+3840×2160, 4096² level, worms at max separation, and confirm frame time < 14 ms.
+
+## Risks (open)
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| 4096² test asset bloats git (~117 MB) | High | D5 — generate on demand |
-| AI/stats overflow on large maps | High pre-PR1 | PR1 makes them dynamic before any large map can load |
-| New magic collides with legacy material bytes | Low | 8-byte distinctive magic at file start; legacy path unchanged |
-| Net play with mismatched sizes | Low | Wire transfer already sends + validates w/h |
-| Memory at 4096² (~117 MB layers + AI) | Medium | D2 cap; fail loudly past 4096; document cost |
-| Determinism regressions from PR1/PR3 sim touch | Medium | `test_determinism`/`test_rollback_*` on every PR |
-| Rollback snapshot too large for online play on big maps | High (4096²) | PR6 — dirty-cell tracking; PR2 already fixed correctness |
-| Spectator world-pass cost O((W×H)/zoom²) on large native windows | High | PR7 — GPU-scale world pass; frustum cull sprites |
-| PR7-1a: `SDL_SetRenderLogicalPresentation(LETTERBOX)` conflicts with manual dest-rect scaling | ~~Medium~~ **Resolved** | Spike (Task 1a, 2026-06-15) proved no conflict: logical size == window pixels ⇒ uniform transform, manual dest rect lands pixel-exact. Keep logical presentation. |
-| PR7-1b: per-frame world-texture upload (≤16 MB+, grows with scratch) becomes the new cost | Medium | Still ≪ 38 ms; cap world-texture max size; measure in Task 1f |
-| PR7-1c: HUD transparency/blend regressions (today's clear is opaque black) | Low | Clear HUD buffer to alpha 0; visual check; HUD is small |
-| PR7-1d: GPU path crashes/no-ops under dummy driver (CI smoke) or in single-screen-replay primary-renderer mode | Medium | Guard on live spectator renderer/window; keep `Gfx::Draw` CPU path for those modes |
+| PR8 Task 1: capped-res HUD text too soft | Medium | Default cap ≥ 1080p; add Task 2 (native-res partial HUD) if playtest dislikes it |
+| PR8 Task 1: small-map / zoom≥1 path accidentally changed | Low | Cap is a no-op when window ≤ cap; assert byte-exact small-map output in test |
+| PR8 Task 1: re-break the two PR7 present bugs (`703af23`, `4f7a187`) | Medium | Keep `gpu_world_src` one-shot + neutral-colormod-restore invariants; smoke-launch incl. pause/menu |
+| PR8 Task 3: locked write-combined texture slow on the RMW (zoom≥1) path | Medium | Use locked path only for the shadow-omitting downscaled pass |
+| Memory at 4096² (~117 MB layers + AI) | Medium | 4096 cap; fail loudly past it |
 
 ## Acceptance
 
-- [x] PR1: all 504×350 hardcodes read `level.width/height`; behavior unchanged; suites green.
-- [x] PR2: new sized format loads/saves; legacy files still load; 4096² level generates on demand; tools + doc updated.
-- [x] PR3: random map size editable in MATCH SETUP; config v5; defaults reproduce 504×350.
-- [x] PR4: spectator auto-zooms to keep both worms visible; 1× on small maps unchanged; minimap scales correctly; weapon-select spectator view correct at all sizes; native-resolution spectator window.
-- [x] PR5: videotool output resolution selectable; scaler input dynamic.
-- [x] PR6: online play on 4096² level no longer noticeably slower than local play; rollback tests green.
-- [~] PR7: spectator frame time greatly improved (≈34→20 ms) via GPU composite +
-  downscaled world pass; pause/start spectator bugs fixed. **Not strictly within
-  the 14 ms budget** at very large windows (≈20 ms at 3440×1440, max zoom-out) —
-  the residual is the two full-window texture uploads, accepted for now. Frustum
-  cull (Task 2) done; Tasks 3/4 (SIMD, min-zoom cap) left as optional follow-ons.
-- [ ] Determinism/rollback suites + format checks pass on every PR.
+- [x] PR1–PR6: see status table above (all merged).
+- [x] PR7 ([#114]): spectator GPU composite + downscaled world pass + frustum
+  cull; pause/start spectator bugs fixed; ≈45 → ≈20 ms. **Not yet within 14 ms**
+  at very large windows.
+- [ ] **PR8: spectator frame time < 14 ms at 3440×1440 and 3840×2160, 4096²,
+  max zoom-out** — via render-resolution cap (Task 1; Tasks 2/3 as needed).
+  Small-map (zoom ≥ 1) output unchanged. Determinism/rollback suites green.

--- a/.claude/plans/arbitrary-map-sizes.plan.md
+++ b/.claude/plans/arbitrary-map-sizes.plan.md
@@ -1,16 +1,18 @@
 # Plan: Arbitrary Map Sizes + Zooming Spectator Viewport + Configurable Videotool Resolution
 
-**Complexity**: Large (originally 5 sequenced PRs; PRs 1–7 landed, PR 8 is the active work)
+**Complexity**: Large (originally 5 sequenced PRs; PRs 1–7 landed, PR 8 code complete and in review — pending real-HW profiling)
 
 ## Summary
 
 Adds: (1) arbitrary map sizes up to 4096×4096 via a new sized on-disk level
 format (legacy headerless 504×350 still loads), (2) a spectator viewport that
 auto-zooms to keep both worms visible on large maps, and (3) a selectable output
-resolution for the videotool. PRs 1–7 are **merged to master**. The remaining
-work (**PR 8**) pushes the spectator frame time under the 14 ms budget on very
-large (4K-class) windows — see the dedicated section at the bottom; everything
-above it is background.
+resolution for the videotool. PRs 1–7 are **merged to master**. **PR 8** pushes
+the spectator frame time under the 14 ms budget on very large (4K-class) windows;
+its code (Tasks 1 & 2) is **complete, tested, and committed** on branch
+`spectator-render-resolution-cap` and open as a PR — the only remaining work is
+real-hardware Tracy profiling + a visual playtest to close acceptance. See the
+PR 8 section at the bottom; everything above it is background.
 
 ## Decisions (still load-bearing)
 
@@ -100,11 +102,26 @@ worms at max separation). Still **above the 14 ms budget at very large windows**
 
 ---
 
-## PR 8 — Bound the spectator cost by a render-resolution cap (ACTIVE)
+## PR 8 — Bound the spectator cost by a render-resolution cap (CODE DONE; PENDING REAL-HW PROFILE)
 
 **Goal:** spectator frame time within the 14 ms budget at 4K-class windows
 (3440×1440 and 3840×2160), 4096² level, worms at maximum separation (full
 zoom-out — the worst case).
+
+**Status (handover):** Tasks 1 and 2 are **implemented, tested, and committed**
+on branch `spectator-render-resolution-cap` (full ctest 274/274, determinism +
+rollback green, clang-format/clang-tidy clean, dummy-driver smoke clean). What
+is **not** done and is the only thing between here and closing the acceptance
+box: (a) the **real-hardware Tracy re-profile** confirming < 14 ms (cannot run
+headless), and (b) a **visual spectator playtest** (the GPU present path is
+guarded off under the dummy driver, so band correctness was proven by code
+enumeration + a full-refresh safety net, not observed). Task 3 remains unstarted
+and is only needed if (a) shows a remainder. One facet of Task 2 (native-res
+crisp HUD) was deliberately deferred — see its section.
+
+Commits: `ComputeCappedRenderResolution` helper + test, the cap wiring (Task 1),
+`ComputeHudDirtyBands` helper + test, and the partial HUD clear/upload wiring
+(Task 2).
 
 ### Problem analysis (profiling-grounded; re-confirm before/after on real HW)
 
@@ -140,51 +157,74 @@ consistently.
 
 ### Approach (in priority order)
 
-#### Task 1 — Cap the spectator internal render resolution (primary fix, low risk)
+#### Task 1 — Cap the spectator internal render resolution (primary fix, low risk) — ✅ DONE
 
-Decouple the spectator render resolution from the window size: render at
-`min(window, cap)` preserving aspect, and let the **existing**
-`SDL_SetRenderLogicalPresentation` upscale to the physical window (that
-mechanism is already in place at `gfx.cpp` ~:407). This bounds **all five**
-window-sized costs (both memsets, the world draw, both uploads) by a constant
-cap instead of the window.
+**Shipped.** The spectator now renders at `min(window, cap)` preserving aspect,
+and the existing `SDL_SetRenderLogicalPresentation` upscales the capped surface
+to the physical window. This bounds all five window-sized costs (both memsets,
+the world draw, both uploads) by the cap instead of the window.
 
-- **Cap value:** start with **1920×1080**, exposed as a hidden-menu setting
-  (mirror an existing numeric setting — pattern: `IntegerBehavior`, `gfx.cpp`
-  ~:1129; settings field + cereal nvp + `kConfigVersion` bump, `settings.hpp` /
-  `cereal_types.hpp`). A single "max spectator render height" (derive width from
-  window aspect) is simpler than two axes and probably sufficient. Default the
-  cap so today's behavior is reproduced when window ≤ cap.
-- **Where to apply:** the spectator renderer's `SetRenderResolution` and the
-  paired `SDL_SetRenderLogicalPresentation` (both in `Gfx::OnWindowResize`,
-  `gfx.cpp` ~:405-414) take `min(window, cap)` instead of the raw window size.
-  `render_res_x/y` then carries the capped size; the world dst-rect math and HUD
-  layout follow automatically. The physical present (logical→window) upscales on
-  the GPU.
-- **Expected:** under 14 ms on its own at 4K.
-- **Cost / tradeoff:** HUD text is upscaled with the world and goes slightly
-  soft. Acceptable for an overview window; if not, add Task 2.
-- **Verify:** re-profile (Tracy zones already in place: `SpectatorViewport::Draw`,
-  `Spectator::WorldPass::*`, `Spectator::Composite::GpuHandoff`,
-  `Gfx::DrawSpectatorGpu`, `Gfx::Flip`) at 3440×1440 and 3840×2160, max
-  zoom-out. Confirm the memsets/uploads shrank to the cap. Visual check: small
-  maps (zoom ≥ 1, window ≤ cap) must be **byte-for-byte unchanged**. Smoke-launch
-  under the dummy driver (the GPU path is guarded off there — must still not
-  crash). `test_spectator_zoom` / `test_blit` stay green; add a unit case for the
-  capped-resolution computation (pure helper, mirror `ComputeWorldPassScratch`
-  in `test_spectator_zoom.cpp`).
+- **Pure helper** `ComputeCappedRenderResolution(window_w, window_h, cap_h)`
+  (`spectatorviewport.{hpp,cpp}`): caps height to `cap_h`, derives width from the
+  window aspect; a no-op when `cap_h <= 0` (disabled) or `window_h <= cap_h`
+  (so small windows are byte-for-byte unchanged); ≥1px width guard. Six
+  `[spectator][rescap]` cases in `test_spectator_zoom.cpp`.
+- **Applied** in `Gfx::OnWindowResize` (the spectator branch, ~`gfx.cpp:406`):
+  the texture, draw surface, `SDL_SetRenderLogicalPresentation`, and
+  `SetRenderResolution` all take the capped `kW/kH`. `render_res_x/y` then
+  carries the capped size; world dst-rect math and HUD layout follow.
+- **Setting** `max_spectator_render_height` (`AppSettings`, default **1080**,
+  `0` = disabled): hidden-menu item "MAX SPECTATOR RES (H)"
+  (`IntegerBehavior`, range 0–4320 step 120), cereal nvp
+  `maxSpectatorRenderHeight`, `kConfigVersion` 5 → **6** (missing key → 1080).
+  Takes effect on the next spectator-window resize / video-mode change.
+- **Cost / tradeoff:** HUD text is upscaled with the world and goes slightly soft
+  at the cap — Task 2's deferred facet (native-res HUD) would restore crispness.
+- **Outstanding verify (real HW):** re-profile (Tracy zones already in place:
+  `SpectatorViewport::Draw`, `Spectator::WorldPass::*`,
+  `Spectator::Composite::GpuHandoff`, `Gfx::DrawSpectatorGpu`, `Gfx::Flip`) at
+  3440×1440 and 3840×2160, max zoom-out; confirm the memsets/uploads shrank to
+  the cap and a small map (zoom ≥ 1, window ≤ cap) is unchanged.
 
-#### Task 2 — Partial HUD upload + partial clear (optional, keeps HUD crisp)
+#### Task 2 — Partial HUD upload + partial clear — ✅ DONE (cost half); native-res HUD facet DEFERRED
 
-Only needed if the soft HUD from Task 1 is unacceptable, or if Task 1 alone
-leaves a remainder. Keep the HUD overlay at native resolution but stop touching
-the whole buffer: track the HUD's dirty bands (bottom ~40 px strip; the banner
-near `banner_y`; the `y=164` "Reloading" text — see the HUD block
-`spectatorviewport.cpp:704-842`) and only `FillTransparent` + `SDL_UpdateTexture`
-those sub-rects. Cuts ~40 MB/frame of HUD traffic to ~1 MB. Stacks cleanly on
-Task 1 (crisp native HUD over a capped world). Watch: bands must cover the
-previous frame's HUD extent too, so moving text (banner scroll) doesn't leave
-stale pixels.
+**Shipped (the cost win).** The HUD overlay no longer clears/uploads the whole
+window-sized buffer each frame; only the dirty bands.
+
+- **Pure helper** `ComputeHudDirtyBands(render_h, banner_y, prev_banner_y)`
+  (`spectatorviewport.{hpp,cpp}`): returns the full-width rows the HUD actually
+  touches — bottom 40 px stats strip, the `y=164` reloading text, and a banner
+  band that **unions current+previous frame** so a scrolling banner leaves no
+  stale row — clamped to `[0, render_h)`, off-screen bands dropped. Band extents
+  were derived by enumerating every `DrawBar`/`DrawString`/`FillRect` in the HUD
+  block (glyph height 8, bars ≤5 px, all inside the 40 px strip; the holdazone/
+  tag timer resolves to `render_h − 39`, also inside it) → coverage is provably
+  complete. Four `[spectator][hudbands]` cases.
+- **`FillTransparentBand(bmp, y, h)`** (`blit.{hpp,cpp}`) clears banded rows.
+- **`SpectatorViewport::Draw`** clears only the bands (full clear on a resolution
+  change) and hands them to the renderer (plain-int fields on `Renderer`);
+  `prev_banner_y` + overlay dims tracked on the viewport.
+- **`Gfx::DrawSpectatorGpu`** uploads only those bands. The first GPU frame after
+  a resolution change *or any CPU present* (menu/pause/alloc-fail fallback)
+  re-uploads the whole overlay, since the texture's untouched rows would
+  otherwise be stale — guarded by `spectator_prev_present_gpu`, maintained in
+  `Flip` and `DrawSpectatorGpu`. (This is the safety net that lets band
+  correctness be asserted without a live GPU to observe.)
+- **Effect:** per-frame HUD clear+upload drops from the full overlay (~16 MB at a
+  1080 cap) to the bands (~1 MB), stacking on Task 1.
+
+**Deferred facet — native-resolution crisp HUD.** The plan also framed Task 2 as
+"keep the HUD overlay at *native* resolution" for crispness. That was **not**
+done: with Task 1 the HUD renders at the capped resolution and is upscaled
+(slightly soft). Making it crisp requires **decoupling the HUD's render
+resolution from the world's** — the HUD block draws into `renderer.bmp` using
+`renderer.render_res_y` / `render_w`, all currently the capped size, and
+`single_screen_renderer` is shared with single-screen replay — so this is a
+non-trivial refactor (two resolutions threaded through one Draw, or a separate
+native-res HUD bitmap+texture). It is a **playtest-gated quality call** ("only if
+the soft HUD is unacceptable"), so it waits on the real-HW playtest. If pursued:
+keep the world capped, give the HUD its own native-res overlay bitmap/texture,
+and recompute the bands in native-res coordinates.
 
 #### Task 3 — Render the world pass into a locked texture (optional, only if still over budget)
 
@@ -230,10 +270,11 @@ For PR 8, additionally re-profile with Tracy on real hardware at 3440×1440 and
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| PR8 Task 1: capped-res HUD text too soft | Medium | Default cap ≥ 1080p; add Task 2 (native-res partial HUD) if playtest dislikes it |
-| PR8 Task 1: small-map / zoom≥1 path accidentally changed | Low | Cap is a no-op when window ≤ cap; assert byte-exact small-map output in test |
-| PR8 Task 1: re-break the two PR7 present bugs (`703af23`, `4f7a187`) | Medium | Keep `gpu_world_src` one-shot + neutral-colormod-restore invariants; smoke-launch incl. pause/menu |
-| PR8 Task 3: locked write-combined texture slow on the RMW (zoom≥1) path | Medium | Use locked path only for the shadow-omitting downscaled pass |
+| PR8 Task 1: capped-res HUD text too soft | Medium | **Open (playtest):** default cap 1080; native-res HUD facet of Task 2 deferred until playtest judges softness |
+| PR8 Task 1: small-map / zoom≥1 path accidentally changed | Low | **Mitigated:** cap is a no-op when window ≤ cap; `[rescap]` test asserts identity; verify on real HW |
+| PR8 Task 1/2: re-break the two PR7 present bugs (`703af23`, `4f7a187`) | Medium | **Code-mitigated, needs playtest:** `gpu_world_src` one-shot + neutral-colormod-restore untouched; Task 2 adds the `spectator_prev_present_gpu` full-refresh guard; dummy-driver smoke clean — but pause/menu visuals unobserved (no GPU here) |
+| PR8 Task 2: dirty bands miss a HUD region → stale/ghost pixels | Medium | **Code-mitigated:** bands derived by exhaustive enumeration of the HUD draws + full-refresh on resize/CPU-present; **confirm by playtest** (death-banner scroll, pause round-trip) |
+| PR8 Task 3 (not started): locked write-combined texture slow on RMW (zoom≥1) | Medium | Use locked path only for the shadow-omitting downscaled pass; only pursue if real-HW profile still over budget |
 | Memory at 4096² (~117 MB layers + AI) | Medium | 4096 cap; fail loudly past it |
 
 ## Acceptance
@@ -242,6 +283,12 @@ For PR 8, additionally re-profile with Tracy on real hardware at 3440×1440 and
 - [x] PR7 ([#114]): spectator GPU composite + downscaled world pass + frustum
   cull; pause/start spectator bugs fixed; ≈45 → ≈20 ms. **Not yet within 14 ms**
   at very large windows.
-- [ ] **PR8: spectator frame time < 14 ms at 3440×1440 and 3840×2160, 4096²,
-  max zoom-out** — via render-resolution cap (Task 1; Tasks 2/3 as needed).
-  Small-map (zoom ≥ 1) output unchanged. Determinism/rollback suites green.
+- [x] **PR8 code:** Task 1 (render-resolution cap + hidden-menu setting, config
+  v6) and Task 2 (partial HUD clear/upload) implemented with unit tests; full
+  ctest 274/274, determinism/rollback green, clang-format/clang-tidy clean,
+  dummy-driver smoke clean. Branch `spectator-render-resolution-cap`.
+- [ ] **PR8 acceptance (real HW, blocks closing):** spectator frame time < 14 ms
+  at 3440×1440 and 3840×2160, 4096², max zoom-out (Tracy re-profile); + visual
+  playtest confirming no HUD ghosting (banner scroll, pause/menu round-trip) and
+  unchanged small-map output. If still over budget → Task 3. If HUD too soft →
+  native-res HUD facet of Task 2.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,13 @@ if(OPENLIERO_BUILD_TESTS)
   target_link_libraries(test_spectator_zoom PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_spectator_zoom DISCOVERY_MODE PRE_TEST)
 
+  add_executable(test_spectator_visibility src/tests/test_spectator_visibility.cpp)
+  target_link_libraries(test_spectator_visibility PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_spectator_visibility
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DISCOVERY_MODE PRE_TEST
+  )
+
   add_executable(test_minimap src/tests/test_minimap.cpp)
   target_link_libraries(test_minimap PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_minimap DISCOVERY_MODE PRE_TEST)

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -420,6 +420,11 @@ void Gfx::OnWindowResize(uint32_t window_id) {
       // Blend so the GPU HUD overlay (PR7 Task 1c) composites over the world;
       // harmless for the CPU present path, whose frames are fully opaque.
       SDL_SetTextureBlendMode(sdl_spectator_texture, SDL_BLENDMODE_BLEND);
+      // Point-sample the HUD overlay so the small pixel font stays crisp when
+      // SDL upscales the capped surface to a larger window (PR8 cap). The world
+      // texture keeps linear sampling (smooth downscaled overview); only the
+      // HUD must avoid the blur, which made it unreadable above the cap.
+      SDL_SetTextureScaleMode(sdl_spectator_texture, SDL_SCALEMODE_NEAREST);
       sdl_spectator_draw_surface = SDL_CreateSurface(kW, kH, SDL_PIXELFORMAT_ARGB8888);
       SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, kW, kH,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1593,13 +1593,17 @@ bool Gfx::RunOneFrame() {
       controller->Unfocus();
       ClearKeys();
 
-      // Restore spectator renderer to the actual window pixel size now that
-      // it's no longer shared with the main window.
+      // Restore the spectator renderer to its windowed render resolution now
+      // that it's no longer shared with the main window. Route through
+      // OnWindowResize so the render resolution, the SDL logical presentation
+      // and the textures are all re-derived together through the PR8 render
+      // cap (ComputeCappedRenderResolution). Setting render_res to the raw
+      // window size here instead would desync it from the capped logical
+      // presentation: the world dst rect would be computed in the larger
+      // window space while SDL clips it to the smaller capped canvas, pushing
+      // the right/bottom of the world — and any worm there — off-screen.
       if (sdl_spectator_window && settings->spectator_window) {
-        int w = 0;
-        int h = 0;
-        SDL_GetWindowSize(sdl_spectator_window, &w, &h);
-        single_screen_renderer.SetRenderResolution(w, h);
+        OnWindowResize(SDL_GetWindowID(sdl_spectator_window));
       }
 
       // Draw one frame so the menu background captures the final game state

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -1711,7 +1711,20 @@ void Gfx::SetSpectatorLayout(bool fixed) {
     target_w = 640;
     target_h = 400;
   } else {
-    SDL_GetWindowSize(sdl_spectator_window, &target_w, &target_h);
+    int win_w = 0;
+    int win_h = 0;
+    SDL_GetWindowSize(sdl_spectator_window, &win_w, &win_h);
+    // Apply the PR8 render cap so this per-frame render resolution matches the
+    // capped textures and SDL logical presentation that OnWindowResize set.
+    // Without it, on a window taller than the cap (e.g. 3440x1440 -> 2580x1080)
+    // render_res would be reset to the full window every frame while the HUD
+    // and world textures stay capped: the HUD's bottom rows then fall outside
+    // the shorter HUD texture (the HUD vanishes) and the world is clipped to
+    // the capped canvas (worms can leave the screen).
+    CappedRenderResolution const kCap =
+        ComputeCappedRenderResolution(win_w, win_h, settings->max_spectator_render_height);
+    target_w = kCap.w;
+    target_h = kCap.h;
   }
   if (single_screen_renderer.render_res_x != target_w ||
       single_screen_renderer.render_res_y != target_h) {

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -413,20 +413,20 @@ void Gfx::OnWindowResize(uint32_t window_id) {
       // surface back to the physical window. A no-op when window_h <= cap.
       CappedRenderResolution const kCap =
           ComputeCappedRenderResolution(window_w, window_h, settings->max_spectator_render_height);
-      int w = kCap.w;
-      int h = kCap.h;
+      int const kW = kCap.w;
+      int const kH = kCap.h;
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
-                                                SDL_TEXTUREACCESS_STREAMING, w, h);
+                                                SDL_TEXTUREACCESS_STREAMING, kW, kH);
       // Blend so the GPU HUD overlay (PR7 Task 1c) composites over the world;
       // harmless for the CPU present path, whose frames are fully opaque.
       SDL_SetTextureBlendMode(sdl_spectator_texture, SDL_BLENDMODE_BLEND);
-      sdl_spectator_draw_surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_ARGB8888);
-      SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, w, h,
+      sdl_spectator_draw_surface = SDL_CreateSurface(kW, kH, SDL_PIXELFORMAT_ARGB8888);
+      SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, kW, kH,
                                        SDL_LOGICAL_PRESENTATION_LETTERBOX);
       // Only resize the renderer when it isn't being used as primary renderer
       // for the main window (i.e. during single-screen replay).
       if (primary_renderer != &single_screen_renderer) {
-        single_screen_renderer.SetRenderResolution(w, h);
+        single_screen_renderer.SetRenderResolution(kW, kH);
       }
     }
   }
@@ -1079,6 +1079,7 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
   if (!sdl_spectator_world_texture) {
     // Allocation failed; present via the CPU path so the window isn't black.
     Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer, renderer);
+    spectator_prev_present_gpu = false;
     return;
   }
 
@@ -1088,9 +1089,24 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
       .x = 0, .y = 0, .w = renderer.gpu_world_used_w, .h = renderer.gpu_world_used_h};
   SDL_UpdateTexture(sdl_spectator_world_texture, &kUsed, world.pixels,
                     static_cast<int>(world.pitch * sizeof(uint32_t)));
-  // HUD overlay: native-res, transparent background, opaque HUD pixels.
-  SDL_UpdateTexture(sdl_spectator_texture, nullptr, renderer.bmp.pixels,
-                    static_cast<int>(renderer.bmp.pitch * sizeof(uint32_t)));
+  // HUD overlay: transparent background, opaque HUD pixels. Upload only the
+  // dirty bands (PR8 Task 2) — except the first GPU frame after a resolution
+  // change or a CPU present, which must refresh the whole overlay since the
+  // texture's untouched rows would otherwise hold stale content.
+  int const kHudPitchBytes = static_cast<int>(renderer.bmp.pitch * sizeof(uint32_t));
+  bool const kFullHud = renderer.hud_overlay_full_refresh || !spectator_prev_present_gpu;
+  if (kFullHud) {
+    SDL_UpdateTexture(sdl_spectator_texture, nullptr, renderer.bmp.pixels, kHudPitchBytes);
+  } else {
+    for (int i = 0; i < renderer.hud_overlay_band_count; ++i) {
+      int const kY = renderer.hud_overlay_band_y[i];
+      SDL_Rect const kBand{
+          .x = 0, .y = kY, .w = renderer.render_res_x, .h = renderer.hud_overlay_band_h[i]};
+      uint32_t const* const kRows =
+          renderer.bmp.pixels + static_cast<std::size_t>(kY) * renderer.bmp.pitch;
+      SDL_UpdateTexture(sdl_spectator_texture, &kBand, kRows, kHudPitchBytes);
+    }
+  }
 
   // Replicate ScaleDraw's per-channel fade ((v*fade)>>5, fade 0..32) via RGB
   // texture modulation so the spectator fade-in survives; alpha is left intact
@@ -1122,6 +1138,10 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
   // recreated the texture.
   SDL_SetTextureColorMod(sdl_spectator_world_texture, 255, 255, 255);
   SDL_SetTextureColorMod(sdl_spectator_texture, 255, 255, 255);
+
+  // This GPU present owns the overlay texture now, so the next GPU frame may
+  // upload just its dirty bands (PR8 Task 2).
+  spectator_prev_present_gpu = true;
 }
 
 void Gfx::Flip() {
@@ -1141,6 +1161,9 @@ void Gfx::Flip() {
     } else {
       Draw(*sdl_spectator_draw_surface, *sdl_spectator_texture, *sdl_spectator_renderer,
            single_screen_renderer);
+      // This CPU present fully overwrote the overlay texture; force the next GPU
+      // frame to re-upload the whole overlay rather than just its dirty bands.
+      spectator_prev_present_gpu = false;
     }
     single_screen_renderer.gpu_world_src = nullptr;
   }

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -38,6 +38,7 @@
 #include "gfx/macros.hpp"
 
 #include "menu/arrayEnumBehavior.hpp"
+#include "spectatorviewport.hpp"
 
 // NOLINTNEXTLINE(bugprone-throwing-static-initialization, cert-err58-cpp) — global Gfx is the platform singleton; an exception here means program startup itself has failed.
 Gfx gfx;
@@ -403,9 +404,17 @@ void Gfx::OnWindowResize(uint32_t window_id) {
     }
 
     if (settings->spectator_window) {
-      int w = 0;
-      int h = 0;
-      SDL_GetWindowSize(sdl_spectator_window, &w, &h);
+      int window_w = 0;
+      int window_h = 0;
+      SDL_GetWindowSize(sdl_spectator_window, &window_w, &window_h);
+      // PR8 Task 1: cap the internal render resolution so the world pass, its
+      // memsets and its texture uploads are bounded by a constant on 4K-class
+      // windows. SDL_SetRenderLogicalPresentation (below) upscales the capped
+      // surface back to the physical window. A no-op when window_h <= cap.
+      CappedRenderResolution const kCap =
+          ComputeCappedRenderResolution(window_w, window_h, settings->max_spectator_render_height);
+      int w = kCap.w;
+      int h = kCap.h;
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
                                                 SDL_TEXTUREACCESS_STREAMING, w, h);
       // Blend so the GPU HUD overlay (PR7 Task 1c) composites over the world;
@@ -439,6 +448,8 @@ void Gfx::LoadMenus() {
   hidden_menu.AddItem(MenuItem(48, 7, "SEE SPAWN POINT", HiddenMenu::kAllowViewingSpawnPoint));
   hidden_menu.AddItem(MenuItem(48, 7, "SINGLE SCREEN REPLAY", HiddenMenu::kSingleScreenReplay));
   hidden_menu.AddItem(MenuItem(48, 7, "SPECTATOR WINDOW", HiddenMenu::kSpectatorWindow));
+  hidden_menu.AddItem(
+      MenuItem(48, 7, "MAX SPECTATOR RES (H)", HiddenMenu::kMaxSpectatorRenderHeight));
 
   player_menu.AddItem(MenuItem(3, 7, "PROFILE LOADED", PlayerMenu::kPlLoadedProfile));
   player_menu.AddItem(MenuItem(3, 7, "SAVE PROFILE", PlayerMenu::kPlSaveProfile));

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -347,6 +347,11 @@ struct Gfx {
   SDL_Texture* sdl_spectator_world_texture = nullptr;
   int sdl_spectator_world_texture_w = 0;
   int sdl_spectator_world_texture_h = 0;
+  // Whether the previous spectator present went through DrawSpectatorGpu. The
+  // HUD overlay partial upload (PR8 Task 2) is only safe to apply over a texture
+  // the GPU path itself last wrote; after a CPU present (menu/pause/fallback)
+  // the next GPU frame must re-upload the whole overlay.
+  bool spectator_prev_present_gpu = false;
   // a software surface to do the actual drawing into
   SDL_Surface* sdl_draw_surface = nullptr;
   // a software surface to do the actual drawing of the spectator view into

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -42,6 +42,16 @@ void Fill(Bitmap& scr, int color) {
 
 void FillTransparent(Bitmap& scr) { std::fill(scr.pixels, scr.pixels + scr.pitch * scr.h, 0U); }
 
+void FillTransparentBand(Bitmap& scr, int y, int h) {
+  int const kY0 = std::max(0, y);
+  int const kY1 = std::min(scr.h, y + h);
+  if (kY1 <= kY0) {
+    return;
+  }
+  std::fill(scr.pixels + static_cast<std::size_t>(kY0) * scr.pitch,
+            scr.pixels + static_cast<std::size_t>(kY1) * scr.pitch, 0U);
+}
+
 void DrawLevelScaled(Bitmap& scr, Level const& level, int view_x, int view_y, float scale) {
   float const kInv = 1.0F / scale;
   for (int py = 0; py < scr.h; ++py) {

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -21,6 +21,10 @@ void Fill(Bitmap& scr, int color);
 // blend over the GPU-scaled world: only the drawn HUD pixels (opaque pal32)
 // show, everything else is see-through.
 void FillTransparent(Bitmap& scr);
+// Clears just the full-width rows [y, y+h) of `scr` to transparent (clamped to
+// the bitmap). The spectator partial-present path (PR8 Task 2) uses this to
+// clear only the HUD's dirty bands instead of the whole window-sized overlay.
+void FillTransparentBand(Bitmap& scr, int y, int h);
 void DrawBar(Bitmap& scr, int x, int y, int width, int color);
 void DrawBar(Bitmap& scr, int x, int y, int width, int height, int color);
 void DrawRoundedBox(Bitmap& scr, int x, int y, int color, int height, int width);

--- a/src/game/gfx/renderer.hpp
+++ b/src/game/gfx/renderer.hpp
@@ -61,4 +61,17 @@ struct Renderer {
   int gpu_world_dst_y = 0;
   int gpu_world_dst_w = 0;
   int gpu_world_dst_h = 0;
+
+  // ── Spectator HUD overlay partial present (PR8 Task 2) ─────────────────────
+  // The HUD overlay only touches a few full-width rows; the spectator viewport
+  // clears and the GPU present uploads just these bands instead of the whole
+  // window-sized overlay. When hud_overlay_full_refresh is true (first frame /
+  // resolution change) the whole overlay is cleared and uploaded so the
+  // never-touched regions start transparent. Bands are kept as plain ints to
+  // avoid a renderer→spectator header dependency; see ComputeHudDirtyBands.
+  bool hud_overlay_full_refresh = true;
+  static constexpr int kMaxHudBands = 3;
+  int hud_overlay_band_count = 0;
+  int hud_overlay_band_y[kMaxHudBands] = {};
+  int hud_overlay_band_h[kMaxHudBands] = {};
 };

--- a/src/game/menu/hiddenMenu.cpp
+++ b/src/game/menu/hiddenMenu.cpp
@@ -49,6 +49,11 @@ ItemBehavior* HiddenMenu::GetItemBehavior(Common& common, MenuItem& item) {
         gfx.settings->spectator_window = v;
         gfx.SetVideoMode();
       });
+    // 0 disables the cap (render at the full window); steps of 120 line up with
+    // standard heights (720/1080/1440/2160). Applied on the next spectator
+    // window resize / video-mode change (see Gfx::OnWindowResize).
+    case kMaxSpectatorRenderHeight:
+      return new IntegerBehavior(common, gfx.settings->max_spectator_render_height, 0, 4320, 120);
 
     default:
       return Menu::GetItemBehavior(common, item);

--- a/src/game/menu/hiddenMenu.hpp
+++ b/src/game/menu/hiddenMenu.hpp
@@ -24,6 +24,7 @@ struct HiddenMenu : Menu {
     kSingleScreenReplay,
     kSpectatorWindow,
     kColorMode,
+    kMaxSpectatorRenderHeight,
   };
 
   HiddenMenu(int x, int y) : Menu(x, y) {}

--- a/src/game/serialization/cereal_types.hpp
+++ b/src/game/serialization/cereal_types.hpp
@@ -189,6 +189,8 @@ void SerializeSettingsScalars(Archive& ar, Settings& s) {
   // v5 fields. Missing on older configs → defaults remain (504x350).
   ar(cereal::make_nvp("randomMapWidth", s.random_map_width));
   ar(cereal::make_nvp("randomMapHeight", s.random_map_height));
+  // v6 field. Missing on older configs → default remains (1080).
+  ar(cereal::make_nvp("maxSpectatorRenderHeight", s.max_spectator_render_height));
 }
 
 // Full Settings fields for binary archives (indexed weapon keys).

--- a/src/game/settings.hpp
+++ b/src/game/settings.hpp
@@ -37,6 +37,12 @@ struct AppSettings {
   int32_t blood_particle_max{700};
   // Default colour mode for the renderers (sticky; live mode is per-renderer).
   bool modern_colors{false};
+  // PR8 Task 1: cap on the spectator window's internal render height. The world
+  // pass, its memsets and texture uploads scale with the render surface, so this
+  // bounds them by a constant on 4K-class windows (width derived from the window
+  // aspect; see ComputeCappedRenderResolution). <=0 disables the cap; a no-op
+  // when the spectator window is no taller than this. Display-only.
+  int32_t max_spectator_render_height{1080};
 };
 
 struct Rand;
@@ -88,7 +94,8 @@ struct Settings : GameplayExtensions, AppSettings {
   // bump when adding fields to the TOML config
   // v4: added modernColors (default false = classic palette).
   // v5: added randomMapWidth/Height (defaults 504x350).
-  static int const kConfigVersion = 5;
+  // v6: added maxSpectatorRenderHeight (default 1080).
+  static int const kConfigVersion = 6;
   std::shared_ptr<WormSettings> worm_settings[kNumWormSettings];
 
   uint64_t hash;

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -154,7 +154,6 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   Common& common = *game.common;
   render_w = renderer.render_res_x;
   render_h = renderer.render_res_y;
-  int const kMultiplier = render_w / 320;
   int const kCenterX = render_w / 2;
 
   // ── World pass ────────────────────────────────────────────────────────────
@@ -777,7 +776,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     ZoneScopedN("Spectator::HUD");
     for (std::size_t i = 0; i < game.worms.size(); ++i) {
       Worm const& worm = *game.worms[i];
-      int const kHudX = worm.stats_x * kMultiplier;
+      // Left worm (stats_x==0): left-anchored at the left edge.
+      // Right worm (stats_x>0): right-anchored so the HUD sits the same
+      // distance from the right edge as it does in a 320px split-screen
+      // viewport (320 - stats_x - 100 = 2px gap at full health).
+      int const kHudX = (worm.stats_x == 0) ? 0 : (render_w - (320 - worm.stats_x));
       int const kOffsetWeaponListX = kCenterX - 15 + (i == 0 ? -90 : 60);
 
       if (worm.visible) {

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -62,6 +62,42 @@ CappedRenderResolution ComputeCappedRenderResolution(int window_w, int window_h,
   return {.w = kW, .h = cap_h};
 }
 
+HudDirtyBands ComputeHudDirtyBands(int render_h, int banner_y, int prev_banner_y) {
+  // Glyph height (Font::DrawChar draws 8 rows at size 1); the banner adds a 1px
+  // drop shadow. The bottom stats strip spans the lowest 40px (weapon list,
+  // life/ammo bars, kills/name/time text, colour box). y=164 is the fixed
+  // "Reloading" text row. These match the draws in SpectatorViewport::Draw's
+  // HUD block — keep them in sync if those move.
+  constexpr int kTextH = 8;
+  constexpr int kBottomStripH = 40;
+  constexpr int kReloadingY = 164;
+  constexpr int kBannerHiddenY = -8;  // banner_y == -8 means hidden (not drawn)
+
+  HudDirtyBands out{};
+
+  // Append [y, y+h) clamped to [0, render_h); drop if it ends up empty.
+  auto push = [&](int y, int h) {
+    int const kY0 = std::max(0, y);
+    int const kY1 = std::min(render_h, y + h);
+    if (kY1 > kY0 && out.count < HudDirtyBands::kMaxBands) {
+      out.bands[out.count++] = {.y = kY0, .h = kY1 - kY0};
+    }
+  };
+
+  push(render_h - kBottomStripH, kBottomStripH);
+  push(kReloadingY, kTextH);
+
+  // Banner band spans both frames' extents so a scrolling banner clears the row
+  // it vacated. Skipped only when hidden in both frames (nothing was drawn).
+  int const kLo = std::min(banner_y, prev_banner_y);
+  int const kHi = std::max(banner_y, prev_banner_y);
+  if (kHi > kBannerHiddenY) {
+    push(kLo, (kHi + kTextH + 1) - kLo);
+  }
+
+  return out;
+}
+
 void SpectatorViewport::Process(Game& game) {
   int const kRenderW = render_w;
   int const kRenderH = render_h;
@@ -686,7 +722,28 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     renderer.gpu_world_dst_y = kDst.y;
     renderer.gpu_world_dst_w = kDst.w;
     renderer.gpu_world_dst_h = kDst.h;
-    FillTransparent(renderer.bmp);
+
+    // Partial overlay clear (PR8 Task 2): clear only the rows the HUD will draw
+    // into this frame plus the previous frame's banner row, leaving the rest of
+    // the (already transparent) overlay untouched. Force a full clear on the
+    // first frame / after a resolution change so the never-touched regions start
+    // transparent. The same bands drive the partial texture upload in
+    // Gfx::DrawSpectatorGpu.
+    bool const kFullRefresh = (render_w != hud_overlay_w || render_h != hud_overlay_h);
+    HudDirtyBands const kBands = ComputeHudDirtyBands(render_h, banner_y, prev_banner_y);
+    if (kFullRefresh) {
+      FillTransparent(renderer.bmp);
+    } else {
+      for (int i = 0; i < kBands.count; ++i) {
+        FillTransparentBand(renderer.bmp, kBands.bands[i].y, kBands.bands[i].h);
+      }
+    }
+    renderer.hud_overlay_full_refresh = kFullRefresh;
+    renderer.hud_overlay_band_count = kBands.count;
+    for (int i = 0; i < kBands.count; ++i) {
+      renderer.hud_overlay_band_y[i] = kBands.bands[i].y;
+      renderer.hud_overlay_band_h[i] = kBands.bands[i].h;
+    }
   } else {
     // CPU path (videotool, single-screen replay, dummy driver): box-filter the
     // scratch straight into `bmp` as before. Retains ScaleDrawArea (Task 1e).
@@ -854,4 +911,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
       }
     }
   }  // end HUD zone
+
+  // Remember this frame's banner position and overlay size so next frame's
+  // partial-present (PR8 Task 2) can union the banner band and detect a
+  // resolution change.
+  prev_banner_y = banner_y;
+  hud_overlay_w = render_w;
+  hud_overlay_h = render_h;
 }

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -48,6 +48,20 @@ WorldPassScratch ComputeWorldPassScratch(int render_w, int render_h, float zoom,
   return {.w = kW, .h = kH, .scale = kScale};
 }
 
+CappedRenderResolution ComputeCappedRenderResolution(int window_w, int window_h, int cap_h) {
+  // Disabled, or the window already fits under the cap → render at native res
+  // (never upscale). Small-window output stays byte-for-byte unchanged.
+  if (cap_h <= 0 || window_h <= cap_h) {
+    return {.w = window_w, .h = window_h};
+  }
+  // Pin height to the cap, derive width from the window aspect so the spectator
+  // overview keeps its shape (ultrawide stays ultrawide). lroundf for symmetric
+  // rounding; guard against a sub-pixel width on extreme aspect ratios.
+  float const kScale = static_cast<float>(cap_h) / static_cast<float>(window_h);
+  int const kW = std::max(1, static_cast<int>(std::lroundf(static_cast<float>(window_w) * kScale)));
+  return {.w = kW, .h = cap_h};
+}
+
 void SpectatorViewport::Process(Game& game) {
   int const kRenderW = render_w;
   int const kRenderH = render_h;

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -53,6 +53,25 @@ struct CappedRenderResolution {
 };
 CappedRenderResolution ComputeCappedRenderResolution(int window_w, int window_h, int cap_h);
 
+// HUD overlay dirty bands (PR8 Task 2). The spectator HUD overlay (drawn over
+// the GPU-composited world) only ever touches a few full-width horizontal
+// strips: the bottom ~40px stats strip, the y=164 "Reloading" text, and the
+// scrolling death banner near banner_y. Tracking these lets the GPU present
+// path clear and upload just those rows instead of the whole window-sized
+// overlay each frame. The banner band spans both the current and previous
+// frame's y so a scrolling banner never leaves a stale row behind. Bands are
+// clamped to [0, render_h); off-screen strips are dropped. Pure so it can be
+// unit-tested.
+struct HudBand {
+  int y, h;
+};
+struct HudDirtyBands {
+  static constexpr int kMaxBands = 3;
+  HudBand bands[kMaxBands];
+  int count;
+};
+HudDirtyBands ComputeHudDirtyBands(int render_h, int banner_y, int prev_banner_y);
+
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -90,4 +90,12 @@ struct SpectatorViewport : Viewport {
   // renderer resolution without needing a Renderer& parameter.
   int render_w{640};
   int render_h{400};
+  // Previous frame's banner_y and overlay dimensions, for the HUD partial
+  // present (PR8 Task 2): the banner band unions both frames so a scrolling
+  // banner leaves no stale row, and a dimension change forces a full overlay
+  // refresh. -1 dims mean "no overlay drawn yet" → first frame is a full
+  // refresh.
+  int prev_banner_y{-8};
+  int hud_overlay_w{-1};
+  int hud_overlay_h{-1};
 };

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -38,6 +38,21 @@ struct WorldPassScratch {
 WorldPassScratch ComputeWorldPassScratch(int render_w, int render_h, float zoom, int level_w,
                                          int level_h);
 
+// Capped spectator render resolution (PR8 Task 1). The spectator world pass,
+// its memsets and its texture uploads all scale with the render surface, not
+// the map; on very large (4K-class) windows that pushes the frame past budget
+// while the zoomed-out world is already sub-pixel. This caps the *internal*
+// render height to `cap_h` (deriving width from the window aspect) so all those
+// costs are bounded by a constant; the existing SDL_SetRenderLogicalPresentation
+// upscales the capped surface back to the physical window. A no-op (returns the
+// window size unchanged) when `cap_h <= 0` (disabled) or `window_h <= cap_h`
+// (small windows render at native res, byte-for-byte unchanged). Pure so it can
+// be unit-tested.
+struct CappedRenderResolution {
+  int w, h;
+};
+CappedRenderResolution ComputeCappedRenderResolution(int window_w, int window_h, int cap_h);
+
 struct SpectatorViewport : Viewport {
   explicit SpectatorViewport(Rect rect) : Viewport(rect, 0) {}
 

--- a/src/tests/test_random_map_size.cpp
+++ b/src/tests/test_random_map_size.cpp
@@ -23,8 +23,8 @@ TEST_CASE("Settings random_map_height defaults to 350", "[random-map-size]") {
   CHECK(kS.random_map_height == 350);
 }
 
-TEST_CASE("Settings config version is 5", "[random-map-size]") {
-  CHECK(Settings::kConfigVersion == 5);
+TEST_CASE("Settings config version is 6", "[random-map-size]") {
+  CHECK(Settings::kConfigVersion == 6);
 }
 
 // ---------------------------------------------------------------------------
@@ -45,9 +45,9 @@ TEST_CASE("Settings random_map dimensions round-trip through TOML", "[random-map
   CHECK(loaded.random_map_height == 192);
 }
 
-TEST_CASE("Settings TOML contains version = 5", "[random-map-size]") {
+TEST_CASE("Settings TOML contains version = 6", "[random-map-size]") {
   Settings const kSettings;
-  CHECK(kSettings.ToToml().contains("version = 5"));
+  CHECK(kSettings.ToToml().contains("version = 6"));
 }
 
 // Configs written before v5 lack randomMapWidth/randomMapHeight.

--- a/src/tests/test_spectator_visibility.cpp
+++ b/src/tests/test_spectator_visibility.cpp
@@ -1,0 +1,130 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <memory>
+
+#include "common.hpp"
+#include "filesystem.hpp"
+#include "game.hpp"
+#include "level.hpp"
+#include "math.hpp"
+#include "mixer/player.hpp"
+#include "settings.hpp"
+#include "spectatorviewport.hpp"
+#include "worm.hpp"
+
+// Drives a real Game + SpectatorViewport::Process at a capped spectator render
+// resolution and asserts that, wherever the two worms are, they both land inside
+// the world region the spectator actually draws. Reproduces the report that with
+// PR8's render-resolution cap a worm can be moved off the spectator screen.
+namespace {
+
+struct SpectatorFixture {
+  std::shared_ptr<Common> common;
+  std::shared_ptr<Settings> settings;
+  std::shared_ptr<SoundPlayer> sound;
+  std::unique_ptr<Game> game;
+  std::unique_ptr<SpectatorViewport> vp;
+
+  SpectatorFixture(int level_w, int level_h) {
+    PrecomputeTables();
+    common = std::make_shared<Common>();
+    common->load(FsNode("data") / "TC" / "openliero");
+
+    settings = std::make_shared<Settings>();
+    settings->random_level = true;
+    settings->random_map_width = level_w;
+    settings->random_map_height = level_h;
+    settings->game_mode = Settings::kGmKillEmAll;
+
+    sound = std::make_shared<NullSoundPlayer>();
+    game = std::make_unique<Game>(common, settings, sound);
+    game->rand.Seed(42);
+
+    for (int idx = 0; idx < 2; ++idx) {
+      auto w = std::make_shared<Worm>();
+      w->settings = settings->worm_settings[idx];
+      w->health = w->settings->health;
+      w->index = idx;
+      w->visible = true;
+      game->AddWorm(w);
+    }
+
+    game->level.GenerateFromSettings(*common, *settings, game->rand);
+    for (auto const& w : game->worms) {
+      w->InitWeapons(*game);
+    }
+
+    vp = std::make_unique<SpectatorViewport>(Rect(0, 0, 640, 400));
+    game->AddSpectatorViewport(vp.get());
+  }
+
+  void SetRenderResolution(int w, int h) const {
+    vp->render_w = w;
+    vp->render_h = h;
+  }
+
+  void PlaceWorm(int idx, int x, int y) const { game->worms[idx]->pos = Itof(IVec2(x, y)); }
+
+  // Reproduces the visible world region the Draw path actually samples and
+  // composites (see SpectatorViewport::Draw): the [x, x+kViewW) x [y, y+kViewH)
+  // rectangle, where kViewW/kViewH are clamped to the level like Draw does.
+  void CheckBothWormsVisible(const char* label) const {
+    vp->Process(*game);
+    int const kViewW =
+        std::min(static_cast<int>(static_cast<float>(vp->render_w) / vp->zoom), game->level.width);
+    int const kViewH =
+        std::min(static_cast<int>(static_cast<float>(vp->render_h) / vp->zoom), game->level.height);
+    for (int idx = 0; idx < 2; ++idx) {
+      int const kWx = Ftoi(game->worms[idx]->pos.x);
+      int const kWy = Ftoi(game->worms[idx]->pos.y);
+      INFO(label << " worm " << idx << " at (" << kWx << "," << kWy << ") view=[" << vp->x << ","
+                 << (vp->x + kViewW) << ")x[" << vp->y << "," << (vp->y + kViewH)
+                 << ") zoom=" << vp->zoom << " render=" << vp->render_w << "x" << vp->render_h
+                 << " level=" << game->level.width << "x" << game->level.height);
+      CHECK(kWx >= vp->x);
+      CHECK(kWx < vp->x + kViewW);
+      CHECK(kWy >= vp->y);
+      CHECK(kWy < vp->y + kViewH);
+    }
+  }
+};
+
+}  // namespace
+
+TEST_CASE("spectator keeps both worms visible on a large map (capped res)",
+          "[spectator][visibility]") {
+  // Large map, capped 1920x1080 spectator render surface (e.g. a 4K window).
+  SpectatorFixture f(2000, 2000);
+  f.SetRenderResolution(1920, 1080);
+
+  // Worms close together near the centre.
+  f.PlaceWorm(0, 980, 980);
+  f.PlaceWorm(1, 1020, 1020);
+  f.CheckBothWormsVisible("close");
+
+  // Worms moderately apart.
+  f.PlaceWorm(0, 400, 400);
+  f.PlaceWorm(1, 1600, 1600);
+  f.CheckBothWormsVisible("mid");
+
+  // Worms at opposite corners — the worst case for zoom-out.
+  f.PlaceWorm(0, 30, 30);
+  f.PlaceWorm(1, 1970, 1970);
+  f.CheckBothWormsVisible("corners");
+
+  // One worm hugging an edge while the other is far away.
+  f.PlaceWorm(0, 1990, 1000);
+  f.PlaceWorm(1, 50, 1000);
+  f.CheckBothWormsVisible("horizontal-spread");
+}
+
+TEST_CASE("spectator keeps both worms visible on a wide map (capped res)",
+          "[spectator][visibility]") {
+  SpectatorFixture f(4000, 700);
+  f.SetRenderResolution(1920, 1080);
+
+  f.PlaceWorm(0, 50, 350);
+  f.PlaceWorm(1, 3950, 350);
+  f.CheckBothWormsVisible("wide-extremes");
+}

--- a/src/tests/test_spectator_visibility.cpp
+++ b/src/tests/test_spectator_visibility.cpp
@@ -24,7 +24,7 @@ struct SpectatorFixture {
   std::shared_ptr<Settings> settings;
   std::shared_ptr<SoundPlayer> sound;
   std::unique_ptr<Game> game;
-  std::unique_ptr<SpectatorViewport> vp;
+  SpectatorViewport vp{Rect(0, 0, 640, 400)};
 
   SpectatorFixture(int level_w, int level_h) {
     PrecomputeTables();
@@ -55,13 +55,12 @@ struct SpectatorFixture {
       w->InitWeapons(*game);
     }
 
-    vp = std::make_unique<SpectatorViewport>(Rect(0, 0, 640, 400));
-    game->AddSpectatorViewport(vp.get());
+    game->AddSpectatorViewport(&vp);
   }
 
-  void SetRenderResolution(int w, int h) const {
-    vp->render_w = w;
-    vp->render_h = h;
+  void SetRenderResolution(int w, int h) {
+    vp.render_w = w;
+    vp.render_h = h;
   }
 
   void PlaceWorm(int idx, int x, int y) const { game->worms[idx]->pos = Itof(IVec2(x, y)); }
@@ -69,23 +68,23 @@ struct SpectatorFixture {
   // Reproduces the visible world region the Draw path actually samples and
   // composites (see SpectatorViewport::Draw): the [x, x+kViewW) x [y, y+kViewH)
   // rectangle, where kViewW/kViewH are clamped to the level like Draw does.
-  void CheckBothWormsVisible(const char* label) const {
-    vp->Process(*game);
+  void CheckBothWormsVisible(const char* label) {
+    vp.Process(*game);
     int const kViewW =
-        std::min(static_cast<int>(static_cast<float>(vp->render_w) / vp->zoom), game->level.width);
+        std::min(static_cast<int>(static_cast<float>(vp.render_w) / vp.zoom), game->level.width);
     int const kViewH =
-        std::min(static_cast<int>(static_cast<float>(vp->render_h) / vp->zoom), game->level.height);
+        std::min(static_cast<int>(static_cast<float>(vp.render_h) / vp.zoom), game->level.height);
     for (int idx = 0; idx < 2; ++idx) {
       int const kWx = Ftoi(game->worms[idx]->pos.x);
       int const kWy = Ftoi(game->worms[idx]->pos.y);
-      INFO(label << " worm " << idx << " at (" << kWx << "," << kWy << ") view=[" << vp->x << ","
-                 << (vp->x + kViewW) << ")x[" << vp->y << "," << (vp->y + kViewH)
-                 << ") zoom=" << vp->zoom << " render=" << vp->render_w << "x" << vp->render_h
+      INFO(label << " worm " << idx << " at (" << kWx << "," << kWy << ") view=[" << vp.x << ","
+                 << (vp.x + kViewW) << ")x[" << vp.y << "," << (vp.y + kViewH)
+                 << ") zoom=" << vp.zoom << " render=" << vp.render_w << "x" << vp.render_h
                  << " level=" << game->level.width << "x" << game->level.height);
-      CHECK(kWx >= vp->x);
-      CHECK(kWx < vp->x + kViewW);
-      CHECK(kWy >= vp->y);
-      CHECK(kWy < vp->y + kViewH);
+      CHECK(kWx >= vp.x);
+      CHECK(kWx < vp.x + kViewW);
+      CHECK(kWy >= vp.y);
+      CHECK(kWy < vp.y + kViewH);
     }
   }
 };

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -187,6 +187,51 @@ TEST_CASE("capped render resolution never collapses width below 1 pixel", "[spec
   CHECK(kR.w >= 1);
 }
 
+TEST_CASE("hud dirty bands always cover the bottom strip and reloading text",
+          "[spectator][hudbands]") {
+  // Banner hidden (-8 == hidden sentinel): only the static bands. Bottom strip
+  // is the 40px stats area; reloading text sits at y=164.
+  HudDirtyBands const kB = ComputeHudDirtyBands(1080, -8, -8);
+  REQUIRE(kB.count == 2);
+  // Bottom strip [H-40, H).
+  CHECK(kB.bands[0].y == 1040);
+  CHECK(kB.bands[0].h == 40);
+  // Reloading text band [164, 164+8).
+  CHECK(kB.bands[1].y == 164);
+  CHECK(kB.bands[1].h == 8);
+}
+
+TEST_CASE("hud dirty bands add a stationary banner band when visible", "[spectator][hudbands]") {
+  HudDirtyBands const kB = ComputeHudDirtyBands(1080, 100, 100);
+  REQUIRE(kB.count == 3);
+  // Banner glyph (8px) + its 1px shadow row → 9px tall at y=100.
+  CHECK(kB.bands[2].y == 100);
+  CHECK(kB.bands[2].h == 9);
+}
+
+TEST_CASE("hud dirty bands union covers a scrolling banner with no stale row",
+          "[spectator][hudbands]") {
+  // Banner scrolled from y=100 (prev) to y=92 (cur). The band must cover both
+  // extents — [92,101) ∪ [100,109) = [92,109) — so the vacated rows are cleared.
+  HudDirtyBands const kB = ComputeHudDirtyBands(1080, 92, 100);
+  REQUIRE(kB.count == 3);
+  HudBand const kBanner = kB.bands[2];
+  CHECK(kBanner.y == 92);
+  CHECK(kBanner.y + kBanner.h == 109);
+  // Both the current and previous banner extents fall inside the band.
+  CHECK(kBanner.y <= 92);
+  CHECK(kBanner.y + kBanner.h >= 100 + 9);
+}
+
+TEST_CASE("hud dirty bands clamp to the render surface", "[spectator][hudbands]") {
+  // Tiny overlay: the bottom strip clamps into [0,H) and the off-screen
+  // reloading band (y=164 >= H) is dropped.
+  HudDirtyBands const kB = ComputeHudDirtyBands(20, -8, -8);
+  REQUIRE(kB.count == 1);
+  CHECK(kB.bands[0].y == 0);
+  CHECK(kB.bands[0].h == 20);
+}
+
 TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator][zoom]") {
   // Large level, bbox between "fits" and "whole level": zoom follows the
   // worm-framing value and sits strictly inside (fill, 1.0).

--- a/src/tests/test_spectator_zoom.cpp
+++ b/src/tests/test_spectator_zoom.cpp
@@ -133,6 +133,60 @@ TEST_CASE("world pass scratch never collapses below 1 pixel", "[spectator][world
   CHECK(kP.h >= 1);
 }
 
+TEST_CASE("capped render resolution is a no-op when the window fits the cap",
+          "[spectator][rescap]") {
+  // Window shorter than the cap: render at native, byte-for-byte unchanged. This
+  // is the small-window guarantee — the cap must never upscale.
+  CappedRenderResolution const kR = ComputeCappedRenderResolution(1280, 800, 1080);
+  CHECK(kR.w == 1280);
+  CHECK(kR.h == 800);
+}
+
+TEST_CASE("capped render resolution is a no-op when the window equals the cap",
+          "[spectator][rescap]") {
+  // Boundary: window height exactly the cap stays untouched (no off-by-one
+  // downscale of a 1080p window under a 1080 cap).
+  CappedRenderResolution const kR = ComputeCappedRenderResolution(1920, 1080, 1080);
+  CHECK(kR.w == 1920);
+  CHECK(kR.h == 1080);
+}
+
+TEST_CASE("capped render resolution caps a 4K window preserving aspect", "[spectator][rescap]") {
+  // 3840x2160 under a 1080 cap → 1920x1080: height pinned to the cap, width
+  // derived from the 16:9 window aspect (3840*1080/2160 = 1920).
+  CappedRenderResolution const kR = ComputeCappedRenderResolution(3840, 2160, 1080);
+  CHECK(kR.h == 1080);
+  CHECK(kR.w == 1920);
+}
+
+TEST_CASE("capped render resolution caps an ultrawide window preserving aspect",
+          "[spectator][rescap]") {
+  // 3440x1440 under a 1080 cap → 2580x1080 (3440*1080/1440 = 2580): the
+  // ultrawide aspect (~2.39:1) is preserved, not squashed to 16:9.
+  CappedRenderResolution const kR = ComputeCappedRenderResolution(3440, 1440, 1080);
+  CHECK(kR.h == 1080);
+  CHECK(kR.w == 2580);
+}
+
+TEST_CASE("capped render resolution is disabled when the cap is non-positive",
+          "[spectator][rescap]") {
+  // cap_h <= 0 disables the cap entirely → render at the full window.
+  CappedRenderResolution const kDisabled = ComputeCappedRenderResolution(3840, 2160, 0);
+  CHECK(kDisabled.w == 3840);
+  CHECK(kDisabled.h == 2160);
+  CappedRenderResolution const kNeg = ComputeCappedRenderResolution(3840, 2160, -1);
+  CHECK(kNeg.w == 3840);
+  CHECK(kNeg.h == 2160);
+}
+
+TEST_CASE("capped render resolution never collapses width below 1 pixel", "[spectator][rescap]") {
+  // Degenerate guard: a sliver window under a tiny cap must still leave a >=1px
+  // width the renderer can allocate.
+  CappedRenderResolution const kR = ComputeCappedRenderResolution(1, 4000, 1);
+  CHECK(kR.h == 1);
+  CHECK(kR.w >= 1);
+}
+
 TEST_CASE("spectator zoom tracks the bounding box in the mid-range", "[spectator][zoom]") {
   // Large level, bbox between "fits" and "whole level": zoom follows the
   // worm-framing value and sits strictly inside (fill, 1.0).

--- a/src/tests/test_versioning.cpp
+++ b/src/tests/test_versioning.cpp
@@ -328,7 +328,7 @@ TEST_CASE("versioning: Settings toToml/fromToml produces human-readable config",
   CHECK(kToml.contains("[player2]"));
   CHECK(kToml.contains("[network_player]"));
   // Version field present for future-proofing
-  CHECK(kToml.contains("version = 5"));
+  CHECK(kToml.contains("version = 6"));
   // No ptr_wrapper noise
   CHECK(!kToml.contains("ptr_wrapper"));
   CHECK(!kToml.contains("[s]"));
@@ -416,6 +416,26 @@ TEST_CASE("versioning: modernColors round-trips and defaults to classic", "[vers
   toml.replace(kPos, std::string("modernColors = true").length(), "");
   legacy.FromToml(toml);
   CHECK(legacy.modern_colors == false);
+}
+
+TEST_CASE("versioning: maxSpectatorRenderHeight round-trips and defaults to 1080", "[versioning]") {
+  Settings src;
+  src.max_spectator_render_height = 1440;
+  std::string const kToml = src.ToToml();
+  CHECK(kToml.contains("maxSpectatorRenderHeight = 1440"));
+
+  Settings dst;
+  dst.FromToml(kToml);
+  CHECK(dst.max_spectator_render_height == 1440);
+
+  // Configs predating the v6 field keep the struct default (1080).
+  Settings legacy;
+  std::string toml = kToml;
+  auto const kPos = toml.find("maxSpectatorRenderHeight = 1440");
+  REQUIRE(kPos != std::string::npos);
+  toml.replace(kPos, std::string("maxSpectatorRenderHeight = 1440").length(), "");
+  legacy.FromToml(toml);
+  CHECK(legacy.max_spectator_render_height == 1080);
 }
 
 TEST_CASE("versioning: out-of-range worm rgb in TOML is clamped on load", "[versioning]") {


### PR DESCRIPTION
Closes out **PR 8** of the arbitrary-map-sizes plan: bound the spectator frame
cost on very large (4K-class) windows. After PR 7 (#114) every remaining cost in
the spectator path scaled with the **window** pixel count, not the map — at max
zoom-out the whole 4096² level is already sub-pixel, so rendering/uploading at
full 4K buys nothing. This PR bounds those costs by a constant.

Purely display-side: no simulation, net protocol, or on-disk *level* format
changes. Determinism and rollback suites are unaffected.

## Task 1 — render-resolution cap
The spectator renders at `min(window, cap)` preserving aspect; the existing
`SDL_SetRenderLogicalPresentation` upscales the capped surface to the physical
window. This bounds all five window-sized costs (two memsets, the world draw,
two uploads) by the cap.

- Pure helper `ComputeCappedRenderResolution(window_w, window_h, cap_h)` — caps
  height, derives width from the window aspect; no-op when disabled (`cap_h<=0`)
  or `window_h<=cap_h` (small windows byte-for-byte unchanged); ≥1px guard.
- Applied in `Gfx::OnWindowResize` (spectator branch).
- New hidden-menu setting **"MAX SPECTATOR RES (H)"** →
  `max_spectator_render_height` (`AppSettings`, default **1080**, `0`=disabled).
  Config bump `kConfigVersion` 5 → **6** (cereal nvp `maxSpectatorRenderHeight`;
  missing key falls back to 1080).

## Task 2 — partial HUD clear + upload
The HUD overlay only touches a few full-width rows, so the GPU present path now
clears and uploads just those bands instead of the whole window-sized overlay
each frame (~16 MB → ~1 MB at a 1080 cap, on top of Task 1).

- Pure helper `ComputeHudDirtyBands(render_h, banner_y, prev_banner_y)` — bottom
  40px stats strip, the `y=164` reloading text, and a banner band that unions
  the current+previous frame (no stale row on scroll); bands clamped, off-screen
  ones dropped. Extents derived by enumerating every HUD draw → provably
  complete.
- `FillTransparentBand` for banded clears; `SpectatorViewport::Draw` clears only
  the bands (full clear on resolution change) and hands them to the renderer.
- `Gfx::DrawSpectatorGpu` uploads only the bands. The first GPU frame after a
  resolution change **or any CPU present** (menu/pause/fallback) re-uploads the
  whole overlay so the texture's untouched rows can't go stale — guarded by
  `spectator_prev_present_gpu`.

The plan's *native-resolution crisp HUD* facet of Task 2 is **deliberately
deferred** (it needs decoupling the HUD's render resolution from the world's, a
larger refactor, and is a playtest-gated quality call).

## Tests / validation
- TDD: red→green per helper. New `[spectator][rescap]` (6) and
  `[spectator][hudbands]` (4) cases in `test_spectator_zoom`; version guards
  moved to v6 + a `maxSpectatorRenderHeight` round-trip case.
- **Full ctest 274/274**, determinism + rollback green, clang-format (v22) +
  clang-tidy diff clean, dummy-driver smoke-launch clean.

## ⚠️ Reviewer action required before merge (cannot run headless)
1. **Tracy re-profile on real HW** at 3440×1440 and 3840×2160, 4096², worms at
   max separation — confirm spectator frame time **< 14 ms** (the acceptance
   target). If still over → plan's Task 3 (locked-texture world pass).
2. **Visual playtest** of the spectator window — the GPU present path is guarded
   off under the dummy driver, so HUD band correctness rests on code enumeration
   + the full-refresh safety net, not observation. Check for HUD ghosting across
   a **death-banner scroll** and a **pause/menu round-trip**, and that small-map
   (zoom ≥ 1, window ≤ cap) output looks unchanged. If the capped HUD reads too
   soft → the deferred native-res HUD facet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)