### PR TITLE
docs: strip PR/task-number references from inline comments

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -354,8 +354,6 @@ void Game::ProcessFrame() {
     }
   }
 
-  // NOTE: This was originally the beginning of the processing, but has been rotated down to
-  // separate out the drawing
   ++cycles;
 
   if (!common->h[HBonusDisable] && settings->max_bonuses > 0 &&

--- a/src/game/gfx.cpp
+++ b/src/game/gfx.cpp
@@ -407,23 +407,23 @@ void Gfx::OnWindowResize(uint32_t window_id) {
       int window_w = 0;
       int window_h = 0;
       SDL_GetWindowSize(sdl_spectator_window, &window_w, &window_h);
-      // PR8 Task 1: cap the internal render resolution so the world pass, its
-      // memsets and its texture uploads are bounded by a constant on 4K-class
-      // windows. SDL_SetRenderLogicalPresentation (below) upscales the capped
-      // surface back to the physical window. A no-op when window_h <= cap.
+      // Cap the internal render resolution so the world pass, its memsets and
+      // texture uploads are bounded by a constant on 4K-class windows.
+      // SDL_SetRenderLogicalPresentation (below) upscales the capped surface
+      // back to the physical window. A no-op when window_h <= cap.
       CappedRenderResolution const kCap =
           ComputeCappedRenderResolution(window_w, window_h, settings->max_spectator_render_height);
       int const kW = kCap.w;
       int const kH = kCap.h;
       sdl_spectator_texture = SDL_CreateTexture(sdl_spectator_renderer, SDL_PIXELFORMAT_ARGB8888,
                                                 SDL_TEXTUREACCESS_STREAMING, kW, kH);
-      // Blend so the GPU HUD overlay (PR7 Task 1c) composites over the world;
-      // harmless for the CPU present path, whose frames are fully opaque.
+      // Blend so the GPU HUD overlay composites over the world; harmless for
+      // the CPU present path, whose frames are fully opaque.
       SDL_SetTextureBlendMode(sdl_spectator_texture, SDL_BLENDMODE_BLEND);
       // Point-sample the HUD overlay so the small pixel font stays crisp when
-      // SDL upscales the capped surface to a larger window (PR8 cap). The world
-      // texture keeps linear sampling (smooth downscaled overview); only the
-      // HUD must avoid the blur, which made it unreadable above the cap.
+      // SDL upscales the capped surface to the physical window. The world
+      // texture keeps linear sampling for a smooth downscaled overview; only
+      // the HUD needs nearest to avoid blurring the pixel font.
       SDL_SetTextureScaleMode(sdl_spectator_texture, SDL_SCALEMODE_NEAREST);
       sdl_spectator_draw_surface = SDL_CreateSurface(kW, kH, SDL_PIXELFORMAT_ARGB8888);
       SDL_SetRenderLogicalPresentation(sdl_spectator_renderer, kW, kH,
@@ -1046,10 +1046,10 @@ void Gfx::Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_ren
 }
 
 bool Gfx::SpectatorGpuComposite() const {
-  // The GPU composite is spectator-window-only (Task 1d). It needs a live
-  // spectator renderer + overlay texture, and must not fire when the
-  // single-screen renderer is currently the main window's primary renderer
-  // (single-screen replay) — that frame is presented via the CPU Draw path.
+  // The GPU composite is spectator-window-only. It needs a live spectator
+  // renderer + overlay texture, and must not fire when the single-screen
+  // renderer is currently the main window's primary renderer (single-screen
+  // replay) — that frame is presented via the CPU Draw path.
   return settings->spectator_window && sdl_spectator_renderer != nullptr &&
          sdl_spectator_texture != nullptr && primary_renderer != &single_screen_renderer;
 }
@@ -1095,9 +1095,9 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
   SDL_UpdateTexture(sdl_spectator_world_texture, &kUsed, world.pixels,
                     static_cast<int>(world.pitch * sizeof(uint32_t)));
   // HUD overlay: transparent background, opaque HUD pixels. Upload only the
-  // dirty bands (PR8 Task 2) — except the first GPU frame after a resolution
-  // change or a CPU present, which must refresh the whole overlay since the
-  // texture's untouched rows would otherwise hold stale content.
+  // dirty bands — except the first GPU frame after a resolution change or a
+  // CPU present, which must refresh the whole overlay since the texture's
+  // untouched rows would otherwise hold stale content.
   int const kHudPitchBytes = static_cast<int>(renderer.bmp.pitch * sizeof(uint32_t));
   bool const kFullHud = renderer.hud_overlay_full_refresh || !spectator_prev_present_gpu;
   if (kFullHud) {
@@ -1144,8 +1144,8 @@ void Gfx::DrawSpectatorGpu(Renderer& renderer) {
   SDL_SetTextureColorMod(sdl_spectator_world_texture, 255, 255, 255);
   SDL_SetTextureColorMod(sdl_spectator_texture, 255, 255, 255);
 
-  // This GPU present owns the overlay texture now, so the next GPU frame may
-  // upload just its dirty bands (PR8 Task 2).
+  // Record that the overlay texture was last written by the GPU path, so the
+  // next GPU frame may upload just its dirty bands.
   spectator_prev_present_gpu = true;
 }
 
@@ -1600,13 +1600,13 @@ bool Gfx::RunOneFrame() {
 
       // Restore the spectator renderer to its windowed render resolution now
       // that it's no longer shared with the main window. Route through
-      // OnWindowResize so the render resolution, the SDL logical presentation
-      // and the textures are all re-derived together through the PR8 render
-      // cap (ComputeCappedRenderResolution). Setting render_res to the raw
-      // window size here instead would desync it from the capped logical
-      // presentation: the world dst rect would be computed in the larger
-      // window space while SDL clips it to the smaller capped canvas, pushing
-      // the right/bottom of the world — and any worm there — off-screen.
+      // OnWindowResize so the render resolution, the SDL logical presentation,
+      // and the textures are all re-derived together (including the render
+      // cap). Setting render_res to the raw window size here instead would
+      // desync it from the capped logical presentation: the world dst rect
+      // would be computed in the larger window space while SDL clips it to
+      // the smaller capped canvas, pushing the right/bottom of the world —
+      // and any worm there — off-screen.
       if (sdl_spectator_window && settings->spectator_window) {
         OnWindowResize(SDL_GetWindowID(sdl_spectator_window));
       }
@@ -1634,9 +1634,9 @@ bool Gfx::RunOneFrame() {
     UpdateMenuPalettes(kMenuFadingOut);
   }
 
-  // Decide per frame whether the spectator viewport hands its world to the GPU
-  // (Task 1b/1d); reset the handoff so a frame that doesn't redraw the viewport
-  // (e.g. a menu over a frozen game) falls back to the CPU present path.
+  // Decide per frame whether the spectator viewport hands its world to the GPU;
+  // reset the handoff so a frame that doesn't redraw the viewport (e.g. a menu
+  // over a frozen game) falls back to the CPU present path.
   single_screen_renderer.gpu_world_composite = SpectatorGpuComposite();
   single_screen_renderer.gpu_world_src = nullptr;
 
@@ -1719,13 +1719,12 @@ void Gfx::SetSpectatorLayout(bool fixed) {
     int win_w = 0;
     int win_h = 0;
     SDL_GetWindowSize(sdl_spectator_window, &win_w, &win_h);
-    // Apply the PR8 render cap so this per-frame render resolution matches the
-    // capped textures and SDL logical presentation that OnWindowResize set.
-    // Without it, on a window taller than the cap (e.g. 3440x1440 -> 2580x1080)
-    // render_res would be reset to the full window every frame while the HUD
-    // and world textures stay capped: the HUD's bottom rows then fall outside
-    // the shorter HUD texture (the HUD vanishes) and the world is clipped to
-    // the capped canvas (worms can leave the screen).
+    // Match per-frame render resolution to the capped textures and SDL logical
+    // presentation set by OnWindowResize. Without this, on a window taller than
+    // the cap (e.g. 3440x1440 → 2580x1080) render_res would be reset to the
+    // full window every frame while the HUD and world textures stay capped:
+    // the HUD's bottom rows then fall outside the shorter texture (HUD vanishes)
+    // and the world is clipped to the capped canvas (worms can leave the screen).
     CappedRenderResolution const kCap =
         ComputeCappedRenderResolution(win_w, win_h, settings->max_spectator_render_height);
     target_w = kCap.w;

--- a/src/game/gfx.hpp
+++ b/src/game/gfx.hpp
@@ -127,18 +127,17 @@ struct Gfx {
   // draws a given surface onto an SDL texture/renderer, using a given Renderer
   void Draw(SDL_Surface& surface, SDL_Texture& texture, SDL_Renderer& sdl_renderer,
             Renderer& renderer);
-  // Spectator-window-only GPU present (PR7 Task 1b/1c): upload the 1:1 world
-  // pass recorded on `renderer` to a streaming texture, scale it on the GPU
-  // into the letterboxed dest rect, then blend the transparent HUD overlay on
-  // top — replacing the CPU box-filter composite.
+  // Spectator-window-only GPU present: uploads the 1:1 world pass from
+  // `renderer` to a streaming texture, scales it on the GPU into the
+  // letterboxed dest rect, then blends the transparent HUD overlay on top.
   void DrawSpectatorGpu(Renderer& renderer);
   // (Re)allocates `sdl_spectator_world_texture` to at least need_w×need_h. A
   // no-op when the current texture already covers the size, so it allocates
   // once per level rather than per frame.
   void EnsureSpectatorWorldTexture(int need_w, int need_h);
   // Whether this frame's spectator present should use the GPU composite. False
-  // for the CPU paths (Task 1d): no spectator window / renderer, or the
-  // single-screen renderer is currently the main window's primary renderer.
+  // when there is no spectator window/renderer, or when the single-screen
+  // renderer is currently the main window's primary renderer.
   bool SpectatorGpuComposite() const;
   void Flip();
   // Per-frame menu palette rebuild (fade step, rotation, worm colours).
@@ -340,17 +339,16 @@ struct Gfx {
   SDL_Texture* sdl_texture = nullptr;
   // full spectator window size texture that represents the spectator window
   SDL_Texture* sdl_spectator_texture = nullptr;
-  // Streaming texture holding the spectator world pass for the GPU composite
-  // (PR7 Task 1b). Allocated once at the level size (clamped to the ceiling);
-  // each frame only the used sub-rect is uploaded. Belongs to
-  // sdl_spectator_renderer.
+  // Streaming texture holding the spectator world pass for the GPU composite.
+  // Allocated once at the level size (clamped to the ceiling); each frame only
+  // the used sub-rect is uploaded. Belongs to sdl_spectator_renderer.
   SDL_Texture* sdl_spectator_world_texture = nullptr;
   int sdl_spectator_world_texture_w = 0;
   int sdl_spectator_world_texture_h = 0;
   // Whether the previous spectator present went through DrawSpectatorGpu. The
-  // HUD overlay partial upload (PR8 Task 2) is only safe to apply over a texture
-  // the GPU path itself last wrote; after a CPU present (menu/pause/fallback)
-  // the next GPU frame must re-upload the whole overlay.
+  // HUD overlay partial upload is only safe over a texture the GPU path itself
+  // last wrote; after a CPU present (menu/pause/fallback) the next GPU frame
+  // must re-upload the whole overlay.
   bool spectator_prev_present_gpu = false;
   // a software surface to do the actual drawing into
   SDL_Surface* sdl_draw_surface = nullptr;

--- a/src/game/gfx/blit.cpp
+++ b/src/game/gfx/blit.cpp
@@ -786,9 +786,8 @@ void DrawHeatmap(Bitmap& scr, int x, int y, Heatmap& hm) {
 }
 
 // Per-channel fade at composition time. Identical arithmetic to
-// Palette::Fade ((v * amount) >> 5), so fading at composition is
-// value-identical to the old palette fade — and it also applies to
-// frozen/captured ARGB content, which palette fade used to cover.
+// Palette::Fade ((v * amount) >> 5), so it also applies to frozen/captured
+// ARGB content that palette-index fade cannot reach.
 static inline uint32_t FadeArgb(uint32_t c, int amount) {
   uint32_t const kR = (((c >> 16) & 0xFFU) * amount) >> 5;
   uint32_t const kG = (((c >> 8) & 0xFFU) * amount) >> 5;

--- a/src/game/gfx/blit.hpp
+++ b/src/game/gfx/blit.hpp
@@ -17,13 +17,11 @@ void Vline(Bitmap& scr, int x, int y1, int y2, int color);
 void FillRect(Bitmap& scr, int x, int y, int w, int h, int color);
 void Fill(Bitmap& scr, int color);
 // Clears `scr` to fully transparent (ARGB 0x00000000) rather than to a palette
-// colour. Used for the spectator HUD overlay layer (PR7 Task 1c), which must
-// blend over the GPU-scaled world: only the drawn HUD pixels (opaque pal32)
-// show, everything else is see-through.
+// colour. Used for the spectator HUD overlay, which blends over the GPU-scaled
+// world: only drawn HUD pixels (opaque pal32) show; everything else is clear.
 void FillTransparent(Bitmap& scr);
 // Clears just the full-width rows [y, y+h) of `scr` to transparent (clamped to
-// the bitmap). The spectator partial-present path (PR8 Task 2) uses this to
-// clear only the HUD's dirty bands instead of the whole window-sized overlay.
+// the bitmap), for partial HUD overlay updates without clearing the whole surface.
 void FillTransparentBand(Bitmap& scr, int y, int h);
 void DrawBar(Bitmap& scr, int x, int y, int width, int color);
 void DrawBar(Bitmap& scr, int x, int y, int width, int height, int color);
@@ -32,10 +30,10 @@ void DrawRoundedLineBox(Bitmap& scr, int x, int y, int color, int width, int hei
 // Paints the level's appearance into the screen (the terrain draw).
 void DrawLevel(Bitmap& scr, Level const& level, int x, int y);
 
-// Downscaled terrain render for the zoomed-out spectator world pass (PR7
-// Task 1): fills `scr` (sized to ~output resolution) by nearest-sampling the
-// level, so terrain cost is bounded by the window, not the level area. Scratch
-// pixel (px,py) samples world ((view_x,view_y) + (px,py)/scale). `scale` < 1.
+// Downscaled terrain render for the zoomed-out spectator world pass: fills
+// `scr` (sized to ~output resolution) by nearest-sampling the level, so
+// terrain cost is bounded by the window, not the level area. Scratch pixel
+// (px,py) samples world ((view_x,view_y) + (px,py)/scale). `scale` < 1.
 void DrawLevelScaled(Bitmap& scr, Level const& level, int view_x, int view_y, float scale);
 
 // Nearest-neighbour scaled sprite blit (transparent: palette index 0 skipped)

--- a/src/game/gfx/renderer.hpp
+++ b/src/game/gfx/renderer.hpp
@@ -38,12 +38,12 @@ struct Renderer {
   int render_res_x = 320;
   int render_res_y = 200;
 
-  // ── Spectator GPU world composite (PR7 Task 1b/1c) ────────────────────────
+  // ── Spectator GPU world composite ────────────────────────────────────────
   // When true, the spectator viewport hands its 1:1 world pass to the GPU for
-  // scaling instead of running the ~38 ms CPU box-filter into `bmp`, and clears
-  // `bmp` to a transparent HUD-only overlay. Gfx sets this only for the live
-  // spectator window (Task 1d); it stays false for the CPU paths (videotool,
-  // single-screen replay, dummy driver), which keep compositing into `bmp`.
+  // scaling instead of a CPU box-filter into `bmp`, and clears `bmp` to a
+  // transparent HUD-only overlay. Set only for the live spectator window; stays
+  // false for CPU paths (videotool, single-screen replay, dummy driver), which
+  // keep compositing into `bmp`.
   bool gpu_world_composite = false;
   // The 1:1 world pass for the GPU composite, owned by the SpectatorViewport
   // (valid until its next Draw). Null when no world layer was emitted this
@@ -62,7 +62,7 @@ struct Renderer {
   int gpu_world_dst_w = 0;
   int gpu_world_dst_h = 0;
 
-  // ── Spectator HUD overlay partial present (PR8 Task 2) ─────────────────────
+  // ── Spectator HUD overlay partial present ───────────────────────────────────
   // The HUD overlay only touches a few full-width rows; the spectator viewport
   // clears and the GPU present uploads just these bands instead of the whole
   // window-sized overlay. When hud_overlay_full_refresh is true (first frame /

--- a/src/game/serialization/cereal_types.hpp
+++ b/src/game/serialization/cereal_types.hpp
@@ -208,7 +208,7 @@ void serialize(Archive& ar, Settings& s, std::uint32_t const kVersion) {
   for (int i = 0; i < Settings::kNumWormSettings; ++i) {
     ar(cereal::make_nvp("worm" + std::to_string(i), s.worm_settings[i]));
   }
-  (void)kVersion;  // all fields always written now (breaking change)
+  (void)kVersion;  // all fields always written regardless of version
 }
 CEREAL_CLASS_VERSION(Settings, 3);
 

--- a/src/game/settings.hpp
+++ b/src/game/settings.hpp
@@ -37,9 +37,9 @@ struct AppSettings {
   int32_t blood_particle_max{700};
   // Default colour mode for the renderers (sticky; live mode is per-renderer).
   bool modern_colors{false};
-  // PR8 Task 1: cap on the spectator window's internal render height. The world
-  // pass, its memsets and texture uploads scale with the render surface, so this
-  // bounds them by a constant on 4K-class windows (width derived from the window
+  // Cap on the spectator window's internal render height. The world pass, its
+  // memsets and texture uploads scale with the render surface, so this bounds
+  // them by a constant on 4K-class windows (width derived from the window
   // aspect; see ComputeCappedRenderResolution). <=0 disables the cap; a no-op
   // when the spectator window is no taller than this. Display-only.
   int32_t max_spectator_render_height{1080};

--- a/src/game/spectatorviewport.cpp
+++ b/src/game/spectatorviewport.cpp
@@ -160,9 +160,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   // kViewW/kViewH is the visible world region at 1:1. When the level fits
   // (zoom >= 1) the scratch is that region and the world is drawn 1:1 (the GPU
   // upscales it). When zoomed out (zoom < 1) the world is instead rendered at
-  // ~output resolution into a smaller scratch (PR7 Task 1, downscaled pass), so
-  // the world pass and its texture upload are bounded by the window, not the
-  // level area.
+  // ~output resolution into a smaller scratch, so the world pass and its
+  // texture upload are bounded by the window, not the level area.
   int const kViewW =
       std::min(static_cast<int>(static_cast<float>(render_w) / zoom), game.level.width);
   int const kViewH =
@@ -705,11 +704,10 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
   SpectatorDstRect const kDst = ComputeSpectatorDstRect(render_w, render_h, kViewW, kViewH, zoom);
 
   if (renderer.gpu_world_composite) {
-    // GPU path (PR7 Task 1b): hand the world pass to Gfx, which uploads the used
-    // sub-rect to a streaming texture and scales it on the GPU
-    // (SDL_RenderTexture), deleting the ~38 ms CPU box-filter. `bmp` becomes a
-    // transparent HUD-only overlay (Task 1c) blended on top of the world. The
-    // scratch is now bounded by the window, so the texture is sized to the
+    // GPU path: hand the world pass to Gfx, which uploads the used sub-rect
+    // to a streaming texture and scales it on the GPU (SDL_RenderTexture).
+    // `bmp` becomes a transparent HUD-only overlay blended on top of the world.
+    // The scratch is bounded by the window, so the texture is sized to the
     // render surface rather than the level.
     ZoneScopedN("Spectator::Composite::GpuHandoff");
     renderer.gpu_world_src = &scratch_bmp;
@@ -722,12 +720,11 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     renderer.gpu_world_dst_w = kDst.w;
     renderer.gpu_world_dst_h = kDst.h;
 
-    // Partial overlay clear (PR8 Task 2): clear only the rows the HUD will draw
-    // into this frame plus the previous frame's banner row, leaving the rest of
-    // the (already transparent) overlay untouched. Force a full clear on the
-    // first frame / after a resolution change so the never-touched regions start
-    // transparent. The same bands drive the partial texture upload in
-    // Gfx::DrawSpectatorGpu.
+    // Clear only the rows the HUD will draw into this frame plus the previous
+    // frame's banner row, leaving the rest of the overlay untouched. Force a
+    // full clear on the first frame / after a resolution change so untouched
+    // regions start transparent. The same bands drive the partial texture
+    // upload in Gfx::DrawSpectatorGpu.
     bool const kFullRefresh = (render_w != hud_overlay_w || render_h != hud_overlay_h);
     HudDirtyBands const kBands = ComputeHudDirtyBands(render_h, banner_y, prev_banner_y);
     if (kFullRefresh) {
@@ -745,7 +742,7 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     }
   } else {
     // CPU path (videotool, single-screen replay, dummy driver): box-filter the
-    // scratch straight into `bmp` as before. Retains ScaleDrawArea (Task 1e).
+    // scratch straight into `bmp` via ScaleDrawArea.
     ZoneScopedN("Spectator::Composite");
     renderer.gpu_world_src = nullptr;
     if (kDst.x > 0 || kDst.y > 0) {
@@ -915,9 +912,8 @@ void SpectatorViewport::Draw(Game& game, Renderer& renderer, GameState state, bo
     }
   }  // end HUD zone
 
-  // Remember this frame's banner position and overlay size so next frame's
-  // partial-present (PR8 Task 2) can union the banner band and detect a
-  // resolution change.
+  // Remember this frame's banner position and overlay size so the next frame
+  // can union the banner band and detect a resolution change.
   prev_banner_y = banner_y;
   hud_overlay_w = render_w;
   hud_overlay_h = render_h;

--- a/src/game/spectatorviewport.hpp
+++ b/src/game/spectatorviewport.hpp
@@ -25,12 +25,11 @@ struct SpectatorDstRect {
 SpectatorDstRect ComputeSpectatorDstRect(int render_w, int render_h, int scr_w, int scr_h,
                                          float zoom);
 
-// Render resolution of the spectator world pass (PR7 Task 1, downscaled pass).
-// `scale` is the world→scratch factor: 1.0 when zoom ≥ 1 (small maps render
-// 1:1, the GPU upscales) and `zoom` when zoomed out (the world is rendered at
-// ~output resolution so its CPU cost and texture upload are bounded by the
-// window, not the level area). `w`/`h` are the scratch size (the visible world
-// region scaled by `scale`). Pure so it can be unit-tested.
+// Render resolution of the spectator world pass. `scale` is the world→scratch
+// factor: 1.0 when zoom ≥ 1 (small maps render 1:1, the GPU upscales) and
+// `zoom` when zoomed out (the world renders at ~output resolution so its CPU
+// cost and texture upload are bounded by the window, not the level area).
+// `w`/`h` are the scratch dimensions. Pure so it can be unit-tested.
 struct WorldPassScratch {
   int w, h;
   float scale;
@@ -38,30 +37,27 @@ struct WorldPassScratch {
 WorldPassScratch ComputeWorldPassScratch(int render_w, int render_h, float zoom, int level_w,
                                          int level_h);
 
-// Capped spectator render resolution (PR8 Task 1). The spectator world pass,
-// its memsets and its texture uploads all scale with the render surface, not
-// the map; on very large (4K-class) windows that pushes the frame past budget
-// while the zoomed-out world is already sub-pixel. This caps the *internal*
-// render height to `cap_h` (deriving width from the window aspect) so all those
-// costs are bounded by a constant; the existing SDL_SetRenderLogicalPresentation
-// upscales the capped surface back to the physical window. A no-op (returns the
-// window size unchanged) when `cap_h <= 0` (disabled) or `window_h <= cap_h`
-// (small windows render at native res, byte-for-byte unchanged). Pure so it can
-// be unit-tested.
+// Capped spectator render resolution. The spectator world pass, its memsets and
+// texture uploads all scale with the render surface, not the map; on very large
+// (4K-class) windows that pushes the frame past budget while the zoomed-out
+// world is already sub-pixel. This caps the *internal* render height to `cap_h`
+// (deriving width from the window aspect) so those costs are bounded by a
+// constant; SDL_SetRenderLogicalPresentation upscales the capped surface back to
+// the physical window. A no-op when `cap_h <= 0` (disabled) or
+// `window_h <= cap_h` (small windows render at native res). Pure.
 struct CappedRenderResolution {
   int w, h;
 };
 CappedRenderResolution ComputeCappedRenderResolution(int window_w, int window_h, int cap_h);
 
-// HUD overlay dirty bands (PR8 Task 2). The spectator HUD overlay (drawn over
-// the GPU-composited world) only ever touches a few full-width horizontal
-// strips: the bottom ~40px stats strip, the y=164 "Reloading" text, and the
-// scrolling death banner near banner_y. Tracking these lets the GPU present
-// path clear and upload just those rows instead of the whole window-sized
-// overlay each frame. The banner band spans both the current and previous
-// frame's y so a scrolling banner never leaves a stale row behind. Bands are
-// clamped to [0, render_h); off-screen strips are dropped. Pure so it can be
-// unit-tested.
+// HUD overlay dirty bands. The spectator HUD overlay only ever touches a few
+// full-width horizontal strips: the bottom ~40px stats strip, the y=164
+// "Reloading" text, and the scrolling death banner near banner_y. Tracking
+// these lets the GPU present path clear and upload just those rows instead of
+// the whole window-sized overlay each frame. The banner band spans both the
+// current and previous frame's y so a scrolling banner never leaves a stale
+// row behind. Bands are clamped to [0, render_h); off-screen strips dropped.
+// Pure so it can be unit-tested.
 struct HudBand {
   int y, h;
 };
@@ -90,11 +86,10 @@ struct SpectatorViewport : Viewport {
   // renderer resolution without needing a Renderer& parameter.
   int render_w{640};
   int render_h{400};
-  // Previous frame's banner_y and overlay dimensions, for the HUD partial
-  // present (PR8 Task 2): the banner band unions both frames so a scrolling
-  // banner leaves no stale row, and a dimension change forces a full overlay
-  // refresh. -1 dims mean "no overlay drawn yet" → first frame is a full
-  // refresh.
+  // Previous frame's banner_y and overlay dimensions: the banner band unions
+  // both frames so a scrolling banner leaves no stale row, and a dimension
+  // change forces a full overlay refresh. -1 dims mean "no overlay drawn yet"
+  // → first frame is a full refresh.
   int prev_banner_y{-8};
   int hud_overlay_w{-1};
   int hud_overlay_h{-1};

--- a/src/tests/test_blit.cpp
+++ b/src/tests/test_blit.cpp
@@ -196,8 +196,8 @@ TEST_CASE("blitshadowimage shadows only seeshadow terrain", "[blit][shadow]") {
 
   Bitmap& bmp = f.renderer.bmp;
   Fill(bmp, 10);
-  // Old semantics keyed off the screen; paint a screen pixel with rock
-  // colour over SeeShadow terrain to prove the level now decides.
+  // Paint a rock-colour pixel over SeeShadow terrain to verify the level
+  // material decides shadowing, not the screen pixel colour.
   bmp.GetPixel(3, 3) = f.renderer.pal32[20];
 
   PalIdx const kSprite[9] = {7, 7, 7, 7, 7, 7, 7, 7, 7};
@@ -429,17 +429,13 @@ TEST_CASE("scaledrawarea upscales small src to fill larger dest", "[blit][scaled
 
 TEST_CASE("spectator-resize: freeze-restore must not shrink renderer bmp",
           "[blit][spectator-resize]") {
-  // Regression for resize-while-paused segfault (introduced a634c3b).
   // After OnWindowResize, SetRenderResolution sets render_res=1920x1080 and
-  // bmp.pitch=1920.  DrawSpectatorInfo (and WeaponSelection::DrawSpectatorViewports)
-  // called bmp.Copy(frozen_spectator_screen), which shrank bmp.pitch back to
-  // the frozen screen's pre-resize pitch (640).  Flip() then called
-  // ScaleDraw(bmp.pixels, render_res_x=1920, render_res_y=1080, pitch=640,...),
-  // which reads at row y*640 for y up to 1079, accessing offset 690560 in a
-  // 256000-element array — out-of-bounds read — segfault.
-  //
-  // The fix: replace bmp.Copy(frozen) with Fill(bmp,0)+BlitBitmap so the bmp
-  // pitch/dimensions are preserved at the render resolution.
+  // bmp.pitch=1920. If freeze-restore uses bmp.Copy(frozen_spectator_screen),
+  // it shrinks bmp.pitch back to the frozen screen's pre-resize pitch (640).
+  // Flip() then calls ScaleDraw(bmp.pixels, render_res_x=1920,
+  // render_res_y=1080, pitch=640,...), reading at row y*640 for y up to 1079
+  // — accessing offset 690560 in a 256000-element array → segfault.
+  // freeze-restore must use Fill+BlitBitmap to preserve bmp pitch/dimensions.
   Renderer renderer;
   renderer.Init(1920, 1080);
 

--- a/src/tests/test_map_size_foundation.cpp
+++ b/src/tests/test_map_size_foundation.cpp
@@ -29,8 +29,7 @@ TEST_CASE("DijkstraLevel CellFromPx clamps to actual level bounds, not hardcoded
   dlevel.Build(level, *common);
 
   // Pixel far outside the 252x175 level must clamp to within level bounds.
-  // Before PR1: CellFromPx clamps to kFullWidth-1=503, kFullHeight-1=349
-  // (hardcoded), so CoordsLevel returns (502, 350) — both outside 252x175.
+  // CellFromPx must use the live level dimensions, not hardcoded constants.
   LevelCell* cell = dlevel.CellFromPx(9999, 9999);
   IVec2 const kCoords = dlevel.CoordsLevel(cell);
 

--- a/src/tests/test_snapshot_fast.cpp
+++ b/src/tests/test_snapshot_fast.cpp
@@ -307,7 +307,7 @@ TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollb
   REQUIRE(snap_a.level_data.size() == kCells);
   REQUIRE(std::equal(snap_a.level_data.begin(), snap_a.level_data.end(),
                      game.level.material_id.begin()));
-  // dirty_list must now be initialised (empty, since no SetPixel since tracking start).
+  // dirty_list must be empty — no SetPixel has run since tracking started.
   REQUIRE(game.level.dirty_list.empty());
 
   // Capture the initial material layout for later comparison.
@@ -363,7 +363,7 @@ TEST_CASE("Dirty-cell tracking: sparse save, correct restore", "[snapshot][rollb
   // materials must be consistent with material_id after restore (no level_materials in slot).
   REQUIRE(game.level.materials[static_cast<std::size_t>(kIdx)].flags ==
           game.common->materials[kNewMat].flags);
-  // display_valid must reflect the post-modification snapshot (cell was zeroed).
+  // display_valid must reflect the snapshot taken after the modification (cell zeroed).
   REQUIRE(game.level.display_valid[static_cast<std::size_t>(kIdx)] == 0);
 
   // Restore from snap_b (saved before the modification) — should recover kOldMat.

--- a/src/tests/test_spectator_visibility.cpp
+++ b/src/tests/test_spectator_visibility.cpp
@@ -15,8 +15,7 @@
 
 // Drives a real Game + SpectatorViewport::Process at a capped spectator render
 // resolution and asserts that, wherever the two worms are, they both land inside
-// the world region the spectator actually draws. Reproduces the report that with
-// PR8's render-resolution cap a worm can be moved off the spectator screen.
+// the world region the spectator actually draws.
 namespace {
 
 struct SpectatorFixture {


### PR DESCRIPTION
## Summary

- Comments added over the last ~20 commits described *the change process* (PR7 Task 1b/1c, PR8 Task 2, "as before", "was originally", "now decides", "Before PR1", commit hashes) rather than the current code state
- Rewrote each to describe the present-state invariant or intent — what the code does and why, not what it replaced
- No logic, signatures, or data format changes; comment-only

## Test plan

- [x] CI passes (no code changes, just comments)
- [x] Skim the diff to confirm no accidental line deletions near comment edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)