### PR TITLE
docs: reframe test file headers to describe ongoing value, not development history

### DIFF
--- a/src/tests/framehash_main.cpp
+++ b/src/tests/framehash_main.cpp
@@ -2,8 +2,8 @@
 // game-draw path and prints one FNV-1a hash per frame of the composed RGB
 // screen (palette-resolved). Two builds rendering the same replay must
 // print identical streams for the renderer to count as pixel-identical;
-// used to verify the modern-colors stage 2 refactor keeps classic output
-// byte-for-byte stable.
+// useful for verifying renderer refactors keep visual output byte-for-byte
+// stable.
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>

--- a/src/tests/test_cereal_types.cpp
+++ b/src/tests/test_cereal_types.cpp
@@ -1,7 +1,6 @@
-// Phase 4 tests: per-type cereal serialize() round-trips through both
-// the binary (PortableBinaryArchive) and TOML (cereal::TomlOutputArchive)
-// archives. The old archive() functions stay in place; this verifies
-// the new cereal-based path before Phase 6 swaps the call sites.
+// Per-type cereal serialize() round-trips through both the binary
+// (PortableBinaryArchive) and TOML (cereal::TomlOutputArchive) archives.
+// Guards against regressions in each type's serialize() implementation.
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/src/tests/test_tc_load.cpp
+++ b/src/tests/test_tc_load.cpp
@@ -64,8 +64,8 @@ TEST_CASE("TC loads without errors", "[tc_load]") {
     REQUIRE(kI >= 0);
   }
 
-  // Step 5: sound fields in weapon / sobject configs are now name-typed.
-  // Anchor a couple of known values so regressions in soundRefFromStr
+  // Sound fields in weapon / sobject configs are name-typed; anchor a
+  // couple of known values so regressions in soundRefFromStr
   // (e.g. unknown-name returning 0 instead of -1) get caught.
   auto find_weapon = [&](std::string const& id) -> Weapon const& {
     for (auto& w : common->weapons) {

--- a/src/tests/test_toml_archive.cpp
+++ b/src/tests/test_toml_archive.cpp
@@ -1,4 +1,4 @@
-// Phase 2 tests: cereal::TomlOutputArchive / TomlInputArchive in isolation.
+// Unit tests for cereal::TomlOutputArchive / TomlInputArchive.
 // Cover primitives, nested objects, arrays of primitives, arrays of objects,
 // missing-key tolerance, and version-tagged types.
 

--- a/src/tests/test_versioning.cpp
+++ b/src/tests/test_versioning.cpp
@@ -1,10 +1,11 @@
-// Phase 5 tests: versioning proof-of-concept.
+// Settings serialization regression tests: binary and TOML round-trips,
+// plus backward-compatibility with old config files.
 //
-// Settings binary round-trip and TOML round-trip tests. The v1 binary
-// fixture backward-compat test was removed when the serialization format
-// was changed to always write bonusTimeout before wormSettings.
+// The v1 binary fixture backward-compat test was removed when the
+// serialization format was changed to always write bonusTimeout before
+// wormSettings.
 //
-// Remaining tests:
+// Tests:
 //   1. v2 binary round-trip — all fields preserved.
 //   2. v2 TOML round-trip — all fields preserved (generic serialize path).
 //   3. v1 TOML fixture → generic reader — missing fields get defaults.


### PR DESCRIPTION
## Summary

Five test file headers referenced the development phase or PR sequence in which they were written (\"Phase 2 tests\", \"Phase 4 tests\", \"Phase 5 tests: versioning proof-of-concept\", \"Step 5:\", \"used to verify the modern-colors stage 2 refactor\"). Those labels made sense during a multi-PR feature build but are now misleading — they describe when the tests were written, not why they still matter.

## Changes

- `test_toml_archive.cpp` — \"Phase 2 tests:\" → \"Unit tests for\"
- `test_cereal_types.cpp` — removed \"Phase 4 tests … before Phase 6 swaps the call sites\"; replaced with what the tests guard against today
- `test_versioning.cpp` — \"Phase 5 tests: versioning proof-of-concept\" → \"Settings serialization regression tests … plus backward-compatibility with old config files\"
- `test_tc_load.cpp` — \"Step 5: sound fields … are now name-typed\" → dropped the step number, kept the why
- `framehash_main.cpp` — \"used to verify the modern-colors stage 2 refactor\" → \"useful for verifying renderer refactors\" (generalised)

## Files Changed

| File | Change |
|------|--------|
| `src/tests/test_toml_archive.cpp` | Comment updated |
| `src/tests/test_cereal_types.cpp` | Comment updated |
| `src/tests/test_versioning.cpp` | Comment updated |
| `src/tests/test_tc_load.cpp` | Inline comment updated |
| `src/tests/framehash_main.cpp` | Comment updated |

## Testing

Comment-only changes — no behaviour affected, no build changes needed.

## Related Issues

None