### PR TITLE
test: full-game integration coverage (single-player + netplay)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,20 @@ if(OPENLIERO_BUILD_TESTS)
     DISCOVERY_MODE PRE_TEST
   )
 
+  add_executable(test_net_full_game src/tests/test_net_full_game.cpp)
+  target_link_libraries(test_net_full_game PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_net_full_game
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DISCOVERY_MODE PRE_TEST
+  )
+
+  add_executable(test_net_session_full_game src/tests/test_net_session_full_game.cpp)
+  target_link_libraries(test_net_session_full_game PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_net_session_full_game
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DISCOVERY_MODE PRE_TEST
+  )
+
   add_executable(test_transport src/tests/test_transport.cpp)
   target_link_libraries(test_transport PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_transport DISCOVERY_MODE PRE_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,13 @@ if(OPENLIERO_BUILD_TESTS)
     DISCOVERY_MODE PRE_TEST
   )
 
+  add_executable(test_full_game src/tests/test_full_game.cpp)
+  target_link_libraries(test_full_game PRIVATE game Catch2::Catch2WithMain)
+  catch_discover_tests(test_full_game
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DISCOVERY_MODE PRE_TEST
+  )
+
   add_executable(test_transport src/tests/test_transport.cpp)
   target_link_libraries(test_transport PRIVATE game Catch2::Catch2WithMain)
   catch_discover_tests(test_transport DISCOVERY_MODE PRE_TEST)

--- a/src/tests/game_harness.hpp
+++ b/src/tests/game_harness.hpp
@@ -82,15 +82,15 @@ struct RunResult {
 // input_fn(worm_index, frame) returns a 7-bit control byte (matches Unpack).
 using InputFn = std::function<uint8_t(int worm_index, int frame)>;
 
-inline RunResult RunToCompletion(Game& game, InputFn input_fn, int max_frames = 500000) {
+inline RunResult RunToCompletion(Game& game, InputFn const& input_fn, int max_frames = 500000) {
   for (int frame = 0; frame < max_frames; ++frame) {
     for (int idx = 0; idx < static_cast<int>(game.worms.size()); ++idx) {
       game.worms[idx]->control_states.Unpack(input_fn(idx, frame));
     }
     game.ProcessFrame();
     if (game.IsGameOver()) {
-      return {frame + 1, true};
+      return {.frames_elapsed = frame + 1, .reached_game_over = true};
     }
   }
-  return {max_frames, false};
+  return {.frames_elapsed = max_frames, .reached_game_over = false};
 }

--- a/src/tests/game_harness.hpp
+++ b/src/tests/game_harness.hpp
@@ -84,8 +84,8 @@ using InputFn = std::function<uint8_t(int worm_index, int frame)>;
 
 inline RunResult RunToCompletion(Game& game, InputFn const& input_fn, int max_frames = 500000) {
   for (int frame = 0; frame < max_frames; ++frame) {
-    for (int idx = 0; idx < static_cast<int>(game.worms.size()); ++idx) {
-      game.worms[idx]->control_states.Unpack(input_fn(idx, frame));
+    for (size_t idx = 0; idx < game.worms.size(); ++idx) {
+      game.worms[idx]->control_states.Unpack(input_fn(static_cast<int>(idx), frame));
     }
     game.ProcessFrame();
     if (game.IsGameOver()) {

--- a/src/tests/game_harness.hpp
+++ b/src/tests/game_harness.hpp
@@ -1,0 +1,96 @@
+// Shared headless game builder for integration tests.
+//
+// ResetWorms() sets worm health from WormSettings::health, so cfg.health is
+// applied after that call to actually take effect.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "game.hpp"
+#include "level.hpp"
+#include "math.hpp"
+#include "mixer/player.hpp"
+#include "viewport.hpp"
+#include "weapon.hpp"
+#include "worm.hpp"
+
+struct HeadlessGameConfig {
+  uint32_t seed{42};
+  int game_mode{Settings::kGmKillEmAll};
+  int lives{3};
+  int health{25};  // per-worm health after ResetWorms; 0 → keep WormSettings::health default
+  int worm_count{2};
+};
+
+// Returns a fully-initialized Game ready for ProcessFrame(), following the
+// DualGameFixture setup order from test_determinism.cpp.
+inline std::unique_ptr<Game> MakeHeadlessGame(HeadlessGameConfig const& cfg = {}) {
+  PrecomputeTables();
+
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(FsNode("data") / "TC" / "openliero");
+  common->load(kTcRoot);
+
+  auto settings = std::make_shared<Settings>();
+  settings->lives = cfg.lives;
+  settings->loading_time = 0;
+  settings->random_level = true;
+  settings->game_mode = cfg.game_mode;
+
+  auto sp = std::make_shared<NullSoundPlayer>();
+  auto game = std::make_unique<Game>(common, settings, sp, /*install_global_sound_player=*/false);
+  game->rand.Seed(cfg.seed);
+
+  for (int idx = 0; idx < cfg.worm_count; ++idx) {
+    auto w = std::make_shared<Worm>();
+    w->settings = settings->worm_settings[idx];
+    w->health = w->settings->health;
+    w->index = idx;
+    w->stats_x = idx == 0 ? 0 : 218;
+    game->AddWorm(w);
+  }
+
+  game->AddViewport(new Viewport(Rect(0, 0, 158, 158), 0));
+  game->AddViewport(new Viewport(Rect(160, 0, 318, 158), 1));
+
+  game->level.GenerateFromSettings(*common, *settings, game->rand);
+  for (auto const& w : game->worms) {
+    w->InitWeapons(*game);
+  }
+
+  game->paused = false;
+  game->StartGame();
+  game->ResetWorms();
+
+  if (cfg.health > 0) {
+    for (auto const& w : game->worms) {
+      w->health = cfg.health;
+    }
+  }
+
+  return game;
+}
+
+struct RunResult {
+  int frames_elapsed;
+  bool reached_game_over;
+};
+
+// Feeds scripted input until IsGameOver() fires or max_frames is exhausted.
+// input_fn(worm_index, frame) returns a 7-bit control byte (matches Unpack).
+using InputFn = std::function<uint8_t(int worm_index, int frame)>;
+
+inline RunResult RunToCompletion(Game& game, InputFn input_fn, int max_frames = 500000) {
+  for (int frame = 0; frame < max_frames; ++frame) {
+    for (int idx = 0; idx < static_cast<int>(game.worms.size()); ++idx) {
+      game.worms[idx]->control_states.Unpack(input_fn(idx, frame));
+    }
+    game.ProcessFrame();
+    if (game.IsGameOver()) {
+      return {frame + 1, true};
+    }
+  }
+  return {max_frames, false};
+}

--- a/src/tests/net_game_harness.hpp
+++ b/src/tests/net_game_harness.hpp
@@ -1,0 +1,212 @@
+// Shared headless harness for full-game *network* integration tests
+// (Layer A). Drives a pair of RollbackControllers through the in-memory
+// JitterTransport (see jitter_transport.hpp) to a complete match.
+//
+// Sibling of game_harness.hpp: that header builds a bare Game for
+// single-player runs; here each RollbackController owns its own Game, so
+// MakeHeadlessGame cannot be reused. Only the builder + RunResult *style*
+// is mirrored.
+//
+// Game-over oracle: termination keys on the controller's
+// State() == kStateGameEnded. The live game latches that at
+// rollbackController.cpp's `game.IsGameOver()` check — the real
+// production end-of-match transition. The shadow Game (StatsGame()) is
+// deliberately NOT used as the oracle: it only advances up to
+// confirmedSimFrame_, which stops the instant the live game latches
+// kStateGameEnded, so it can freeze a few frames short of the game-over
+// frame and never report it.
+//
+// Convergence is verified through the confirmed-frame checksum callbacks
+// (SetChecksumCallback fires only on non-predicted frames), not by
+// comparing frozen live state: under jitter the two peers can latch
+// game-over on different (predicted) frames, so their frozen live
+// checksums need not be bit-identical, but every *confirmed* frame they
+// both ran must agree.
+//
+// Weapon selection is skipped (SetSkipWeaponSelection(true)); the WS /
+// menu phase is covered by test_rollback_replay.cpp and
+// test_session_rollback.cpp.
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "controller/rollbackController.hpp"
+#include "game.hpp"
+#include "jitter_transport.hpp"
+#include "math.hpp"
+#include "mixer/player.hpp"
+
+namespace rollback_test {
+
+struct NetGameConfig {
+  uint32_t world_seed{0xBEEF};
+  int game_mode{Settings::kGmKillEmAll};
+  int lives{1};
+  int health{15};  // per-worm spawn health; 0 → keep WormSettings default
+};
+
+// The two controllers plus the env keeping their shared Common/Settings
+// alive. Each controller owns its Game (rollback runs the live game
+// speculatively and a confirmed-only shadow alongside it).
+struct RollbackPair {
+  std::shared_ptr<Common> common;
+  std::shared_ptr<Settings> settings;
+  std::unique_ptr<RollbackController> a;
+  std::unique_ptr<RollbackController> b;
+};
+
+inline RollbackPair MakeRollbackPair(NetGameConfig const& cfg = {}) {
+  PrecomputeTables();
+
+  auto common = std::make_shared<Common>();
+  FsNode const kTcRoot(FsNode("data") / "TC" / "openliero");
+  common->load(kTcRoot);
+
+  auto settings = std::make_shared<Settings>();
+  settings->lives = cfg.lives;
+  settings->loading_time = 0;
+  settings->load_change = true;
+  settings->random_level = true;
+  settings->game_mode = cfg.game_mode;
+  if (cfg.health > 0) {
+    for (auto& ws : settings->worm_settings) {
+      if (ws) {
+        ws->health = cfg.health;
+      }
+    }
+  }
+
+  RollbackPair pair;
+  pair.common = common;
+  pair.settings = settings;
+  pair.a = std::make_unique<RollbackController>(common, settings, 0);
+  pair.b = std::make_unique<RollbackController>(common, settings, 1);
+  pair.a->SetSkipWeaponSelection(/*skip=*/true);
+  pair.b->SetSkipWeaponSelection(/*skip=*/true);
+  // The frame-advantage stall is a time-sync clamp orthogonal to the
+  // rollback algorithm; disable it so the peers freely run ahead and
+  // exercise prediction, exactly as the rollback correctness/loss tests
+  // do. Confirmation lag is still bounded by the ring (kMaxRollback).
+  pair.a->SetFrameAdvantageEnabled(/*enabled=*/false);
+  pair.b->SetFrameAdvantageEnabled(/*enabled=*/false);
+  // Identical world RNG on both peers — without this the per-frame
+  // checksums diverge from frame 0 and a mismatch reflects a harness
+  // seeding bug, not a rollback-code bug.
+  pair.a->game.rand.Seed(cfg.world_seed);
+  pair.b->game.rand.Seed(cfg.world_seed);
+  return pair;
+}
+
+struct NetRunResult {
+  int frames_elapsed{0};          // scripted ticks executed before both ended
+  bool reached_game_over{false};  // both peers latched kStateGameEnded
+  bool desynced{false};           // a confirmed-frame checksum disagreed
+  uint64_t compared_frames{0};    // confirmed frames compared (>0 ⇒ non-vacuous)
+  uint64_t rollback_count_a{0};
+  uint64_t rollback_count_b{0};
+  uint32_t max_lag{0};  // max(simFrame - (confirmedFrame+1)) over both, post-warmup
+};
+
+// input_fn(peer_idx, frame) returns the 7-bit control byte for that
+// peer's local worm (peer 0 → worm 0, peer 1 → worm 1). A peer that has
+// already reached game-over is fed idle input.
+using PairInputFn = std::function<uint8_t(int peer_idx, int frame)>;
+
+inline NetRunResult RunPairToCompletion(RollbackPair& pair, JitterTransport& transport,
+                                        PairInputFn const& input_fn, int max_frames = 200000) {
+  RollbackController& a = *pair.a;
+  RollbackController& b = *pair.b;
+
+  NetRunResult res;
+
+  // Confirmed-frame checksum exchange for desync detection. Store each
+  // peer's emission keyed by frame; when both have produced a checksum
+  // for the same confirmed frame, compare them.
+  std::map<uint32_t, uint32_t> a_chk;
+  std::map<uint32_t, uint32_t> b_chk;
+  auto record = [&res](std::map<uint32_t, uint32_t>& mine, std::map<uint32_t, uint32_t>& other,
+                       uint32_t frame, uint32_t chk) {
+    mine[frame] = chk;
+    auto it = other.find(frame);
+    if (it != other.end()) {
+      ++res.compared_frames;
+      if (it->second != chk) {
+        res.desynced = true;
+      }
+    }
+  };
+  a.SetChecksumCallback(
+      [&](uint8_t /*gen*/, uint32_t f, uint32_t c) { record(a_chk, b_chk, f, c); });
+  b.SetChecksumCallback(
+      [&](uint8_t /*gen*/, uint32_t f, uint32_t c) { record(b_chk, a_chk, f, c); });
+
+  a.SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendAToB(gen, bf, c, in, lf);
+  });
+  b.SetInputCallbacks([&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    transport.SendBToA(gen, bf, c, in, lf);
+  });
+
+  a.Focus();
+  b.Focus();
+
+  // Pre-seed the input-delay window (default inputDelay = 3). These
+  // bypass the transport so both peers start advancing immediately,
+  // mirroring how a real session synchronises its starting frames.
+  for (uint32_t f = 0; f < 3; ++f) {
+    a.InjectRemoteInput(f, 0);
+    b.InjectRemoteInput(f, 0);
+  }
+
+  auto deliver_a = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    a.InjectRemoteBatch(gen, bf, c, in, lf);
+  };
+  auto deliver_b = [&](uint8_t gen, uint32_t bf, uint8_t c, uint8_t const* in, uint32_t lf) {
+    b.InjectRemoteBatch(gen, bf, c, in, lf);
+  };
+
+  int frame = 0;
+  for (; frame < max_frames; ++frame) {
+    bool const kAOver = a.State() == kStateGameEnded;
+    bool const kBOver = b.State() == kStateGameEnded;
+    if (kAOver && kBOver) {
+      break;
+    }
+
+    a.SetLocalControlState(kAOver ? uint8_t{0} : input_fn(0, frame));
+    b.SetLocalControlState(kBOver ? uint8_t{0} : input_fn(1, frame));
+    a.Process();
+    b.Process();
+    transport.Tick(deliver_a, deliver_b);
+
+    // Skip the warm-up window so it doesn't pollute the running maximum.
+    if (frame > 50) {
+      uint32_t const kLagA = a.CurrentFrame() - static_cast<uint32_t>(a.ConfirmedFrame() + 1);
+      uint32_t const kLagB = b.CurrentFrame() - static_cast<uint32_t>(b.ConfirmedFrame() + 1);
+      res.max_lag = std::max({res.max_lag, kLagA, kLagB});
+    }
+  }
+
+  // Flush any in-flight tail packets and run a short idle drain so both
+  // confirmation chains catch up and exchange their final checksums.
+  transport.Flush(deliver_a, deliver_b);
+  for (int i = 0; i < 16; ++i) {
+    a.SetLocalControlState(0);
+    b.SetLocalControlState(0);
+    a.Process();
+    b.Process();
+    transport.Tick(deliver_a, deliver_b);
+  }
+
+  res.frames_elapsed = frame;
+  res.reached_game_over = a.State() == kStateGameEnded && b.State() == kStateGameEnded;
+  res.rollback_count_a = a.RollbackCount();
+  res.rollback_count_b = b.RollbackCount();
+  return res;
+}
+
+}  // namespace rollback_test

--- a/src/tests/test_full_game.cpp
+++ b/src/tests/test_full_game.cpp
@@ -1,5 +1,104 @@
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
 
 #include "game_harness.hpp"
+#include "rand.hpp"
+#include "stateHash.hpp"
 
-TEST_CASE("placeholder", "[full_game]") { REQUIRE(true); }
+namespace {
+
+uint8_t CombatInput(Rand& rng, int idx) {
+  uint8_t input = rng() & 0x7f;
+  if ((rng() % 10) < 6) {
+    input |= (1 << 4);  // fire
+  }
+  if ((rng() % 10) < 4) {
+    input |= (1 << (idx == 0 ? 1 : 0));  // move toward opponent
+  }
+  return input;
+}
+
+constexpr HeadlessGameConfig kKillEmAllCfg{.seed = 42, .lives = 2, .health = 25};
+constexpr uint32_t kInputSeed = 0xDEAD1234;
+constexpr int kMaxFrames = 300000;
+
+}  // namespace
+
+TEST_CASE("KillEmAll game reaches game over via scripted input", "[full_game]") {
+  auto game = MakeHeadlessGame(kKillEmAllCfg);
+  Rand input_rng(kInputSeed);
+
+  auto const kResult = RunToCompletion(
+      *game, [&input_rng](int idx, int) { return CombatInput(input_rng, idx); }, kMaxFrames);
+
+  INFO("Frames elapsed: " << kResult.frames_elapsed);
+  REQUIRE(kResult.reached_game_over);
+  REQUIRE(kResult.frames_elapsed < kMaxFrames);
+}
+
+TEST_CASE("KillEmAll end-state satisfies termination invariants", "[full_game]") {
+  auto game = MakeHeadlessGame(kKillEmAllCfg);
+  Rand input_rng(kInputSeed);
+
+  RunToCompletion(*game, [&input_rng](int idx, int) { return CombatInput(input_rng, idx); });
+
+  REQUIRE(game->cycles > 0);
+
+  bool any_lives_depleted = false;
+  for (auto const& w : game->worms) {
+    if (w->lives <= 0) {
+      any_lives_depleted = true;
+    }
+    REQUIRE(w->health <= w->settings->health);
+  }
+  REQUIRE(any_lives_depleted);
+}
+
+TEST_CASE("Full game run is deterministic", "[full_game][determinism]") {
+  uint32_t hash1 = 0;
+  uint32_t hash2 = 0;
+
+  for (int run = 0; run < 2; ++run) {
+    auto game = MakeHeadlessGame(kKillEmAllCfg);
+    Rand input_rng(kInputSeed);
+
+    RunToCompletion(*game, [&input_rng](int idx, int) { return CombatInput(input_rng, idx); });
+
+    uint32_t const kHash = HashGameState(*game);
+    if (run == 0) {
+      hash1 = kHash;
+    } else {
+      hash2 = kHash;
+    }
+  }
+
+  REQUIRE(hash1 == hash2);
+}
+
+TEST_CASE("GameOfTag terminates when it-timer reaches time_to_lose", "[full_game][smoke]") {
+  // Timer increments once per 70 frames while the last killer is visible;
+  // time_to_lose=1 means a single 70-frame tick after the first kill suffices.
+  auto game = MakeHeadlessGame({.seed = 42, .game_mode = Settings::kGmGameOfTag});
+  game->settings->time_to_lose = 1;
+
+  Rand input_rng(kInputSeed);
+  auto const kResult = RunToCompletion(
+      *game, [&input_rng](int idx, int) { return CombatInput(input_rng, idx); }, 5000);
+
+  INFO("Frames elapsed: " << kResult.frames_elapsed);
+  REQUIRE(kResult.reached_game_over);
+}
+
+TEST_CASE("Holdazone terminates when zone-timer reaches time_to_lose", "[full_game][smoke]") {
+  // Timer increments once per 70 frames while holdazone.holder_idx is set.
+  // Pre-set worm 0 as holder so the test doesn't depend on random zone capture.
+  auto game = MakeHeadlessGame({.seed = 42, .game_mode = Settings::kGmHoldazone});
+  game->settings->time_to_lose = 1;
+  game->holdazone.holder_idx = 0;
+  game->holdazone.timeout_left = 1000;
+
+  auto const kResult = RunToCompletion(*game, [](int, int) { return uint8_t{0}; }, 200);
+
+  INFO("Frames elapsed: " << kResult.frames_elapsed);
+  REQUIRE(kResult.reached_game_over);
+}

--- a/src/tests/test_full_game.cpp
+++ b/src/tests/test_full_game.cpp
@@ -1,0 +1,5 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "game_harness.hpp"
+
+TEST_CASE("placeholder", "[full_game]") { REQUIRE(true); }

--- a/src/tests/test_full_game.cpp
+++ b/src/tests/test_full_game.cpp
@@ -75,6 +75,18 @@ TEST_CASE("Full game run is deterministic", "[full_game][determinism]") {
   REQUIRE(hash1 == hash2);
 }
 
+TEST_CASE("KillEmAll terminates across a sweep of seeds", "[full_game][sweep]") {
+  for (uint32_t seed = 0; seed < 100; ++seed) {
+    INFO("seed=" << seed);
+    auto game = MakeHeadlessGame({.seed = seed, .lives = 2, .health = 25});
+    Rand input_rng(kInputSeed);
+    auto const kResult = RunToCompletion(
+        *game, [&input_rng](int idx, int) { return CombatInput(input_rng, idx); }, kMaxFrames);
+    REQUIRE(kResult.reached_game_over);
+    REQUIRE(kResult.frames_elapsed < kMaxFrames);
+  }
+}
+
 TEST_CASE("GameOfTag terminates when it-timer reaches time_to_lose", "[full_game][smoke]") {
   // Timer increments once per 70 frames while the last killer is visible;
   // time_to_lose=1 means a single 70-frame tick after the first kill suffices.

--- a/src/tests/test_net_full_game.cpp
+++ b/src/tests/test_net_full_game.cpp
@@ -15,7 +15,7 @@
 // Convergence is asserted via the confirmed-frame checksum callbacks
 // (NetRunResult::desynced / compared_frames), not by comparing the two
 // peers' frozen final state — see net_game_harness.hpp for why. Game-
-// over is the live game's State() == kStateGameEnded latch (plan Task 0).
+// over is the live game's State() == kStateGameEnded latch.
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>

--- a/src/tests/test_net_full_game.cpp
+++ b/src/tests/test_net_full_game.cpp
@@ -1,0 +1,100 @@
+// Full network game-loop integration tests (Layer A).
+//
+// Drives two RollbackControllers through the in-memory JitterTransport
+// to a complete KillEmAll match (both peers reach game-over), under two
+// network profiles:
+//
+//   1. zero-jitter / no-loss — deterministic delivery; the confirmed
+//      timeline must agree on every frame and no rollback-induced
+//      desync may occur.
+//   2. jitter + 10% packet loss — mispredictions and rollback are
+//      inevitable; the steady-state confirmation lag must stay bounded
+//      by kMaxRollback, rollback must actually fire, and the confirmed
+//      timeline must still agree.
+//
+// Convergence is asserted via the confirmed-frame checksum callbacks
+// (NetRunResult::desynced / compared_frames), not by comparing the two
+// peers' frozen final state — see net_game_harness.hpp for why. Game-
+// over is the live game's State() == kStateGameEnded latch (plan Task 0).
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+
+#include "net_game_harness.hpp"
+#include "rand.hpp"
+#include "rollback/buffer.hpp"
+#include "worm.hpp"
+
+namespace {
+
+// Aggressive damage-forcing input: random movement/aim, a high fire
+// duty cycle (pulsed, so edge-triggered weapons keep shooting and worms
+// ready up), plus a bias to move toward the opponent. Mirrors
+// test_full_game.cpp's CombatInput so a match terminates in a bounded
+// number of frames instead of wandering.
+uint8_t CombatInput(Rand& rng, int peer_idx) {
+  uint8_t input = rng() & 0x7f;
+  if ((rng() % 10) < 6) {
+    input |= (1 << Worm::kFire);
+  }
+  if ((rng() % 10) < 4) {
+    input |= (1 << (peer_idx == 0 ? 1 : 0));  // move toward opponent
+  }
+  return input;
+}
+
+constexpr uint32_t kInputSeed = 0xDEAD1234;
+// Single-player KillEmAll terminates well under this with lives=1 +
+// low health + aggressive combat; the cap only guards a pathological
+// non-terminating run.
+constexpr int kMaxFrames = 200000;
+
+}  // namespace
+
+TEST_CASE("Layer A: two rollback peers reach game-over with zero jitter", "[net_full_game]") {
+  rollback_test::RollbackPair pair = rollback_test::MakeRollbackPair({.world_seed = 0xBEEF});
+  rollback_test::JitterTransport transport({.seed = 0x1234});  // delay 0, no loss
+
+  Rand rng_a(kInputSeed);
+  Rand rng_b(kInputSeed ^ 0x55555555U);
+  auto const kResult = rollback_test::RunPairToCompletion(
+      pair, transport, [&](int peer, int) { return CombatInput(peer == 0 ? rng_a : rng_b, peer); },
+      kMaxFrames);
+
+  INFO("frames=" << kResult.frames_elapsed << " compared=" << kResult.compared_frames
+                 << " max_lag=" << kResult.max_lag);
+  REQUIRE(kResult.reached_game_over);
+  REQUIRE(kResult.frames_elapsed < kMaxFrames);
+  // The confirmed timeline agreed on every overlapping frame...
+  REQUIRE(kResult.compared_frames > 0);  // ...and the check wasn't vacuous.
+  REQUIRE_FALSE(kResult.desynced);
+}
+
+TEST_CASE("Layer A: two rollback peers reach game-over under jitter + 10% loss",
+          "[net_full_game]") {
+  rollback_test::RollbackPair pair = rollback_test::MakeRollbackPair({.world_seed = 0xBEEF});
+  rollback_test::JitterTransport transport(
+      {.seed = 0x10ADED, .min_delay_frames = 1, .max_delay_frames = 3, .loss_probability = 0.10});
+
+  Rand rng_a(kInputSeed);
+  Rand rng_b(kInputSeed ^ 0x55555555U);
+  auto const kResult = rollback_test::RunPairToCompletion(
+      pair, transport, [&](int peer, int) { return CombatInput(peer == 0 ? rng_a : rng_b, peer); },
+      kMaxFrames);
+
+  INFO("frames=" << kResult.frames_elapsed << " compared=" << kResult.compared_frames
+                 << " max_lag=" << kResult.max_lag << " rb_a=" << kResult.rollback_count_a
+                 << " rb_b=" << kResult.rollback_count_b
+                 << " dropped=" << transport.packets_dropped);
+  REQUIRE(kResult.reached_game_over);
+  REQUIRE(kResult.frames_elapsed < kMaxFrames);
+  // Loss + jitter must have actually exercised rollback...
+  REQUIRE(transport.packets_dropped > 0);
+  REQUIRE(kResult.rollback_count_a > 0);
+  REQUIRE(kResult.rollback_count_b > 0);
+  // ...confirmation lag stayed within the ring's bound...
+  REQUIRE(kResult.max_lag <= static_cast<uint32_t>(rollback::kMaxRollback));
+  // ...and the confirmed timeline still converged.
+  REQUIRE(kResult.compared_frames > 0);
+  REQUIRE_FALSE(kResult.desynced);
+}

--- a/src/tests/test_net_session_full_game.cpp
+++ b/src/tests/test_net_session_full_game.cpp
@@ -1,0 +1,197 @@
+// Full network game-loop integration test (Layer B).
+//
+// Stands two NetSessions up over real ENet TCP/UDP loopback, drives the
+// production state machine (handshake → settings → mapdata → kPlaying →
+// real weapon select → game phase) and plays an aggressive KillEmAll
+// match all the way to a natural game-over (a worm's lives reach 0).
+//
+// This is the end-to-end complement to the Layer A controller-pair
+// tests (test_net_full_game.cpp): it exercises the same game-over path
+// but through the actual NetSession / NetTransport wiring rather than an
+// in-memory transport. Game-over is detected via Process() returning
+// false, which the controller returns only once the kStateGameEnded
+// fade has fully drained (rollbackController.cpp) — the real
+// end-of-match signal a live session uses.
+//
+// Single case, no injected jitter: loopback is effectively lossless, so
+// this validates the integration path, not rollback robustness (covered
+// by Layer A). Weapon select IS exercised here (the session does not
+// skip it), unlike Layer A.
+
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "controller/rollbackController.hpp"
+#include "game.hpp"
+#include "math.hpp"
+#include "net/session.hpp"
+#include "rand.hpp"
+#include "worm.hpp"
+
+namespace {
+
+struct Env {
+  std::shared_ptr<Common> common;
+  std::shared_ptr<Settings> settings;
+  FsNode tc_root;
+
+  Env() {
+    PrecomputeTables();
+    common = std::make_shared<Common>();
+    tc_root = FsNode("data") / "TC" / "openliero";
+    common->load(tc_root);
+    settings = std::make_shared<Settings>();
+    // lives=1 + low spawn health → the first kill ends the match, so a
+    // full game terminates in a bounded number of ticks under loopback.
+    settings->lives = 1;
+    settings->loading_time = 0;
+    settings->load_change = true;
+    settings->random_level = true;
+    settings->game_mode = Settings::kGmKillEmAll;
+    settings->input_delay = 1;
+    for (auto& ws : settings->worm_settings) {
+      if (ws) {
+        ws->health = 5;
+      }
+    }
+  }
+};
+
+template <typename Pred>
+bool PollUntil(NetSession& a, NetSession& b, Pred pred, int max_ms = 5000) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_ms);
+  while (!pred() && std::chrono::steady_clock::now() < deadline) {
+    a.Update();
+    b.Update();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return pred();
+}
+
+uint8_t CombatInput(Rand& rng, int peer_idx) {
+  uint8_t input = rng() & 0x7f;
+  if ((rng() % 10) < 6) {
+    input |= (1 << Worm::kFire);
+  }
+  if ((rng() % 10) < 4) {
+    input |= (1 << (peer_idx == 0 ? 1 : 0));  // move toward opponent
+  }
+  return input;
+}
+
+}  // namespace
+
+TEST_CASE("Layer B: two NetSessions reach game-over over loopback", "[net_session_full_game]") {
+  Env const kE;
+
+  // Each peer needs its own deep copy of the per-worm settings so the
+  // single-process weapon-select mutations on one side don't bleed into
+  // the other (mirrors test_session_rollback.cpp).
+  auto host_settings = std::make_shared<Settings>(*kE.settings);
+  auto client_settings = std::make_shared<Settings>(*kE.settings);
+  for (auto* s : {&host_settings, &client_settings}) {
+    for (auto& ws : (*s)->worm_settings) {
+      if (ws) {
+        ws = std::make_shared<WormSettings>(*ws);
+      }
+    }
+  }
+
+  NetSession host(kE.common, host_settings, kE.tc_root);
+  NetSession client(kE.common, client_settings, kE.tc_root);
+
+  REQUIRE(host.HostGame(0));
+  uint16_t const kPort = host.Transport().ListeningPort();
+  REQUIRE(client.JoinGame("127.0.0.1", kPort));
+
+  bool const kReady = PollUntil(host, client, [&]() {
+    return host.State() == NetSession::kPlaying && client.State() == NetSession::kPlaying;
+  });
+  REQUIRE(kReady);
+
+  auto* hc = host.Rollback();
+  auto* cc = client.Rollback();
+  REQUIRE(hc != nullptr);
+  REQUIRE(cc != nullptr);
+
+  hc->Focus();
+  cc->Focus();
+
+  constexpr uint8_t kBitDown = uint8_t{1} << Worm::kDown;
+  constexpr uint8_t kBitFire = uint8_t{1} << Worm::kFire;
+
+  bool host_transitioned = false;
+  bool client_transitioned = false;
+
+  auto run_tick = [&](uint8_t in_h, uint8_t in_c) {
+    hc->SetLocalControlState(in_h);
+    cc->SetLocalControlState(in_c);
+    hc->Process();
+    cc->Process();
+    host.Update();
+    client.Update();
+    if (!host_transitioned && hc->State() == kStateGame) {
+      host_transitioned = true;
+    }
+    if (!client_transitioned && cc->State() == kStateGame) {
+      client_transitioned = true;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  };
+
+  // Drive both peers through weapon select: 6× Down (each press toggled
+  // off to make a clean rising edge), a short idle pad, then Fire.
+  std::vector<uint8_t> ws_script;
+  for (int i = 0; i < 6; ++i) {
+    ws_script.push_back(kBitDown);
+    ws_script.push_back(0);
+  }
+  ws_script.push_back(0);
+  ws_script.push_back(kBitFire);
+  ws_script.push_back(0);
+  for (uint8_t const kB : ws_script) {
+    run_tick(kB, kB);
+  }
+  for (int i = 0; i < 400 && !(host_transitioned && client_transitioned); ++i) {
+    run_tick(0, 0);
+  }
+  REQUIRE(host_transitioned);
+  REQUIRE(client_transitioned);
+
+  // Play the match out with aggressive combat until both controllers
+  // finalize (Process() returns false once the kStateGameEnded fade has
+  // drained). hc drives worm 0, cc drives worm 1.
+  Rand rng_h(0xDEAD1234);
+  Rand rng_c(0xDEAD1234U ^ 0x55555555U);
+  bool host_done = false;
+  bool client_done = false;
+  constexpr int kMaxTicks = 40000;
+  int ticks = 0;
+  for (; ticks < kMaxTicks && !(host_done && client_done); ++ticks) {
+    uint8_t const kInH = host_done ? uint8_t{0} : CombatInput(rng_h, 0);
+    uint8_t const kInC = client_done ? uint8_t{0} : CombatInput(rng_c, 1);
+    hc->SetLocalControlState(kInH);
+    cc->SetLocalControlState(kInC);
+    if (!host_done && !hc->Process()) {
+      host_done = true;
+    }
+    if (!client_done && !cc->Process()) {
+      client_done = true;
+    }
+    host.Update();
+    client.Update();
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+
+  INFO("ticks=" << ticks);
+  REQUIRE(host_done);
+  REQUIRE(client_done);
+  REQUIRE(hc->State() == kStateGameEnded);
+  REQUIRE(cc->State() == kStateGameEnded);
+  REQUIRE(!host.DesyncDetected());
+  REQUIRE(!client.DesyncDetected());
+}


### PR DESCRIPTION
## Summary

Adds full-game integration test coverage that drives the simulation all the way to `IsGameOver()` — both single-player and netplay — where the existing suite only exercised isolated mechanisms over fixed frame windows.

### Single-player (earlier commits on this branch)
- `src/tests/game_harness.hpp` — shared headless builder: `MakeHeadlessGame(cfg)` + `RunToCompletion()` feed scripted input to one `Game` until game-over.
- `src/tests/test_full_game.cpp` — KillEmAll to game-over, termination invariants, determinism, a seed sweep (0–99), and GameOfTag/Holdazone smoke cases.

### Netplay (this work)
- `src/tests/net_game_harness.hpp` — **Layer A** harness: `MakeRollbackPair` + `RunPairToCompletion` drive two `RollbackController`s through the shared in-memory `JitterTransport` to a complete match.
- `src/tests/test_net_full_game.cpp` — two rollback peers to game-over under (1) zero jitter and (2) jitter + 10% packet loss; asserts both reach game-over, bounded confirmation lag (≤ `kMaxRollback`), rollback actually fired, and a converged confirmed timeline.
- `src/tests/test_net_session_full_game.cpp` — **Layer B**: two `NetSession`s over ENet loopback driven through the real state machine (handshake → weapon select → game phase) to a natural KillEmAll game-over, asserting a clean end with no desync.

## Design notes
- **Game-over oracle**: termination keys on the live game's `State() == kStateGameEnded` latch (the production end-of-match path). The confirmed-only shadow `Game` (`StatsGame()`) is unsuitable as the oracle — it only advances to `confirmedSimFrame_`, which stops the instant the live game latches `kStateGameEnded`, so it can freeze short of the game-over frame.
- **Convergence** is verified through the confirmed-frame checksum callbacks (which fire only on non-predicted frames), not by comparing frozen live state: under jitter the two peers can latch game-over on different predicted frames, but every *confirmed* frame they both ran must agree.
- Weapon select is skipped in Layer A (covered by `test_rollback_replay`); Layer B exercises the real weapon-select path.

## Validation
- New tests pass and are fast (Layer A ~0.2s/case, Layer B ~0.5s); flake-checked across repeated runs.
- Regression suites intact: `test_rollback_correctness`, `test_rollback_desync`, `test_determinism`.
- clang-format v22 (diff + full-file dry-run) and clang-tidy clean on new sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)